### PR TITLE
feat(genogram): foster-care P0 — dual-parent, sibling-of, ?-placeholder, ~/~

### DIFF
--- a/docs/reference/01-GENOGRAM-STANDARD.md
+++ b/docs/reference/01-GENOGRAM-STANDARD.md
@@ -412,9 +412,10 @@ To turn off entirely: `legend: off`.
 | Relationship | Line Style | DSL Syntax | SVG |
 |-------------|-----------|------------|-----|
 | Marriage | Solid horizontal line | `A -- B` | `<line>` stroke-width: 2 |
-| Cohabitation/LTR | Dashed line | `A ~ B` | stroke-dasharray="6,4" |
+| Cohabitation/LTR (current) | Dashed line | `A ~ B` | stroke-dasharray="6,4" |
+| Cohabitation ended (never-married) | Dashed line + single slash | `A ~/~ B` | stroke-dasharray + slash mark — common in LATAM child-protection caseloads where bio parents lived together unmarried and the relationship has broken |
 | Engagement | Solid + small diamond midpoint | `A -o- B` | line + small diamond marker |
-| Separation | Solid + single slash | `A -/- B` | line + one diagonal slash |
+| Separation | Solid + single slash | `A -/- B` or `A -// B` | line + one diagonal slash |
 | Divorce | Solid + double slash | `A -x- B` | line + two diagonal slashes |
 | Consanguinity | Double horizontal line | `A == B` | Two parallel lines, gap 4px |
 | Remarriage | New marriage line from same person | Second `A -- C` | Additional horizontal line |
@@ -518,12 +519,98 @@ M x1,y1 L x1+10,y1-5 L x1+20,y1+5 L x1+30,y1-5 ... L x2,y2
 | Biological child | Solid vertical line | (default) | 亲生 |
 | Adopted child | Dashed line + brackets | `[adopted]` | 收养 |
 | Foster child | Dotted vertical line | `[foster]` | 寄养 |
+| Guardianship by relative | Dotted vertical line (same as foster) | `[guardian]` | 监护（非亲生），如祖父母监护，与 foster 共用同一 secondary-link primitive |
+| **Dual parents** (bio + current caregiver) | Bio link primary; secondary dotted line from caregiver couple | Redeclare child under second couple with `[foster]` / `[adopted]` / `[guardian]` | 寄养/收养/监护中"现照护人"链接，layout 仍由 bio couple 主导 — see §3.4.1 |
+| Unknown-count siblings placeholder | Single diamond with `?` glyph | Bare `?` on a child line, or `[unknown-siblings]` marker | 已知存在但身份不明的兄弟姐妹 |
+| Sibling-of (known relative, unknown ancestry) | Dashed bracket between two same-generation nodes, no parents drawn | `[sibling-of: <id>]` property | 已知亲属、家系未知（标准 pedigree 约定） |
 | Identical twins | Lines meet at single point (V) | `[twin-identical]` | 同卵双胞胎 |
 | Fraternal twins | Lines connect with bar | `[twin-fraternal]` | 异卵双胞胎 |
 | Triplets+ | 3+ lines from single point/bar | `[triplet-identical]` | 三胞胎+ |
 | Surrogacy | Dotted line + S label | `[surrogate]` | 代孕 |
 | Donor gamete | Dotted line + D label | `[donor]` | 供体配子 |
 | Step-child | Step-shaped line (two right angles) | `[step]` | 继子女 |
+
+### 3.4.1 Dual-parent rendering (foster / adoption / guardianship)
+
+**用例：** 子女已被从生父母手中带走，目前与寄养家庭/收养家庭/亲属监护人同住。临床/法律 genogram 必须同时展示两条 parent-child 链接，但只有一组（生父母）应主导布局——否则视觉上会暗示"现照护人"是生父母，与案件事实相反。
+
+**DSL 写法（推荐 approach a — 重复声明 + secondary marker）：**
+
+```
+genogram "Foster placement"
+  bp1 [male, label: "Bio dad"]
+  bp2 [female, label: "Bio mom"]
+  bp1 ~/~ bp2
+    child [male, 2018, index]    # ← first declaration: structural
+  fp1 [male, label: "Foster dad"]
+  fp2 [female, label: "Foster mom"]
+  fp1 -- fp2
+    own [male, 2010]
+    child [foster]                # ← redeclaration: secondary, dotted link
+```
+
+**Parser 行为：**
+1. 第一次 `child [male, 2018, index]` 在生父母 children block 中 → 建立 primary `parent-child` 关系，`child` 加入 `childrenWithPrimary` 集合。
+2. 第二次 `child [foster]` 在寄养父母 children block 中 → 因为 `child` 已在 `childrenWithPrimary`，且 `[foster]`（或 `[adopted]` / `[guardian]`）是 secondary-link prop → 建立 `foster` 关系并标记 `secondary: true`。
+3. `mergeIndividual` 合并两次声明的非冲突字段（sex, birthYear, label, markers）。冲突的 sex 会抛 `ParseError`。
+
+**Layout 行为：**
+- `buildGraph` 收集 `fu.children` 时**跳过** `secondary === true` 的关系。
+- 寄养 couple 的布局只考虑其生物学 children（如 `own`）。
+- 生父母 couple 把 `child` 居中在他们的 sibship line 下方。
+
+**Renderer 行为：**
+- Primary 边走标准 structural-edges 通道。
+- Secondary 边走独立的 dotted-line 通道（CSS class `schematex-genogram-edge-secondary`），`stroke-dasharray: 2,4`，`opacity: 0.85`，从寄养 couple 的中点 Manhattan-route 到 child 顶部。
+- 跨 generation 也能画——dotted 路径不会被结构性 sibship line 抢占。
+
+**Anti-patterns（明确禁止）：**
+- ❌ 不要为 `[adopted]` / `[foster]` / `[guardian]` 实现独立的 layout 分支。三者都是同一 primitive："生父母关系已存在时的 secondary parent-child link"，只有 visual 标签不同。
+- ❌ 不要为 secondary 边引入新 `RelationshipType`。`secondary: boolean` 标记已足够——保留 `type` 让 legend 自动派生 "Foster" / "Adopted" 行。
+
+**Related：** Gap 1 of 2026-04 foster-care brief。 Cf. Bennett 2022 §6.3 (adopted-out children in pedigree)。
+
+---
+
+### 3.4.2 Sibling-of (known relative, unknown ancestry)
+
+**用例：** 案件文档提到"Mónica 的弟弟"，但他与 IP 没有当前关系，且案卷里没有外祖父母信息。强行声明 phantom 外祖父母会引入虚假信息。
+
+**DSL：**
+```
+monica [female, 1990]
+uncle [male, label: "Tío materno", sibling-of: monica]
+```
+
+**Parser：** `sibling-of: <id>` KV 解析为 `Individual.siblingOf`。
+**Layout：** `assignGenerations` 在 BFS 完成后，迭代地把 `siblingOf` 节点的 generation 设置为引用对象的 generation。`orderGeneration` 把 sibling-of 节点插入到引用对象旁边。
+**Renderer：** `renderSiblingOfBrackets` 在 ast pass 中独立绘制 dashed bracket（`schematex-genogram-sibling-of`），从 left node 顶部 → 上方 8px → right node 顶部。
+
+不合成 phantom parents——这是 pedigree 标准约定。
+
+---
+
+### 3.4.3 Unknown-count sibling placeholder
+
+**用例：** "孩子还有兄弟姐妹但姓名年龄未知"。强迫起一个虚假的占位符 ID 是 false precision。
+
+**DSL（两种等价形式）：**
+
+```
+# Shorthand: bare ? on a child line
+dad -- mom
+  ?
+  known_kid [male, 2018]
+
+# Explicit: [unknown-siblings] marker on a regular id
+dad -- mom
+  sibs [unknown-siblings]
+```
+
+**Parser：** `?` 在 child line 上自动生成 `__unknown_siblings_<n>` ID + `unknown-siblings` marker + sex `unknown` + label `?`。
+**Symbols：** `unknown-siblings` marker 在 diamond 中心绘制粗体 `?` 字符（`schematex-genogram-unknown-siblings-mark`）。
+
+---
 
 ### 3.5 Modern Family Structures
 
@@ -619,6 +706,7 @@ individual_def = ID properties? NEWLINE
 properties     = "[" property ("," property)* "]"
 property       = sex_prop | gender_prop | status_prop | year_prop
                | condition_prop | heritage_prop | child_prop | kv_prop
+               | "index" | "unknown-siblings"
 
 sex_prop       = "male" | "female" | "unknown" | "nonbinary" | "intersex"
 gender_prop    = "transgender"
@@ -631,19 +719,25 @@ fill_position  = "full" | "half-left" | "half-right" | "half-top" | "half-bottom
                | "quad-tl" | "quad-tr" | "quad-bl" | "quad-br"
 heritage_prop  = "heritage:" IDENTIFIER ("+" IDENTIFIER)*
 color          = "#" HEX{6} | NAMED_COLOR
-child_prop     = "adopted" | "foster" | "surrogate" | "donor" | "step"
+child_prop     = "adopted" | "foster" | "guardian" | "surrogate" | "donor" | "step"
                | "twin-identical" | "twin-fraternal"
                | "triplet-identical" | "triplet-fraternal"
 kv_prop        = IDENTIFIER ":" VALUE
+               | "sibling-of" ":" ID
+               | "label" ":" quoted_string
+               | "age" ":" INTEGER
+               | "death" ":" /[0-9]{4}/
 
 annotation_def = INDENT "@" IDENTIFIER ":" quoted_string NEWLINE  # follows individual_def
 
 relationship_def       = couple_rel | couple_with_children
 couple_rel             = ID couple_op ID rel_label? NEWLINE
 couple_with_children   = ID couple_op ID rel_label? NEWLINE INDENT child+ DEDENT
-couple_op              = "--" | "-x-" | "-/-" | "~" | "==" | "-o-" | "~dp~"
+couple_op              = "--" | "-x-" | "-/-" | "-//" | "~" | "~/~" | "==" | "-o-" | "~dp~"
+# Note: "~/~" / "-//" must be matched before "~" / "-/-" — longest token wins.
 rel_label              = "[" "label:" quoted_string "]"
-child                  = individual_def
+child                  = individual_def | unknown_sib_placeholder
+unknown_sib_placeholder = INDENT "?" NEWLINE  # auto-generated unknown-siblings node
 
 emotional_rel_def      = ID emotional_op ID rel_label? NEWLINE
 emotional_op           = "-" EMOTIONAL_TYPE "-" ID
@@ -868,6 +962,38 @@ genogram "Extended Family"
   brother -- sis-in-law [female, 1999]
 ```
 验证：两个 grandparent couple 在 generation 0，parents + uncles/aunts 在 generation 1，me/siblings + in-laws 在 generation 2。
+
+---
+
+### Case 14: Foster Care / Child Protection (LATAM)
+```
+genogram "Familia Isaías"
+  victor [male, label: "Víctor Seguel"]
+  monica [female, label: "Mónica Barrientos"]
+  victor ~/~ monica
+    ?
+    isaias [male, 2020, age: 6, label: "Isaías", index]
+  pablo_sr [male, label: "Don Pablo"]
+  priscila [female, label: "Doña Priscila"]
+  pablo_sr -- priscila
+    pablo_jr [male, label: "Pablo (jr)"]
+    alanis [female, label: "Alanis"]
+    isaias [foster]
+  tio_materno [male, label: "Tío materno", sibling-of: monica]
+  victor -physical-abuse-> isaias
+  monica -physical-abuse-> isaias
+  tio_materno -nevermet- isaias
+```
+
+**验证（陌生人读图后必须能正确得出的 6 个结论）：**
+1. Isaías 是 Víctor 和 Mónica 的生子（生父母 cohabiting-ended，已分手）
+2. 当前与 Don Pablo + Doña Priscila 一起寄养（dotted secondary 链接）
+3. 因被生父母双方身体虐待而被带走（两条 abuse arrows）
+4. Tío materno 是 Mónica 的兄弟，与 Isaías 无关系（`sibling-of` + `nevermet`）
+5. Isaías 还有未知数量的兄弟姐妹仍跟生父母（`?` 占位符）
+6. Isaías 是案件 IP（concentric 同心标记）
+
+覆盖能力：dual-parent rendering · same-id merge · sibling-of · cohabiting-ended · `?` placeholder · directional abuse · index marker — i.e. all five P0 gaps from the 2026-04 foster-care brief.
 
 ---
 

--- a/examples/genogram/childless-couple.svg
+++ b/examples/genogram/childless-couple.svg
@@ -29,8 +29,15 @@
 .schematex-genogram-label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; text-anchor: middle; fill: #0f172a; }
 .schematex-genogram-edge { stroke: #94a3b8; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
 .schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
 .schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: #94a3b8; stroke-width: 2; }
 .schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: #0f172a; pointer-events: none; }
 .schematex-genogram-deceased-mark { stroke: #b71c1c; stroke-width: 2; stroke-linecap: round; }
 /* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
 .schematex-genogram-condition-fill:not([fill]) { fill: #1565c0; }
@@ -40,6 +47,7 @@
 .schematex-genogram-index-border { stroke: #d97706; stroke-width: 3; fill: none; }
 </style>
 <g><g><g class="schematex-genogram-edges"><g class="schematex-genogram-edge schematex-genogram-edge-married" data-from="husband" data-to="wife"><path d="M 84.6 60 L 164.6 60" class="schematex-genogram-edge-path"/></g></g>
+<g class="schematex-genogram-sibling-of-edges"></g>
 <g class="schematex-genogram-emotional-edges"></g>
 <g class="schematex-genogram-generation schematex-genogram-generation-0" data-generation="0"><g class="schematex-genogram-node schematex-genogram-male" data-individual-id="husband" transform="translate(64.6, 60)"><title>Husband (1960)</title>
 <rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/></g>

--- a/examples/genogram/divorce-remarriage.svg
+++ b/examples/genogram/divorce-remarriage.svg
@@ -29,8 +29,15 @@
 .schematex-genogram-label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; text-anchor: middle; fill: #0f172a; }
 .schematex-genogram-edge { stroke: #94a3b8; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
 .schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
 .schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: #94a3b8; stroke-width: 2; }
 .schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: #0f172a; pointer-events: none; }
 .schematex-genogram-deceased-mark { stroke: #b71c1c; stroke-width: 2; stroke-linecap: round; }
 /* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
 .schematex-genogram-condition-fill:not([fill]) { fill: #1565c0; }
@@ -47,6 +54,7 @@
 <g class="schematex-genogram-edge schematex-genogram-edge-married" data-from="tom" data-to="susan"><path d="M 328 60 L 408 60" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="tom" data-to="susan"><path d="M 368 60 L 368 141" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="tom+susan" data-to="child2"><path d="M 368 60 L 368 206" class="schematex-genogram-edge-path"/></g></g>
+<g class="schematex-genogram-sibling-of-edges"></g>
 <g class="schematex-genogram-emotional-edges"></g>
 <g class="schematex-genogram-generation schematex-genogram-generation-0" data-generation="0"><g class="schematex-genogram-node schematex-genogram-female" data-individual-id="jane" transform="translate(60, 60)"><title>Jane (1952)</title>
 <circle cx="0" cy="0" r="20" class="schematex-genogram-shape"/></g>

--- a/examples/genogram/foster-care-isaias.svg
+++ b/examples/genogram/foster-care-isaias.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 710.1999999999999 464" class="schematex-diagram schematex-genogram" width="710.1999999999999" height="464"><title>Genogram: Familia Isaías</title>
+<desc>Genogram diagram with 9 individuals across 2 generations</desc>
+<defs><marker id="schematex-genogram-arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#333"/></marker></defs>
+<style>
+.schematex-genogram {
+  --schematex-bg: #ffffff;
+  --schematex-text: #0f172a;
+  --schematex-text-muted: #475569;
+  --schematex-stroke: #334155;
+  --schematex-fill: #ffffff;
+  --schematex-fill-muted: #f1f5f9;
+  --schematex-accent: #2563eb;
+  --schematex-positive: #059669;
+  --schematex-negative: #dc2626;
+  --schematex-neutral: #94a3b8;
+  --schematex-warn: #d97706;
+  --schematex-font-title: 16px;
+  --schematex-font-label: 12px;
+  --schematex-font-small: 9px;
+  --schematex-stroke-thin: 1;
+  --schematex-stroke-normal: 2;
+  --schematex-stroke-thick: 3;
+  background: #ffffff;
+}
+.schematex-genogram-shape { fill: #ffffff; stroke: #334155; stroke-width: 2; stroke-linejoin: round; }
+.schematex-genogram-male .schematex-genogram-shape { fill: #dbeafe; }
+.schematex-genogram-female .schematex-genogram-shape { fill: #fce7f3; }
+.schematex-genogram-unknown .schematex-genogram-shape { fill: #f5f5f5; }
+.schematex-genogram-label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; text-anchor: middle; fill: #0f172a; }
+.schematex-genogram-edge { stroke: #94a3b8; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: #0f172a; pointer-events: none; }
+.schematex-genogram-deceased-mark { stroke: #b71c1c; stroke-width: 2; stroke-linecap: round; }
+/* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
+.schematex-genogram-condition-fill:not([fill]) { fill: #1565c0; }
+.schematex-genogram-age { font-family: system-ui, -apple-system, sans-serif; fill: #0f172a; pointer-events: none; }
+.schematex-genogram-title { fill: #0f172a; }
+.schematex-genogram-edge-label { font-family: system-ui, -apple-system, sans-serif; fill: #0f172a; }
+.schematex-genogram-index-border { stroke: #d97706; stroke-width: 3; fill: none; }
+</style>
+<g><text x="355.09999999999997" y="28" class="schematex-genogram-title" text-anchor="middle" font-size="20" font-weight="bold" font-family="system-ui, -apple-system, sans-serif">Familia Isaías</text>
+<g transform="translate(0, 40)"><g class="schematex-genogram-edges"><g class="schematex-genogram-edge schematex-genogram-edge-cohabiting-ended" data-from="victor" data-to="monica"><path d="M 80.8 60 L 160.8 60" class="schematex-genogram-edge-path"/>
+<line x1="116.80000000000001" y1="54" x2="124.80000000000001" y2="66" class="schematex-genogram-separation-mark" stroke="#333" stroke-width="2"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="victor" data-to="monica"><path d="M 120.8 60 L 120.8 141" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="victor" data-to="monica"><path d="M 60.8 141 L 180.8 141" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="victor+monica" data-to="isaias"><path d="M 60.8 141 L 60.8 206" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="victor+monica" data-to="__unknown_siblings_1"><path d="M 180.8 141 L 180.8 206" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-married" data-from="pablo_sr" data-to="priscila"><path d="M 520.8 60 L 600.8 60" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="pablo_sr" data-to="priscila"><path d="M 560.8 60 L 560.8 141" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="pablo_sr" data-to="priscila"><path d="M 500.8 141 L 620.8 141" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="pablo_sr+priscila" data-to="pablo_jr"><path d="M 500.8 141 L 500.8 206" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="pablo_sr+priscila" data-to="alanis"><path d="M 620.8 141 L 620.8 206" class="schematex-genogram-edge-path"/></g>
+<g class="schematex-genogram-edge schematex-genogram-edge-secondary schematex-genogram-edge-secondary-foster" data-from="pablo_sr+priscila" data-to="isaias"><path d="M 560.8 84 L 560.8 143 L 60.8 143 L 60.8 202" class="schematex-genogram-edge-path"/></g></g>
+<g class="schematex-genogram-sibling-of-edges"><g class="schematex-genogram-sibling-of" data-from="tio_materno" data-to="monica"><path d="M 340.8 40 L 340.8 28 L 180.8 28 L 180.8 40"/></g></g>
+<g class="schematex-genogram-emotional-edges"><g class="schematex-genogram-emotional schematex-genogram-emotional-physical-abuse" data-from="victor" data-to="isaias" data-relationship-type="physical-abuse"><path d="M 60.8 60 Q 110.8 143 60.8 226" fill="none" stroke="#b71c1c" stroke-width="2" marker-end="url(#schematex-genogram-arrow)"/></g>
+<g class="schematex-genogram-emotional schematex-genogram-emotional-physical-abuse" data-from="monica" data-to="isaias" data-relationship-type="physical-abuse"><path d="M 180.8 60 Q 230.8 143 60.8 226" fill="none" stroke="#b71c1c" stroke-width="2" marker-end="url(#schematex-genogram-arrow)"/></g>
+<g class="schematex-genogram-emotional schematex-genogram-emotional-nevermet" data-from="tio_materno" data-to="isaias" data-relationship-type="nevermet"><path d="M 340.8 60 Q 390.8 143 60.8 226" fill="none" stroke="#9e9e9e" stroke-width="2" style="stroke-dasharray: 6,4;"/></g></g>
+<g class="schematex-genogram-generation schematex-genogram-generation-0" data-generation="0"><g class="schematex-genogram-node schematex-genogram-male" data-individual-id="victor" transform="translate(60.8, 60)"><title>Víctor Seguel</title>
+<rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/></g>
+<g class="schematex-genogram-node schematex-genogram-female" data-individual-id="monica" transform="translate(180.8, 60)"><title>Mónica Barrientos</title>
+<circle cx="0" cy="0" r="20" class="schematex-genogram-shape"/></g>
+<g class="schematex-genogram-node schematex-genogram-male" data-individual-id="tio_materno" transform="translate(340.8, 60)"><title>Tío materno</title>
+<rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/></g>
+<g class="schematex-genogram-node schematex-genogram-male" data-individual-id="pablo_sr" transform="translate(500.8, 60)"><title>Don Pablo</title>
+<rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/></g>
+<g class="schematex-genogram-node schematex-genogram-female" data-individual-id="priscila" transform="translate(620.8, 60)"><title>Doña Priscila</title>
+<circle cx="0" cy="0" r="20" class="schematex-genogram-shape"/></g></g>
+<g class="schematex-genogram-generation schematex-genogram-generation-1" data-generation="1"><g class="schematex-genogram-node schematex-genogram-male schematex-genogram-index-person" data-individual-id="isaias" transform="translate(60.8, 226)"><title>Isaías (2020)</title>
+<rect x="-24" y="-24" width="48" height="48" class="schematex-genogram-index-border"/>
+<rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/>
+<text x="0" y="5" class="schematex-genogram-age" text-anchor="middle" font-size="11">6</text></g>
+<g class="schematex-genogram-node schematex-genogram-unknown schematex-genogram-unknown-siblings" data-individual-id="__unknown_siblings_1" transform="translate(180.8, 226)"><title>?</title>
+<polygon points="0,-20 20,0 0,20 -20,0" class="schematex-genogram-shape"/>
+<text x="0" y="5" class="schematex-genogram-unknown-siblings-mark" text-anchor="middle" font-size="16" font-weight="bold">?</text></g>
+<g class="schematex-genogram-node schematex-genogram-male" data-individual-id="pablo_jr" transform="translate(500.8, 226)"><title>Pablo (jr)</title>
+<rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/></g>
+<g class="schematex-genogram-node schematex-genogram-female" data-individual-id="alanis" transform="translate(620.8, 226)"><title>Alanis</title>
+<circle cx="0" cy="0" r="20" class="schematex-genogram-shape"/></g></g>
+<g class="schematex-genogram-labels"><text x="60.8" y="98" class="schematex-genogram-label" data-individual-id="victor">Víctor Seguel</text>
+<text x="180.8" y="98" class="schematex-genogram-label" data-individual-id="monica">Mónica Barrientos</text>
+<text x="340.8" y="98" class="schematex-genogram-label" data-individual-id="tio_materno">Tío materno</text>
+<text x="500.8" y="98" class="schematex-genogram-label" data-individual-id="pablo_sr">Don Pablo</text>
+<text x="620.8" y="98" class="schematex-genogram-label" data-individual-id="priscila">Doña Priscila</text>
+<text x="60.8" y="264" class="schematex-genogram-label" data-individual-id="isaias">Isaías (b. 2020)</text>
+<text x="180.8" y="264" class="schematex-genogram-label" data-individual-id="__unknown_siblings_1">?</text>
+<text x="500.8" y="264" class="schematex-genogram-label" data-individual-id="pablo_jr">Pablo (jr)</text>
+<text x="620.8" y="264" class="schematex-genogram-label" data-individual-id="alanis">Alanis</text></g>
+<g class="schematex-genogram-edge-labels"></g></g></g>
+<g class="schematex-legend"><style>
+.schematex-legend { font-family: system-ui, -apple-system, sans-serif; }
+.schematex-legend-title { font-size: 12px; font-weight: 700; fill: #0f172a; }
+.schematex-legend-section { font-size: 9px; font-weight: 600; fill: #475569; letter-spacing: 0.6px; }
+.schematex-legend-label { font-size: 11px; fill: #0f172a; dominant-baseline: alphabetic; }
+</style>
+<text x="16" y="388.5" class="schematex-legend-section">SYMBOLS</text>
+<g class="schematex-legend-row" data-legend-key="sex.unknown" data-legend-section="symbols"><polygon points="140.45,380 145.45,385 140.45,390 135.45,385" fill="#f5f5f5" stroke="#334155"/>
+<text x="159.45" y="388.5" class="schematex-legend-label">Unknown</text></g>
+<text x="16" y="406.5" class="schematex-legend-section">STRUCTURAL</text>
+<g class="schematex-legend-row" data-legend-key="cohabiting-ended" data-legend-section="structural"><line x1="130.45" y1="403" x2="150.45" y2="403" stroke="#334155" stroke-width="2" stroke-linecap="round" stroke-dasharray="5,3"/><line x1="145.45" y1="408" x2="153.45" y2="398" stroke="#334155" stroke-width="1.6"/>
+<text x="159.45" y="406.5" class="schematex-legend-label">Cohabiting (ended)</text></g>
+<g class="schematex-legend-row" data-legend-key="foster" data-legend-section="structural"><line x1="297.45" y1="403" x2="317.45" y2="403" stroke="#334155" stroke-width="2" stroke-linecap="round" stroke-dasharray="5,3"/>
+<text x="326.45" y="406.5" class="schematex-legend-label">Foster</text></g>
+<text x="16" y="424.5" class="schematex-legend-section">RELATIONSHIPS</text>
+<g class="schematex-legend-row" data-legend-key="nevermet" data-legend-section="relationships"><line x1="130.45" y1="421" x2="150.45" y2="421" stroke="#9e9e9e" stroke-width="2" stroke-linecap="round" stroke-dasharray="5,3"/>
+<text x="159.45" y="424.5" class="schematex-legend-label">Nevermet</text></g>
+<g class="schematex-legend-row" data-legend-key="physical-abuse" data-legend-section="relationships"><line x1="231.45" y1="421" x2="251.45" y2="421" stroke="#b71c1c" stroke-width="2" stroke-linecap="round"/>
+<text x="260.45" y="424.5" class="schematex-legend-label">Physical Abuse</text></g>
+<text x="16" y="442.5" class="schematex-legend-section">MARKERS</text>
+<g class="schematex-legend-row" data-legend-key="marker.index-person" data-legend-section="markers"><rect x="132.45" y="436" width="16" height="6" fill="#fef3c7" stroke="#334155"/><rect x="130.45" y="434" width="20" height="10" fill="none" stroke="#334155" stroke-width="1.2"/>
+<text x="159.45" y="442.5" class="schematex-legend-label">Index person (focal subject)</text></g>
+<g class="schematex-legend-row" data-legend-key="marker.unknown-siblings" data-legend-section="markers"><polygon points="373.45,434 378.45,439 373.45,444 368.45,439" fill="#ffffff" stroke="#334155"/>
+<text x="392.45" y="442.5" class="schematex-legend-label">Sibling(s) — unknown count</text></g></g></svg>

--- a/examples/genogram/medical-conditions.svg
+++ b/examples/genogram/medical-conditions.svg
@@ -31,8 +31,15 @@
 .schematex-genogram-label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; text-anchor: middle; fill: #0f172a; }
 .schematex-genogram-edge { stroke: #94a3b8; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
 .schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
 .schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: #94a3b8; stroke-width: 2; }
 .schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: #0f172a; pointer-events: none; }
 .schematex-genogram-deceased-mark { stroke: #b71c1c; stroke-width: 2; stroke-linecap: round; }
 /* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
 .schematex-genogram-condition-fill:not([fill]) { fill: #1565c0; }
@@ -44,6 +51,7 @@
 <g transform="translate(95.19999999999999, 0)"><g><g class="schematex-genogram-edges"><g class="schematex-genogram-edge schematex-genogram-edge-married" data-from="father" data-to="mother"><path d="M 80.8 60 L 160.8 60" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="father" data-to="mother"><path d="M 120.8 60 L 120.8 141" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="father+mother" data-to="son"><path d="M 120.8 60 L 120.8 206" class="schematex-genogram-edge-path"/></g></g>
+<g class="schematex-genogram-sibling-of-edges"></g>
 <g class="schematex-genogram-emotional-edges"></g>
 <g class="schematex-genogram-generation schematex-genogram-generation-0" data-generation="0"><g class="schematex-genogram-node schematex-genogram-male" data-individual-id="father" transform="translate(60.8, 60)"><title>Father (1945)</title>
 <rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/>

--- a/examples/genogram/nuclear-family.svg
+++ b/examples/genogram/nuclear-family.svg
@@ -29,8 +29,15 @@
 .schematex-genogram-label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; text-anchor: middle; fill: #0f172a; }
 .schematex-genogram-edge { stroke: #94a3b8; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
 .schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
 .schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: #94a3b8; stroke-width: 2; }
 .schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: #0f172a; pointer-events: none; }
 .schematex-genogram-deceased-mark { stroke: #b71c1c; stroke-width: 2; stroke-linecap: round; }
 /* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
 .schematex-genogram-condition-fill:not([fill]) { fill: #1565c0; }
@@ -44,6 +51,7 @@
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="john" data-to="mary"><path d="M 60 141 L 180 141" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="john+mary" data-to="alice"><path d="M 60 141 L 60 206" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="john+mary" data-to="bob"><path d="M 180 141 L 180 206" class="schematex-genogram-edge-path"/></g></g>
+<g class="schematex-genogram-sibling-of-edges"></g>
 <g class="schematex-genogram-emotional-edges"></g>
 <g class="schematex-genogram-generation schematex-genogram-generation-0" data-generation="0"><g class="schematex-genogram-node schematex-genogram-male" data-individual-id="john" transform="translate(60, 60)"><title>John (1950)</title>
 <rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/></g>

--- a/examples/genogram/single-individual.svg
+++ b/examples/genogram/single-individual.svg
@@ -29,8 +29,15 @@
 .schematex-genogram-label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; text-anchor: middle; fill: #0f172a; }
 .schematex-genogram-edge { stroke: #94a3b8; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
 .schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
 .schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: #94a3b8; stroke-width: 2; }
 .schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: #0f172a; pointer-events: none; }
 .schematex-genogram-deceased-mark { stroke: #b71c1c; stroke-width: 2; stroke-linecap: round; }
 /* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
 .schematex-genogram-condition-fill:not([fill]) { fill: #1565c0; }
@@ -40,6 +47,7 @@
 .schematex-genogram-index-border { stroke: #d97706; stroke-width: 3; fill: none; }
 </style>
 <g><g><g class="schematex-genogram-edges"></g>
+<g class="schematex-genogram-sibling-of-edges"></g>
 <g class="schematex-genogram-emotional-edges"></g>
 <g class="schematex-genogram-generation schematex-genogram-generation-0" data-generation="0"><g class="schematex-genogram-node schematex-genogram-female" data-individual-id="solo" transform="translate(60, 60)"><title>Solo (1990)</title>
 <circle cx="0" cy="0" r="20" class="schematex-genogram-shape"/></g></g>

--- a/examples/genogram/three-generation.svg
+++ b/examples/genogram/three-generation.svg
@@ -29,8 +29,15 @@
 .schematex-genogram-label { font-family: system-ui, -apple-system, sans-serif; font-size: 12px; text-anchor: middle; fill: #0f172a; }
 .schematex-genogram-edge { stroke: #94a3b8; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
 .schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
 .schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: #94a3b8; stroke-width: 2; }
 .schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: #94a3b8; stroke-width: 2; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: #94a3b8; stroke-width: 2; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: #0f172a; pointer-events: none; }
 .schematex-genogram-deceased-mark { stroke: #b71c1c; stroke-width: 2; stroke-linecap: round; }
 /* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
 .schematex-genogram-condition-fill:not([fill]) { fill: #1565c0; }
@@ -50,6 +57,7 @@
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="dad" data-to="mom"><path d="M 60 307 L 180 307" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="dad+mom" data-to="me"><path d="M 60 307 L 60 372" class="schematex-genogram-edge-path"/></g>
 <g class="schematex-genogram-edge schematex-genogram-edge-parent-child" data-from="dad+mom" data-to="sister"><path d="M 180 307 L 180 372" class="schematex-genogram-edge-path"/></g></g>
+<g class="schematex-genogram-sibling-of-edges"></g>
 <g class="schematex-genogram-emotional-edges"></g>
 <g class="schematex-genogram-generation schematex-genogram-generation-0" data-generation="0"><g class="schematex-genogram-node schematex-genogram-male schematex-genogram-deceased" data-individual-id="grandpa" transform="translate(120, 60)"><title>Grandpa (1930)</title>
 <rect x="-20" y="-20" width="40" height="40" class="schematex-genogram-shape"/>

--- a/preview/genogram.html
+++ b/preview/genogram.html
@@ -105,6 +105,23 @@ const sections = [
   patient -cutoff- brother
   patient -harmony- mother`],
 
+      ['Foster Care · Isaías (LATAM child protection)', `genogram "Familia Isaías"
+  victor [male, label: "Víctor Seguel"]
+  monica [female, label: "Mónica Barrientos"]
+  victor ~/~ monica
+    ?
+    isaias [male, 2020, age: 6, label: "Isaías", index]
+  pablo_sr [male, label: "Don Pablo"]
+  priscila [female, label: "Doña Priscila"]
+  pablo_sr -- priscila
+    pablo_jr [male, label: "Pablo (jr)"]
+    alanis [female, label: "Alanis"]
+    isaias [foster]
+  tio_materno [male, label: "Tío materno", sibling-of: monica]
+  victor -physical-abuse-> isaias
+  monica -physical-abuse-> isaias
+  tio_materno -nevermet- isaias`],
+
       ['Harry Potter Family', `genogram "The Potter Family"
   fleamont [male, 1909, 1979, deceased]
   euphemia [female, 1920, 1979, deceased]

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -194,6 +194,13 @@ export interface Individual {
   annotations?: Record<string, string>;
   /** Whether this individual is external/non-family (dashed border) */
   external?: boolean;
+  /**
+   * Pedigree convention for "known relative, unknown ancestry":
+   * id of another individual whose generation this person shares as a sibling.
+   * No phantom parents are synthesized — layout pins generation, renderer
+   * draws a dashed bracket between the two.
+   */
+  siblingOf?: string;
   /** Custom properties for extensibility */
   properties?: Record<string, string>;
 }
@@ -247,7 +254,9 @@ export type IndividualMarker =
   | "index-person" // genogram: identified patient (concentric shape)
   | "transgender" // Bennett 2022: gender ≠ assigned sex
   | "no-children" // by choice
-  | "infertile";
+  | "infertile"
+  // Pedigree convention: ≥1 sibling(s) of unknown count — single diamond with "?"
+  | "unknown-siblings";
 
 export type TwinType =
   | "twin-identical" // monozygotic
@@ -474,6 +483,7 @@ export type RelationshipType =
   | "separated"
   | "engaged"
   | "cohabiting"
+  | "cohabiting-ended" // unmarried cohabitation that has ended (LATAM "quiebre")
   | "domestic-partnership"
   | "consanguineous"
   // Structural parent-child
@@ -540,6 +550,13 @@ export interface Relationship {
   weight?: number;
   /** For ecomap: energy flow direction */
   energyFlow?: "from" | "to" | "mutual" | "none";
+  /**
+   * Genogram parent-child only. When true, this link is data-true but
+   * does NOT dominate layout — used for foster/adopted/guardian "current
+   * caregiver" relationships when biological parents already claim the
+   * child structurally. Renderer draws it as a dotted line.
+   */
+  secondary?: boolean;
 }
 
 // ─── Layout Types ────────────────────────────────────────────

--- a/src/diagrams/genogram/layout.ts
+++ b/src/diagrams/genogram/layout.ts
@@ -37,8 +37,19 @@ export function layoutGenogram(
   const ordered = orderNodesInGenerations(graph, config);
   const positions = assignPositions(ordered, graph, config);
   const edges = computeEdges(graph, positions, config);
+  const secondaryEdges = computeSecondaryParentEdges(
+    ast.relationships,
+    graph,
+    positions,
+    config
+  );
   const emotionalEdges = computeEmotionalEdges(ast.relationships, positions, config);
-  return packageResult(positions, [...edges, ...emotionalEdges], graph, config);
+  return packageResult(
+    positions,
+    [...edges, ...secondaryEdges, ...emotionalEdges],
+    graph,
+    config
+  );
 }
 
 // ─── Step 1: Build graph ────────────────────────────────────
@@ -60,6 +71,7 @@ function buildGraph(ast: DiagramAST): LayoutGraph {
       r.type === "separated" ||
       r.type === "engaged" ||
       r.type === "cohabiting" ||
+      r.type === "cohabiting-ended" ||
       r.type === "consanguineous"
   );
 
@@ -86,14 +98,17 @@ function buildGraph(ast: DiagramAST): LayoutGraph {
       partners = [rel.from, rel.to];
     }
 
-    // Find children for this family unit
+    // Find children for this family unit. Skip *secondary* parent-child rels
+    // (foster/adopted "current caregiver" links): they are data-true but must
+    // not dominate layout — the bio couple keeps the child structurally.
     const children: string[] = [];
     for (const r of ast.relationships) {
       if (
         (r.type === "parent-child" ||
           r.type === "adopted" ||
           r.type === "foster") &&
-        r.from === fuId
+        r.from === fuId &&
+        !r.secondary
       ) {
         children.push(r.to);
         childOf.set(r.to, fuId);
@@ -124,9 +139,15 @@ function buildGraph(ast: DiagramAST): LayoutGraph {
 function assignGenerations(graph: LayoutGraph): void {
   const { individuals, familyUnits, childOf, generations } = graph;
 
-  // Find roots: individuals not a child of any family unit
+  // Find roots: individuals not a child of any family unit AND not anchored
+  // via siblingOf to another individual (those will be placed in step 2).
   const allIds = Array.from(individuals.keys());
-  const roots = allIds.filter((id) => !childOf.has(id));
+  const roots = allIds.filter((id) => {
+    if (childOf.has(id)) return false;
+    const ind = individuals.get(id);
+    if (ind?.siblingOf) return false;
+    return true;
+  });
 
   if (roots.length === 0 && allIds.length > 0) {
     // Fallback: everyone is generation 0
@@ -181,6 +202,24 @@ function assignGenerations(graph: LayoutGraph): void {
           generations.set(childId, childGen);
           changed = true;
         }
+      }
+    }
+  }
+
+  // Resolve siblingOf anchors — copy generation from the referenced sibling.
+  // Iterate to fixed point in case of chains (siblingOf → siblingOf).
+  let siblingChanged = true;
+  let safety = 0;
+  while (siblingChanged && safety++ < allIds.length + 1) {
+    siblingChanged = false;
+    for (const id of allIds) {
+      if (generations.has(id)) continue;
+      const ind = individuals.get(id);
+      if (!ind?.siblingOf) continue;
+      const refGen = generations.get(ind.siblingOf);
+      if (refGen !== undefined) {
+        generations.set(id, refGen);
+        siblingChanged = true;
       }
     }
   }
@@ -298,15 +337,36 @@ function orderGeneration(
     }
   }
 
-  // Place remaining unpartnered individuals (sorted by birth year)
+  // Place remaining unpartnered individuals. Sibling-of anchors get inserted
+  // immediately adjacent to their referenced sibling so the dashed bracket
+  // stays short. Everyone else falls back to birth-year sort.
   const remaining = nodeIds.filter((id) => !placed.has(id));
-  remaining.sort((a, b) => {
+  const siblingOfRemaining = remaining.filter((id) => {
+    const ind = graph.individuals.get(id);
+    return ind?.siblingOf && placed.has(ind.siblingOf);
+  });
+  const otherRemaining = remaining.filter(
+    (id) => !siblingOfRemaining.includes(id)
+  );
+  otherRemaining.sort((a, b) => {
     const indA = graph.individuals.get(a);
     const indB = graph.individuals.get(b);
     return (indA?.birthYear ?? 9999) - (indB?.birthYear ?? 9999);
   });
-  for (const id of remaining) {
+  for (const id of otherRemaining) {
     ordered.push(id);
+    placed.add(id);
+  }
+  // Insert each sibling-of node right after its referenced sibling.
+  for (const id of siblingOfRemaining) {
+    const ind = graph.individuals.get(id);
+    if (!ind?.siblingOf) continue;
+    const refIdx = ordered.indexOf(ind.siblingOf);
+    if (refIdx === -1) {
+      ordered.push(id);
+    } else {
+      ordered.splice(refIdx + 1, 0, id);
+    }
     placed.add(id);
   }
 
@@ -871,6 +931,63 @@ function computeEmotionalEdges(
       to: rel.to,
       relationship: rel,
       path: pathData,
+    });
+  }
+
+  return edges;
+}
+
+// ─── Secondary parent-child edges (foster/adopted "current caregiver") ──
+
+function computeSecondaryParentEdges(
+  relationships: Relationship[],
+  graph: LayoutGraph,
+  positions: Map<string, NodePosition>,
+  config: LayoutConfig
+): LayoutEdge[] {
+  const edges: LayoutEdge[] = [];
+  const half = config.nodeHeight / 2;
+
+  for (const rel of relationships) {
+    if (!rel.secondary) continue;
+    if (
+      rel.type !== "parent-child" &&
+      rel.type !== "foster" &&
+      rel.type !== "adopted"
+    )
+      continue;
+
+    // Resolve couple key "leftId+rightId" → midpoint of the two partners
+    const fu = graph.familyUnits.find((f) => f.id === rel.from);
+    if (!fu) continue;
+    const posA = positions.get(fu.partners[0]);
+    const posB = positions.get(fu.partners[1]);
+    const childPos = positions.get(rel.to);
+    if (!posA || !posB || !childPos) continue;
+
+    const coupleMidX = (posA.x + posB.x) / 2;
+    const coupleY = posA.y;
+    // Anchor on the bottom edge of the couple line, route to top of child
+    const startX = coupleMidX;
+    const startY = coupleY + half + 4;
+    const childTopY = childPos.y - half - 4;
+
+    // Manhattan-style routing so the dotted line is unambiguous, even when
+    // the foster couple sits on a different generation than the bio child.
+    const path =
+      childPos.y === coupleY
+        ? `M ${startX} ${startY} L ${startX} ${startY + 16} L ${childPos.x} ${
+            startY + 16
+          } L ${childPos.x} ${childPos.y - half - 4}`
+        : `M ${startX} ${startY} L ${startX} ${
+            (startY + childTopY) / 2
+          } L ${childPos.x} ${(startY + childTopY) / 2} L ${childPos.x} ${childTopY}`;
+
+    edges.push({
+      from: rel.from,
+      to: rel.to,
+      relationship: rel,
+      path,
     });
   }
 

--- a/src/diagrams/genogram/legend.ts
+++ b/src/diagrams/genogram/legend.ts
@@ -43,7 +43,7 @@ const EMOTIONAL_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 const STRUCTURAL_TYPES: ReadonlySet<string> = new Set([
-  "married", "divorced", "separated", "engaged", "cohabiting",
+  "married", "divorced", "separated", "engaged", "cohabiting", "cohabiting-ended",
   "domestic-partnership", "consanguineous",
   "parent-child", "adopted", "foster",
   "twin-identical", "twin-fraternal",
@@ -255,7 +255,7 @@ function buildStructuralItems(
   }
   // Order matters for legend display.
   const order: RelationshipType[] = [
-    "divorced", "separated", "engaged", "cohabiting",
+    "divorced", "separated", "engaged", "cohabiting", "cohabiting-ended",
     "domestic-partnership", "consanguineous",
     "adopted", "foster",
     "twin-identical", "twin-fraternal",
@@ -283,6 +283,14 @@ function structuralItem(t: RelationshipType, theme?: GenogramThemeLike): LegendI
       return { ...base, kind: "edge", marker: "X", pattern: "solid" };
     case "separated":
       return { ...base, kind: "edge", marker: "slash", pattern: "solid" };
+    case "cohabiting-ended":
+      return {
+        ...base,
+        label: "Cohabiting (ended)",
+        kind: "edge",
+        marker: "slash",
+        pattern: "dashed",
+      };
     case "engaged":
     case "cohabiting":
     case "adopted":
@@ -438,7 +446,7 @@ function buildMarkerItems(
   }
   const order: IndividualMarker[] = [
     "proband", "consultand", "evaluated", "index-person",
-    "transgender", "no-children", "infertile",
+    "transgender", "no-children", "infertile", "unknown-siblings",
   ];
   const items: LegendItem[] = [];
   for (const m of order) {
@@ -472,6 +480,16 @@ function markerItem(m: IndividualMarker, theme?: GenogramThemeLike): LegendItem 
       return { key: `marker.${m}`, label: "No children (by choice)", kind: "marker", marker: "slash", section: "markers" };
     case "infertile":
       return { key: `marker.${m}`, label: "Infertile", kind: "marker", marker: "X", section: "markers" };
+    case "unknown-siblings":
+      return {
+        key: `marker.${m}`,
+        label: "Sibling(s) — unknown count",
+        kind: "shape",
+        shape: "diamond",
+        fill: "#ffffff",
+        color: theme?.stroke,
+        section: "markers",
+      };
     default:
       return { key: `marker.${m}`, label: humanize(m), kind: "marker", marker: "dot", section: "markers" };
   }

--- a/src/diagrams/genogram/parser.ts
+++ b/src/diagrams/genogram/parser.ts
@@ -25,7 +25,11 @@ export class ParseError extends Error {
 
 // ─── Couple operators ───────────────────────────────────────
 
+// Order matters — the parser tries these in sequence and the first match wins.
+// Longer tokens MUST come first so e.g. `~/~` is not split as `~` + `/~`.
 const COUPLE_OPS: Array<{ token: string; type: RelationshipType }> = [
+  { token: "~/~", type: "cohabiting-ended" },
+  { token: "-//", type: "separated" }, // alias for -/-
   { token: "-x-", type: "divorced" },
   { token: "-/-", type: "separated" },
   { token: "-o-", type: "engaged" },
@@ -47,6 +51,10 @@ const SPECIAL_CHILD_PROPS = new Set([
   "twin-identical",
   "twin-fraternal",
 ]);
+// Tokens whose appearance on a redeclared child indicates the link is a
+// secondary "current caregiver" relationship (foster / adopted / guardian),
+// not the structural biological link.
+const SECONDARY_LINK_PROPS = new Set(["foster", "adopted", "guardian"]);
 const VALID_FILLS = new Set([
   "full",
   "half-left",
@@ -114,6 +122,12 @@ export function parseGenogram(text: string): DiagramAST {
   const relationships: Relationship[] = [];
   const childSpecialProps = new Map<string, string>();
   const legendOverrides: LegendOverrides = {};
+  // Track which children already have a structural (primary) parent-child rel.
+  // The first one wins layout; later declarations under another couple become
+  // secondary "current caregiver" links.
+  const childrenWithPrimary = new Set<string>();
+  // Counter for auto-generated `?` placeholder ids.
+  let unknownSibCounter = 0;
 
   skipBlankAndComments(state);
 
@@ -186,8 +200,14 @@ export function parseGenogram(text: string): DiagramAST {
       // Register right individual if it has inline props or doesn't exist yet
       const rightKey = rightId.toLowerCase();
       if (rightProps) {
-        const rightIndividual = buildIndividual(rightId, rightProps, lineNum, lineText);
-        individualsMap.set(rightKey, rightIndividual);
+        const incoming = buildIndividual(rightId, rightProps, lineNum, lineText);
+        const existing = individualsMap.get(rightKey);
+        individualsMap.set(
+          rightKey,
+          existing
+            ? mergeIndividual(existing, incoming, lineNum, lineText)
+            : incoming
+        );
       } else if (!individualsMap.has(rightKey)) {
         throw new ParseError(
           `Unknown individual '${rightId}'`,
@@ -219,35 +239,69 @@ export function parseGenogram(text: string): DiagramAST {
 
         // This is a child line
         const childLineNum = state.currentLine + 1;
-        const { id: childId, propsStr } = splitIdAndProps(childTrimmed);
-        const childKey = childId.toLowerCase();
 
-        const individual = buildIndividual(
-          childId,
-          propsStr,
+        // `?` shorthand → synthetic placeholder id with unknown-siblings marker
+        let parsedId: string;
+        let parsedProps: string | null;
+        if (childTrimmed === "?" || childTrimmed.startsWith("? ")) {
+          parsedId = `__unknown_siblings_${++unknownSibCounter}`;
+          parsedProps = "unknown, unknown-siblings";
+        } else {
+          const split = splitIdAndProps(childTrimmed);
+          parsedId = split.id;
+          parsedProps = split.propsStr;
+        }
+        const childKey = parsedId.toLowerCase();
+
+        const incoming = buildIndividual(
+          parsedId,
+          parsedProps,
           childLineNum,
           childLine
         );
 
         // Check for special child properties (adopted, foster, twin)
-        if (propsStr) {
-          for (const sp of SPECIAL_CHILD_PROPS) {
-            if (propsTokens(propsStr).includes(sp)) {
-              childSpecialProps.set(childKey, sp);
-            }
-          }
+        const tokens = parsedProps ? propsTokens(parsedProps) : [];
+        for (const sp of SPECIAL_CHILD_PROPS) {
+          if (tokens.includes(sp)) childSpecialProps.set(childKey, sp);
         }
+        const isSecondaryDecl = tokens.some((t) => SECONDARY_LINK_PROPS.has(t));
 
-        individualsMap.set(childKey, individual);
+        const existing = individualsMap.get(childKey);
+        individualsMap.set(
+          childKey,
+          existing
+            ? mergeIndividual(existing, incoming, childLineNum, childLine)
+            : incoming
+        );
 
         // parent-child relationship: from = "leftKey+rightKey"
+        // IMPORTANT: derive the rel type from THIS line's tokens, not from
+        // the cross-declaration `childSpecialProps` map — otherwise a child
+        // declared once with `[foster]` and again as a plain bio child would
+        // see the bio rel typed as "foster" too (the global map is sticky).
         const coupleKey = `${leftKey}+${rightKey}`;
-        const pcType = childSpecialProps.get(childKey);
+        const lineChildType = tokens.find((t) =>
+          SPECIAL_CHILD_PROPS.has(t)
+        );
         const relType: RelationshipType =
-          pcType && (pcType === "adopted" || pcType === "foster")
-            ? pcType
+          lineChildType === "adopted" || lineChildType === "foster"
+            ? (lineChildType as RelationshipType)
             : "parent-child";
-        relationships.push({ type: relType, from: coupleKey, to: childKey });
+
+        // Dual-parent handling: if this child already has a primary
+        // structural rel, demote this one to secondary so it doesn't
+        // compete for layout. Otherwise this becomes the primary.
+        const isSecondary =
+          isSecondaryDecl && childrenWithPrimary.has(childKey);
+        const rel: Relationship = {
+          type: relType,
+          from: coupleKey,
+          to: childKey,
+        };
+        if (isSecondary) rel.secondary = true;
+        relationships.push(rel);
+        if (!isSecondary) childrenWithPrimary.add(childKey);
 
         state.currentLine++;
       }
@@ -261,7 +315,10 @@ export function parseGenogram(text: string): DiagramAST {
 
       const existing = individualsMap.get(key);
       if (existing) {
-        individualsMap.set(key, mergeIndividual(existing, individual));
+        individualsMap.set(
+          key,
+          mergeIndividual(existing, individual, lineNum, lineText)
+        );
       } else {
         individualsMap.set(key, individual);
       }
@@ -301,6 +358,14 @@ export function parseGenogram(text: string): DiagramAST {
     }
   }
 
+  // Order-insensitive primary/secondary normalization for dual-parent cases.
+  // If a child has multiple parent-child rels, prefer the bio one as primary
+  // (`type: "parent-child"`); otherwise keep the first declared as primary.
+  // All other parent-child rels for that child become `secondary: true`. This
+  // protects against the LLM emitting foster-parents-first / bio-parents-second
+  // (which would otherwise leave both rels primary and break layout).
+  normalizePrimaryParentRels(relationships);
+
   const hasLegendOverrides =
     Object.keys(legendOverrides).length > 0 &&
     Object.values(legendOverrides).some((v) => v !== undefined);
@@ -312,6 +377,36 @@ export function parseGenogram(text: string): DiagramAST {
     metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     legendOverrides: hasLegendOverrides ? legendOverrides : undefined,
   };
+}
+
+function normalizePrimaryParentRels(relationships: Relationship[]): void {
+  const PARENT_CHILD_TYPES = new Set<RelationshipType>([
+    "parent-child",
+    "adopted",
+    "foster",
+  ]);
+  // Group indices by child id
+  const byChild = new Map<string, number[]>();
+  for (let i = 0; i < relationships.length; i++) {
+    const r = relationships[i];
+    if (!PARENT_CHILD_TYPES.has(r.type)) continue;
+    const arr = byChild.get(r.to) ?? [];
+    arr.push(i);
+    byChild.set(r.to, arr);
+  }
+  for (const indices of byChild.values()) {
+    if (indices.length < 2) continue;
+    // Prefer "parent-child" (bio) as primary; else first declared.
+    let primaryIdx = indices.find((i) => relationships[i].type === "parent-child");
+    if (primaryIdx === undefined) primaryIdx = indices[0];
+    for (const i of indices) {
+      if (i === primaryIdx) {
+        delete relationships[i].secondary;
+      } else {
+        relationships[i].secondary = true;
+      }
+    }
+  }
 }
 
 // ─── Helpers ────────────────────────────────────────────────
@@ -500,7 +595,11 @@ function buildIndividual(
     } else if (tokenLower === "index") {
       if (!individual.markers) individual.markers = [];
       individual.markers.push("index-person");
-    } else if (SPECIAL_CHILD_PROPS.has(tokenLower)) {
+    } else if (tokenLower === "unknown-siblings") {
+      if (!individual.markers) individual.markers = [];
+      individual.markers.push("unknown-siblings");
+      if (!individual.label || individual.label === id) individual.label = "?";
+    } else if (SPECIAL_CHILD_PROPS.has(tokenLower) || tokenLower === "guardian") {
       // Handled at caller level for relationships
       continue;
     } else if (/^\d{4}$/.test(tokenLower)) {
@@ -527,13 +626,15 @@ function buildIndividual(
         if (!isNaN(deathNum)) individual.deathYear = deathNum;
       } else if (key === "label") {
         individual.label = value.replace(/^"|"$/g, "");
+      } else if (key === "sibling-of") {
+        individual.siblingOf = value.toLowerCase();
       } else {
         if (!individual.properties) individual.properties = {};
         individual.properties[key] = value;
       }
     } else {
       throw new ParseError(
-        `Unknown property '${token}'. Valid: male, female, unknown, deceased, stillborn, miscarriage, abortion, adopted, foster, twin-identical, twin-fraternal, index, a 4-digit year, conditions:..., age:N, death:YYYY, or key:value`,
+        `Unknown property '${token}'. Valid: male, female, unknown, deceased, stillborn, miscarriage, abortion, adopted, foster, guardian, twin-identical, twin-fraternal, index, unknown-siblings, a 4-digit year, conditions:..., age:N, death:YYYY, label:"...", sibling-of:ID, or key:value`,
         lineNum,
         1,
         lineText
@@ -583,20 +684,117 @@ function parseConditions(
   return conditions;
 }
 
+/**
+ * Merge a redeclaration into an existing individual.
+ *
+ * Rule: defaults (`sex: "unknown"`, `status: "alive"`, label === id) yield to
+ * any non-default value from the other side. Two conflicting non-default
+ * values (e.g. sex declared as both `male` and `female`) raise ParseError —
+ * silent data loss is the bug we're fixing here.
+ */
 function mergeIndividual(
   existing: Individual,
-  incoming: Individual
+  incoming: Individual,
+  lineNum: number,
+  lineText: string
 ): Individual {
+  // Sex conflict detection (defaults pass through silently)
+  let mergedSex = existing.sex;
+  if (incoming.sex !== "unknown") {
+    if (existing.sex !== "unknown" && existing.sex !== incoming.sex) {
+      throw new ParseError(
+        `Conflicting sex for '${existing.id}': previously '${existing.sex}', now '${incoming.sex}'`,
+        lineNum,
+        1,
+        lineText
+      );
+    }
+    mergedSex = incoming.sex;
+  }
+
+  let mergedStatus = existing.status;
+  if (incoming.status !== "alive") {
+    if (existing.status !== "alive" && existing.status !== incoming.status) {
+      throw new ParseError(
+        `Conflicting status for '${existing.id}': previously '${existing.status}', now '${incoming.status}'`,
+        lineNum,
+        1,
+        lineText
+      );
+    }
+    mergedStatus = incoming.status;
+  }
+
+  if (
+    incoming.birthYear !== undefined &&
+    existing.birthYear !== undefined &&
+    incoming.birthYear !== existing.birthYear
+  ) {
+    throw new ParseError(
+      `Conflicting birth year for '${existing.id}': previously ${existing.birthYear}, now ${incoming.birthYear}`,
+      lineNum,
+      1,
+      lineText
+    );
+  }
+  if (
+    incoming.deathYear !== undefined &&
+    existing.deathYear !== undefined &&
+    incoming.deathYear !== existing.deathYear
+  ) {
+    throw new ParseError(
+      `Conflicting death year for '${existing.id}': previously ${existing.deathYear}, now ${incoming.deathYear}`,
+      lineNum,
+      1,
+      lineText
+    );
+  }
+
+  // Label: incoming overrides only if it's not the default (id-derived)
+  const incomingHasExplicitLabel =
+    incoming.label !== incoming.id && incoming.label !== "";
+  const existingHasExplicitLabel =
+    existing.label !== existing.id && existing.label !== "";
+  const mergedLabel = incomingHasExplicitLabel
+    ? incoming.label
+    : existingHasExplicitLabel
+    ? existing.label
+    : existing.label;
+
+  // Markers: union (preserve set semantics)
+  const mergedMarkers = mergeArrayUnique(existing.markers, incoming.markers);
+
   return {
     ...existing,
-    sex: incoming.sex !== "unknown" ? incoming.sex : existing.sex,
-    status: incoming.status !== "alive" ? incoming.status : existing.status,
+    sex: mergedSex,
+    status: mergedStatus,
+    label: mergedLabel,
     birthYear: incoming.birthYear ?? existing.birthYear,
     deathYear: incoming.deathYear ?? existing.deathYear,
+    age: incoming.age ?? existing.age,
     conditions: incoming.conditions ?? existing.conditions,
+    heritage: incoming.heritage ?? existing.heritage,
+    siblingOf: incoming.siblingOf ?? existing.siblingOf,
+    markers: mergedMarkers,
     properties: {
       ...existing.properties,
       ...incoming.properties,
     },
   };
+}
+
+function mergeArrayUnique<T>(
+  a: T[] | undefined,
+  b: T[] | undefined
+): T[] | undefined {
+  if (!a && !b) return undefined;
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const v of [...(a ?? []), ...(b ?? [])]) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out.length ? out : undefined;
 }

--- a/src/diagrams/genogram/renderer.ts
+++ b/src/diagrams/genogram/renderer.ts
@@ -26,7 +26,14 @@ export function renderGenogram(
   const emotionalLayer = renderEmotionalEdges(emotionalEdges);
   const nodeLayers = renderNodes(genGroups);
   const labelLayer = renderLabels(layout.nodes, config);
-  const edgeLabelLayer = renderEdgeLabels(structuralEdges, config);
+  // Secondary parent-child rels carry their own visible label (e.g. "foster")
+  // already embedded in the relationship; suppress edge labels for them so
+  // the sentinel from layout doesn't render as text.
+  const labelEdges = structuralEdges.filter(
+    (e) => !e.relationship.secondary
+  );
+  const edgeLabelLayer = renderEdgeLabels(labelEdges, config);
+  const siblingOfLayer = renderSiblingOfBrackets(layout, ast);
 
   const nodeCount = layout.nodes.length;
   const genCount = genGroups.size;
@@ -69,7 +76,7 @@ export function renderGenogram(
   chartContent.push(
     group(
       { transform: titleHeight > 0 ? `translate(0, ${titleHeight})` : undefined },
-      [edgeLayers, emotionalLayer, ...nodeLayers, labelLayer, edgeLabelLayer]
+      [edgeLayers, siblingOfLayer, emotionalLayer, ...nodeLayers, labelLayer, edgeLabelLayer]
     )
   );
 
@@ -142,8 +149,15 @@ function buildStyles(config: RenderConfig): string {
 .schematex-genogram-label { font-family: ${config.fontFamily}; font-size: ${config.fontSize}px; text-anchor: middle; fill: ${t.text}; }
 .schematex-genogram-edge { stroke: ${t.neutral}; stroke-width: ${STROKE_WIDTH.normal}; fill: none; stroke-linecap: round; stroke-linejoin: round; }
 .schematex-genogram-edge-cohabiting path { stroke-dasharray: 6,4; }
+.schematex-genogram-edge-cohabiting-ended path { stroke-dasharray: 6,4; }
 .schematex-genogram-edge-divorced .schematex-genogram-divorce-mark { stroke: ${t.neutral}; stroke-width: ${STROKE_WIDTH.normal}; }
 .schematex-genogram-edge-separated .schematex-genogram-separation-mark { stroke: ${t.neutral}; stroke-width: ${STROKE_WIDTH.normal}; }
+.schematex-genogram-edge-cohabiting-ended .schematex-genogram-separation-mark { stroke: ${t.neutral}; stroke-width: ${STROKE_WIDTH.normal}; }
+/* Secondary parent-child link (foster/adopted "current caregiver") — dotted, muted */
+.schematex-genogram-edge-secondary path { stroke: ${t.neutral}; stroke-width: ${STROKE_WIDTH.normal}; stroke-dasharray: 2,4; fill: none; opacity: 0.85; }
+/* Sibling-of bracket (known relative, unknown ancestry) — dashed */
+.schematex-genogram-sibling-of path { stroke: ${t.neutral}; stroke-width: ${STROKE_WIDTH.normal}; stroke-dasharray: 4,3; fill: none; opacity: 0.7; }
+.schematex-genogram-unknown-siblings-mark { fill: ${t.text}; pointer-events: none; }
 .schematex-genogram-deceased-mark { stroke: ${t.deceasedMark}; stroke-width: ${STROKE_WIDTH.normal}; stroke-linecap: round; }
 /* Inline fill on each .schematex-genogram-condition-fill element comes from cond.color. The CSS only sets a default for elements that did not receive an inline fill attribute. */
 .schematex-genogram-condition-fill:not([fill]) { fill: ${t.conditionFill}; }
@@ -301,11 +315,32 @@ function renderEdges(edges: LayoutEdge[]): string {
 
   for (const edge of edges) {
     const relType = edge.relationship.type;
-    const cssClass = `schematex-genogram-edge schematex-genogram-edge-${relType}`;
+    const isSecondary = edge.relationship.secondary === true;
+    const cssClass = isSecondary
+      ? `schematex-genogram-edge schematex-genogram-edge-secondary schematex-genogram-edge-secondary-${relType}`
+      : `schematex-genogram-edge schematex-genogram-edge-${relType}`;
 
     const elements: string[] = [
       el("path", { d: edge.path, class: "schematex-genogram-edge-path" }),
     ];
+
+    // cohabiting-ended: single slash mark like separation
+    if (relType === "cohabiting-ended" && !isSecondary) {
+      const mid = pathMidpoint(edge.path);
+      if (mid) {
+        elements.push(
+          el("line", {
+            x1: mid.x - 4,
+            y1: mid.y - 6,
+            x2: mid.x + 4,
+            y2: mid.y + 6,
+            class: "schematex-genogram-separation-mark",
+            stroke: "#333",
+            "stroke-width": "2",
+          })
+        );
+      }
+    }
 
     // Divorce markers: two short slashes at midpoint
     if (relType === "divorced") {
@@ -424,7 +459,51 @@ function renderNodes(
   return layers;
 }
 
-// ─── Labels ─────────────────────────────────────────────────
+// ─── Sibling-of brackets (known relative, unknown ancestry) ────
+// Drawn directly from AST + layout (not as LayoutEdges) so the synthetic
+// edge type doesn't pollute structural / emotional / secondary classifiers.
+// Cross-generation references are skipped — `siblingOf` is generationally
+// pinned by `assignGenerations`, so a mismatch here means user error or a
+// missing referent, both of which we silently no-op rather than misdraw.
+
+function renderSiblingOfBrackets(
+  layout: LayoutResult,
+  ast?: DiagramAST
+): string {
+  if (!ast) return group({ class: "schematex-genogram-sibling-of-edges" }, []);
+  const elements: string[] = [];
+  const nodeById = new Map(layout.nodes.map((n) => [n.id, n] as const));
+
+  for (const ind of ast.individuals) {
+    if (!ind.siblingOf) continue;
+    const fromNode = nodeById.get(ind.id);
+    const toNode = nodeById.get(ind.siblingOf);
+    if (!fromNode || !toNode) continue;
+    if (fromNode.generation !== toNode.generation) continue;
+
+    const fromCx = fromNode.x + fromNode.width / 2;
+    const fromTopY = fromNode.y;
+    const toCx = toNode.x + toNode.width / 2;
+    const toTopY = toNode.y;
+    const bracketY = Math.min(fromTopY, toTopY) - 12;
+
+    const path =
+      `M ${fromCx} ${fromTopY} L ${fromCx} ${bracketY}` +
+      ` L ${toCx} ${bracketY} L ${toCx} ${toTopY}`;
+    elements.push(
+      group(
+        {
+          class: "schematex-genogram-sibling-of",
+          "data-from": ind.id,
+          "data-to": ind.siblingOf,
+        },
+        [el("path", { d: path })]
+      )
+    );
+  }
+
+  return group({ class: "schematex-genogram-sibling-of-edges" }, elements);
+}
 
 function renderLabels(
   nodes: LayoutNode[],

--- a/src/diagrams/genogram/symbols.ts
+++ b/src/diagrams/genogram/symbols.ts
@@ -70,6 +70,26 @@ export function renderIndividualSymbol(
     );
   }
 
+  // Unknown-siblings glyph: bold "?" centered in the diamond.
+  // Drawn after the base shape so the question mark sits on top.
+  const isUnknownSiblings = individual.markers?.includes("unknown-siblings");
+  if (isUnknownSiblings) {
+    classes.push("schematex-genogram-unknown-siblings");
+    children.push(
+      text(
+        {
+          x: 0,
+          y: 5,
+          class: "schematex-genogram-unknown-siblings-mark",
+          "text-anchor": "middle",
+          "font-size": "16",
+          "font-weight": "bold",
+        },
+        "?"
+      )
+    );
+  }
+
   return group(
     {
       class: classes.join(" "),

--- a/tests/ai/tools.test.ts
+++ b/tests/ai/tools.test.ts
@@ -14,14 +14,16 @@ import {
 } from "../../src/ai";
 
 describe("listDiagrams", () => {
-  it("returns all 20 diagram types", () => {
+  it("returns all 22 diagram types", () => {
     const list = listDiagrams();
-    expect(list.length).toBe(20);
+    expect(list.length).toBe(22);
     const types = list.map((d) => d.type);
     expect(types).toContain("genogram");
     expect(types).toContain("sld");
     expect(types).toContain("fishbone");
     expect(types).toContain("decisiontree");
+    expect(types).toContain("state");
+    expect(types).toContain("pid");
   });
 
   it("each entry has tagline + useWhen + standard", () => {

--- a/tests/genogram/foster-care.test.ts
+++ b/tests/genogram/foster-care.test.ts
@@ -1,0 +1,395 @@
+import { describe, test, expect } from "vitest";
+import { parseGenogram, ParseError } from "../../src/diagrams/genogram/parser";
+import { layoutGenogram } from "../../src/diagrams/genogram/layout";
+import { render } from "../../src/index";
+import type { LayoutConfig } from "../../src/core/types";
+
+const DEFAULT_CONFIG: LayoutConfig = {
+  nodeSpacingX: 60,
+  nodeSpacingY: 120,
+  nodeWidth: 40,
+  nodeHeight: 40,
+};
+
+// ─── Gap 2: Same-id redeclaration must merge, not overwrite ───────
+
+describe("same-id merge (gap 2)", () => {
+  test("redeclaration preserves sex, birth year, label", () => {
+    const ast = parseGenogram(`
+genogram
+  isaias [male, 2020, label: "Isaías"]
+  pablo [male]
+  priscila [female]
+  pablo -- priscila
+    isaias [foster]
+`);
+    const isaias = ast.individuals.find((i) => i.id === "isaias");
+    expect(isaias?.sex).toBe("male");
+    expect(isaias?.birthYear).toBe(2020);
+    expect(isaias?.label).toBe("Isaías");
+  });
+
+  test("redeclaration preserves index marker", () => {
+    const ast = parseGenogram(`
+genogram
+  child [male, 2018, index]
+  fp1 [male]
+  fp2 [female]
+  fp1 -- fp2
+    child [foster]
+`);
+    const child = ast.individuals.find((i) => i.id === "child");
+    expect(child?.markers).toContain("index-person");
+    expect(child?.sex).toBe("male");
+  });
+
+  test("conflicting non-default sex throws", () => {
+    expect(() =>
+      parseGenogram(`
+genogram
+  x [male, 2010]
+  y [female]
+  z [male]
+  z -- y
+    x [female]
+`)
+    ).toThrow(ParseError);
+  });
+
+  test("inline-on-couple-right merges with prior declaration", () => {
+    const ast = parseGenogram(`
+genogram
+  mary [female, 1955]
+  john [male, 1950]
+  john -- mary [female, 1955]
+`);
+    expect(ast.individuals).toHaveLength(2);
+    const mary = ast.individuals.find((i) => i.id === "mary");
+    expect(mary?.sex).toBe("female");
+    expect(mary?.birthYear).toBe(1955);
+  });
+});
+
+// ─── Gap 4: cohabiting-ended + cohabiting/separated aliases ───────
+
+describe("cohabiting-ended operator (gap 4)", () => {
+  test("~/~ parses to cohabiting-ended", () => {
+    const ast = parseGenogram(`
+genogram
+  v [male, 1985]
+  m [female, 1987]
+  v ~/~ m
+`);
+    const r = ast.relationships.find((r) => r.type === "cohabiting-ended");
+    expect(r).toBeDefined();
+    expect(r?.from).toBe("v");
+    expect(r?.to).toBe("m");
+  });
+
+  test("-// is alias for separated", () => {
+    const ast = parseGenogram(`
+genogram
+  a [male]
+  b [female]
+  a -// b
+`);
+    expect(ast.relationships.find((r) => r.type === "separated")).toBeDefined();
+  });
+
+  test("cohabiting-ended couple still produces children rels", () => {
+    const ast = parseGenogram(`
+genogram
+  v [male, 1985]
+  m [female, 1987]
+  v ~/~ m
+    kid [male, 2018]
+`);
+    const pc = ast.relationships.find(
+      (r) => r.type === "parent-child" && r.to === "kid"
+    );
+    expect(pc).toBeDefined();
+    expect(pc?.from).toContain("v");
+  });
+});
+
+// ─── Gap 5: ? placeholder + [unknown-siblings] marker ─────────────
+
+describe("unknown-siblings placeholder (gap 5)", () => {
+  test("? as child id auto-generates synthetic placeholder", () => {
+    const ast = parseGenogram(`
+genogram
+  dad [male]
+  mom [female]
+  dad -- mom
+    ?
+    real_kid [male, 2010]
+`);
+    const placeholder = ast.individuals.find((i) =>
+      i.markers?.includes("unknown-siblings")
+    );
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.sex).toBe("unknown");
+    // Should have a parent-child rel pointing to it
+    const pc = ast.relationships.find(
+      (r) => r.type === "parent-child" && r.to === placeholder?.id
+    );
+    expect(pc).toBeDefined();
+  });
+
+  test("multiple ? placeholders get unique ids", () => {
+    const ast = parseGenogram(`
+genogram
+  dad [male]
+  mom [female]
+  dad -- mom
+    ?
+    ?
+`);
+    const placeholders = ast.individuals.filter((i) =>
+      i.markers?.includes("unknown-siblings")
+    );
+    expect(placeholders).toHaveLength(2);
+    expect(placeholders[0].id).not.toBe(placeholders[1].id);
+  });
+
+  test("explicit [unknown-siblings] marker on regular id works", () => {
+    const ast = parseGenogram(`
+genogram
+  dad [male]
+  mom [female]
+  dad -- mom
+    sibs [unknown-siblings]
+`);
+    const sibs = ast.individuals.find((i) => i.id === "sibs");
+    expect(sibs?.markers).toContain("unknown-siblings");
+  });
+
+  test("renders ? glyph inside the placeholder shape", () => {
+    const svg = render(`genogram
+  dad [male]
+  mom [female]
+  dad -- mom
+    ?`);
+    expect(svg).toContain("schematex-genogram-unknown-siblings");
+  });
+});
+
+// ─── Gap 3: sibling-of declaration ────────────────────────────────
+
+describe("sibling-of declaration (gap 3)", () => {
+  test("sibling-of populates Individual.siblingOf field", () => {
+    const ast = parseGenogram(`
+genogram
+  monica [female, 1990]
+  uncle [male, sibling-of: monica]
+`);
+    const uncle = ast.individuals.find((i) => i.id === "uncle");
+    expect(uncle?.siblingOf).toBe("monica");
+  });
+
+  test("siblingOf shares generation with referenced sibling", () => {
+    const ast = parseGenogram(`
+genogram
+  gp1 [male]
+  gp2 [female]
+  gp1 -- gp2
+    monica [female, 1990]
+  uncle [male, sibling-of: monica]
+`);
+    const layout = layoutGenogram(ast, DEFAULT_CONFIG);
+    const monica = layout.nodes.find((n) => n.id === "monica");
+    const uncle = layout.nodes.find((n) => n.id === "uncle");
+    expect(monica?.generation).toBe(uncle?.generation);
+  });
+
+  test("renderer emits sibling-of dashed bracket", () => {
+    const svg = render(`genogram
+  monica [female, 1990]
+  uncle [male, sibling-of: monica]`);
+    expect(svg).toContain("schematex-genogram-sibling-of");
+  });
+});
+
+// ─── Gap 1: dual-parent rendering ─────────────────────────────────
+
+describe("dual-parent (foster + biological) (gap 1)", () => {
+  test("redeclared child under second couple emits secondary rel", () => {
+    const ast = parseGenogram(`
+genogram
+  bp1 [male]
+  bp2 [female]
+  bp1 -- bp2
+    child [male, 2018]
+  fp1 [male]
+  fp2 [female]
+  fp1 -- fp2
+    child [foster]
+`);
+    const allChildRels = ast.relationships.filter(
+      (r) =>
+        (r.type === "parent-child" || r.type === "foster" || r.type === "adopted") &&
+        r.to === "child"
+    );
+    expect(allChildRels).toHaveLength(2);
+    const primary = allChildRels.filter((r) => !r.secondary);
+    const secondary = allChildRels.filter((r) => r.secondary === true);
+    expect(primary).toHaveLength(1);
+    expect(secondary).toHaveLength(1);
+    expect(primary[0].from).toBe("bp1+bp2");
+    expect(secondary[0].from).toBe("fp1+fp2");
+    expect(secondary[0].type).toBe("foster");
+  });
+
+  test("layout positions child under bio couple, not foster couple", () => {
+    const ast = parseGenogram(`
+genogram
+  bp1 [male, 1985]
+  bp2 [female, 1987]
+  bp1 -- bp2
+    child [male, 2018]
+  fp1 [male, 1970]
+  fp2 [female, 1972]
+  fp1 -- fp2
+    fk1 [male, 2005]
+    child [foster]
+`);
+    const layout = layoutGenogram(ast, DEFAULT_CONFIG);
+    const bp1 = layout.nodes.find((n) => n.id === "bp1")!;
+    const bp2 = layout.nodes.find((n) => n.id === "bp2")!;
+    const fp1 = layout.nodes.find((n) => n.id === "fp1")!;
+    const fp2 = layout.nodes.find((n) => n.id === "fp2")!;
+    const child = layout.nodes.find((n) => n.id === "child")!;
+    const fk1 = layout.nodes.find((n) => n.id === "fk1")!;
+
+    const bioMid = (bp1.x + bp2.x) / 2;
+    const fosterMid = (fp1.x + fp2.x) / 2;
+
+    expect(Math.abs(child.x + child.width / 2 - bioMid)).toBeLessThan(40);
+    expect(Math.abs(child.x + child.width / 2 - fosterMid)).toBeGreaterThan(40);
+    // foster couple's only structural child is fk1
+    expect(Math.abs(fk1.x + fk1.width / 2 - fosterMid)).toBeLessThan(40);
+  });
+
+  test("declaration order is irrelevant — bio always wins as primary", () => {
+    // Reversed: foster declared FIRST, bio declared SECOND. Engine must
+    // still treat bio as primary and demote foster to secondary.
+    const ast = parseGenogram(`
+genogram
+  fp1 [male]
+  fp2 [female]
+  fp1 -- fp2
+    child [male, foster]
+  bp1 [male]
+  bp2 [female]
+  bp1 -- bp2
+    child
+`);
+    const allChildRels = ast.relationships.filter(
+      (r) =>
+        (r.type === "parent-child" || r.type === "foster") && r.to === "child"
+    );
+    expect(allChildRels).toHaveLength(2);
+    const primary = allChildRels.find((r) => !r.secondary);
+    const secondary = allChildRels.find((r) => r.secondary === true);
+    expect(primary?.type).toBe("parent-child");
+    expect(primary?.from).toBe("bp1+bp2");
+    expect(secondary?.type).toBe("foster");
+    expect(secondary?.from).toBe("fp1+fp2");
+  });
+
+  test("renderer emits secondary parent-child edge as dotted line", () => {
+    const svg = render(`genogram
+  bp1 [male]
+  bp2 [female]
+  bp1 -- bp2
+    child [male, 2018]
+  fp1 [male]
+  fp2 [female]
+  fp1 -- fp2
+    child [foster]`);
+    expect(svg).toContain("schematex-genogram-edge-secondary");
+  });
+});
+
+// ─── Integration: full Isaías foster-care case ────────────────────
+
+describe("Isaías full foster-care case (integration)", () => {
+  const ISAIAS_DSL = `genogram "Familia Isaías"
+  victor [male, label: "Víctor Seguel"]
+  monica [female, label: "Mónica Barrientos"]
+  victor ~/~ monica
+    ?
+    isaias [male, 2020, age: 6, label: "Isaías", index]
+  pablo_sr [male, label: "Don Pablo"]
+  priscila [female, label: "Doña Priscila"]
+  pablo_sr -- priscila
+    pablo_jr [male]
+    alanis [female]
+    isaias [foster]
+  tio_materno [male, label: "Tío materno", sibling-of: monica]
+  victor -physical-abuse-> isaias
+  monica -physical-abuse-> isaias
+  tio_materno -nevermet- isaias`;
+
+  test("AST satisfies the 6 success criteria", () => {
+    const ast = parseGenogram(ISAIAS_DSL);
+
+    // 1. Isaías is bio son of Víctor + Mónica
+    const bio = ast.relationships.find(
+      (r) => r.to === "isaias" && r.from === "victor+monica" && !r.secondary
+    );
+    expect(bio).toBeDefined();
+    expect(bio?.type).toBe("parent-child");
+
+    // 2. Currently fostered with Don Pablo + Doña Priscila
+    const foster = ast.relationships.find(
+      (r) => r.to === "isaias" && r.from === "pablo_sr+priscila" && r.secondary
+    );
+    expect(foster).toBeDefined();
+    expect(foster?.type).toBe("foster");
+
+    // 3. Removed from bio parents due to physical abuse from both
+    const abuses = ast.relationships.filter((r) => r.type === "physical-abuse" && r.to === "isaias");
+    expect(abuses).toHaveLength(2);
+    expect(abuses.map((a) => a.from).sort()).toEqual(["monica", "victor"]);
+
+    // 4. Tío materno is Mónica's brother
+    const tio = ast.individuals.find((i) => i.id === "tio_materno");
+    expect(tio?.siblingOf).toBe("monica");
+    const nevermet = ast.relationships.find((r) => r.type === "nevermet");
+    expect(nevermet).toBeDefined();
+
+    // 5. Unknown-count siblings still with bio parents
+    const unknownSib = ast.individuals.find((i) =>
+      i.markers?.includes("unknown-siblings")
+    );
+    expect(unknownSib).toBeDefined();
+    const sibPC = ast.relationships.find(
+      (r) => r.to === unknownSib?.id && r.from === "victor+monica"
+    );
+    expect(sibPC).toBeDefined();
+
+    // 6. Isaías is the index person
+    const isaias = ast.individuals.find((i) => i.id === "isaias");
+    expect(isaias?.markers).toContain("index-person");
+    expect(isaias?.sex).toBe("male");
+    expect(isaias?.birthYear).toBe(2020);
+    expect(isaias?.label).toBe("Isaías");
+
+    // bio couple is cohabiting-ended (the LATAM "quiebre")
+    const bioCouple = ast.relationships.find(
+      (r) => r.from === "victor" && r.to === "monica"
+    );
+    expect(bioCouple?.type).toBe("cohabiting-ended");
+  });
+
+  test("renders without error and produces an SVG with expected markers", () => {
+    const svg = render(ISAIAS_DSL);
+    expect(svg).toMatch(/^<svg/);
+    expect(svg).toContain("Familia Isaías");
+    expect(svg).toContain("schematex-genogram-edge-secondary");
+    expect(svg).toContain("schematex-genogram-sibling-of");
+    expect(svg).toContain("schematex-genogram-unknown-siblings");
+    expect(svg).toContain("schematex-genogram-index-person");
+  });
+});

--- a/website/content/docs/genogram.mdx
+++ b/website/content/docs/genogram.mdx
@@ -64,9 +64,11 @@ An individual line is `id [attr1, attr2, …]`. Attributes are comma-separated, 
 | Birth year | 4-digit number, e.g. `1980` | First 4-digit token = birth year |
 | Death year | 4-digit number after birth, e.g. `1980, 2055` | Second 4-digit token = death year |
 | `index` | flag | Concentric shape = identified patient |
+| `unknown-siblings` | flag | Diamond with `?` — placeholder for ≥1 siblings of unknown count |
 | `age:N` | e.g. `age:42` | Age shown inside shape |
 | `death:YYYY` | e.g. `death:2020` | Explicit death year |
 | `label:"…"` | e.g. `label:"Dr. Smith"` | Display label override |
+| `sibling-of:<id>` | e.g. `sibling-of:monica` | Pins same generation as the referenced sibling, draws a dashed bracket — for known relatives with unknown ancestry. |
 | `conditions:…` | see §5 | Medical/psychological conditions |
 | `key:value` | any custom | Stored as metadata |
 
@@ -105,11 +107,13 @@ The parser tries these in order. The first one that matches wins — so `-x-` be
 | Operator | Type | Example | Meaning |
 |---|---|---|---|
 | `-x-` | divorced | `a -x- b` | Divorce |
-| `-/-` | separated | `a -/- b` | Separation |
+| `-/-` | separated | `a -/- b` | Separation (married) |
+| `-//` | separated | `a -// b` | Separation (alias for `-/-`) |
 | `-o-` | engaged | `a -o- b` | Engagement |
 | `==` | consanguineous | `a == b` | Blood-related couple |
 | `--` | married | `a -- b` | Marriage |
-| `~` | cohabiting | `a ~ b` | Cohabiting / LTR |
+| `~` | cohabiting | `a ~ b` | Cohabiting / LTR (current) |
+| `~/~` | cohabiting-ended | `a ~/~ b` | Cohabitation has ended (never-married). Common in LATAM child-protection caseloads where biological parents lived together unmarried and the relationship has since broken — distinct from `-x-` divorce (no marriage) and `-/-` separation (still married). |
 
 A trailing quoted string becomes the relationship label (`a -- b "m. 2005"`).
 
@@ -141,8 +145,46 @@ Indentation under a couple line = "these are the children of this couple." Any i
 |---|---|
 | `adopted` | Adoption line style |
 | `foster` | Foster relationship |
+| `guardian` | Guardianship by a non-parent relative (e.g. grandparent custody). Same primitive as `foster` — drawn as a secondary "current caregiver" link when biological parents are also declared. |
 | `twin-identical` | Grouped with other `twin-identical` children of the same couple |
 | `twin-fraternal` | Grouped with other `twin-fraternal` children |
+| `unknown-siblings` | Single diamond with `?` glyph — "≥1 siblings, count and identities unknown" (pedigree convention). |
+
+### 4.3.1 Dual-parent families (foster, adoption, guardianship)
+
+Children placed with a non-biological caregiver while biological parents are still part of the case can be declared under both couples. **Declare the child with full attributes the first time** (under the biological couple), then **redeclare with just `[foster]` / `[adopted]` / `[guardian]`** under the current caregiver. The first declaration wins layout; the second is drawn as a secondary dotted "current caregiver" link that does not pull the child away from their biological position.
+
+<Playground initial={`genogram "Foster placement"
+  bp1 [male, label: "Bio dad"]
+  bp2 [female, label: "Bio mom"]
+  bp1 ~/~ bp2
+    child [male, 2018, index]
+  fp1 [male, label: "Foster dad"]
+  fp2 [female, label: "Foster mom"]
+  fp1 -- fp2
+    own [male, 2010]
+    child [foster]`} />
+
+The same primitive serves adoption (closed/open), foster placement, and guardianship by a relative — only the keyword differs. Re-declaration **merges** non-conflicting attributes (sex, birth year, label, `index` marker) into the original; declaring a conflicting `male` vs `female` raises a parse error rather than silently overwriting.
+
+### 4.3.2 Unknown-count siblings
+
+When a case file mentions "the child has siblings" without naming them, use either the `?` shorthand on its own line, or `[unknown-siblings]` on a regular id. Both render as a single diamond with a "?" glyph — the standard pedigree marker for "one or more siblings, identities unknown."
+
+<Playground initial={`genogram
+  dad [male]
+  mom [female]
+  dad -- mom
+    ?
+    known_kid [male, 2018]`} />
+
+### 4.3.3 Sibling-of (known relative, unknown ancestry)
+
+To express "X is a sibling of Y" without inventing parents, use the `sibling-of: <id>` property. The renderer pins X to Y's generation and draws a dashed bracket above the two — the standard pedigree convention for a known relative whose ancestry is not part of the case.
+
+<Playground initial={`genogram
+  monica [female, 1990]
+  uncle [male, label: "Tío materno", sibling-of: monica]`} />
 
 ### 4.4 Emotional relationships
 
@@ -229,7 +271,9 @@ genogram "Smith Family"
 **Reserved at line start:** `genogram` (header keyword).
 
 **Reserved operator tokens** inside a line — avoid using these sequences in IDs:
-`--`, `~`, `==`, `-x-`, `-/-`, `-o-`, and any `-<type>-` / `-<type>->` matching an emotional-relationship type.
+`--`, `~`, `~/~`, `==`, `-x-`, `-/-`, `-//`, `-o-`, and any `-<type>-` / `-<type>->` matching an emotional-relationship type.
+
+**Reserved id `?`** — bare `?` on a child line auto-generates a synthetic placeholder with the `unknown-siblings` marker. Do not use `?` as a real id.
 
 **Strings with spaces** must be double-quoted: titles, labels, `label:"…"`. Single quotes and backticks are not recognized.
 
@@ -249,6 +293,8 @@ Real parser errors, what triggers them, and how to fix.
 | `conditions: diabetes + cancer` (no parens) | `Invalid condition format 'diabetes'` | Add fill: `conditions: diabetes(half-left) + cancer(half-right)` |
 | `[triplet-identical]` | `Unknown property 'triplet-identical'` | Triplets not yet parseable (§13 Roadmap) |
 | `dad -- mom # first marriage` | Trailing inline `#` comment is treated as part of the label / errors | Move the comment to its own line |
+| Same id declared twice with different sex (`x [male]` then `x [female]`) | `Conflicting sex for 'x': previously 'male', now 'female'` | Pick one or rename one of the ids |
+| `child [foster]` redeclared but biological parents never declared | `child` becomes the foster couple's regular child (no secondary link drawn) | This is intentional — secondary links require an existing primary parent-child rel from a prior declaration |
 
 ---
 
@@ -264,12 +310,13 @@ individual     = INDENT id ( "[" attrs "]" )? NEWLINE
 couple-block   = INDENT id WS coupleOp WS right-side ( WS quoted-string )? NEWLINE
                    ( deeper-indent child )*
 child          = INDENT id ( "[" attrs "]" )? NEWLINE
+               | INDENT "?" NEWLINE                              // unknown-count sibling shorthand
 right-side     = id ( "[" attrs "]" )?
 
 emotional      = INDENT id WS "-" type "-"  id ( WS quoted-string )? NEWLINE
                | INDENT id WS "-" type "->" id ( WS quoted-string )? NEWLINE
 
-coupleOp       = "-x-" | "-/-" | "-o-" | "==" | "--" | "~"
+coupleOp       = "~/~" | "-//" | "-x-" | "-/-" | "-o-" | "==" | "--" | "~"
 type           = "harmony" | "close" | "bestfriends" | "love" | "inlove"
                | "friendship" | "hostile" | "conflict" | "enmity"
                | "distant-hostile" | "cutoff" | "close-hostile" | "fused"
@@ -283,12 +330,14 @@ id             = [a-zA-Z] [a-zA-Z0-9_-]*
 attrs          = attr ("," attr)*
 attr           = "male" | "female" | "unknown" | "other"
                | "deceased" | "stillborn" | "miscarriage" | "abortion"
-               | "adopted" | "foster" | "twin-identical" | "twin-fraternal"
-               | "index"
+               | "adopted" | "foster" | "guardian"
+               | "twin-identical" | "twin-fraternal"
+               | "index" | "unknown-siblings"
                | digit digit digit digit                         // year
                | "age" ":" digits
                | "death" ":" digit digit digit digit
                | "label" ":" quoted-string
+               | "sibling-of" ":" id
                | "conditions" ":" condition ("+" condition)*
                | key ":" value                                    // custom
 condition      = name "(" fill ("," "#" hex)? ")"
@@ -334,6 +383,7 @@ Ready-to-use scenarios from the examples gallery:
   'genogram-medical-history',
   'genogram-brca-cancer',
   'genogram-potter-family',
+  'genogram-foster-care',
 ]} />
 
 ---
@@ -348,5 +398,6 @@ Ready-to-use scenarios from the examples gallery:
 - **Category shorthand for conditions** — `conditions: cardiovascular + depression` without `(fill)`, auto-assigning quadrants and default colors.
 - **Domestic partnership operator** — `~dp~` / explicit DP label.
 - **Heritage annotations** — cultural-genogram heritage identifiers on individuals.
+- **Household boundary boxes** — group nodes that share a roof (foster placement, multi-generational household).
 
 Track in the GitHub issues if you need any of these sooner.

--- a/website/content/examples/genogram-foster-care.mdx
+++ b/website/content/examples/genogram-foster-care.mdx
@@ -1,0 +1,57 @@
+---
+title: Foster care / child protection
+description: Foster-care genogram for a real LATAM child-protection case — biological parents (cohabitation ended), abuse, current foster placement (dotted secondary link), unknown-count siblings, and a maternal uncle as known-relative-with-unknown-ancestry.
+diagram: genogram
+standard: McGoldrick 2020 + Bennett 2022 (adopted-out / dual-parent convention)
+industry: [social-work, child-protection, legal]
+persona: For the foster-care social worker
+complexity: 4
+tags: [foster-care, dual-parent, abuse, sibling-of, unknown-siblings, latam]
+featured: true
+relatedLink:
+  label: Genogram syntax
+  href: /docs/genogram
+status: published
+dsl: |
+  genogram "Familia Isaías"
+    victor [male, label: "Víctor Seguel"]
+    monica [female, label: "Mónica Barrientos"]
+    victor ~/~ monica
+      ?
+      isaias [male, 2020, age: 6, label: "Isaías", index]
+    pablo_sr [male, label: "Don Pablo"]
+    priscila [female, label: "Doña Priscila"]
+    pablo_sr -- priscila
+      pablo_jr [male, label: "Pablo (jr)"]
+      alanis [female, label: "Alanis"]
+      isaias [foster]
+    tio_materno [male, label: "Tío materno", sibling-of: monica]
+    victor -physical-abuse-> isaias
+    monica -physical-abuse-> isaias
+    tio_materno -nevermet- isaias
+---
+
+## Scenario
+
+A foster-care social worker in Chile is preparing the case file for Isaías, a 6-year-old boy removed from his biological parents (Víctor and Mónica) due to physical abuse from both. He currently lives with foster parents Don Pablo and Doña Priscila, who have two biological children of their own. The case file mentions Isaías has siblings whose names and ages are unknown, and a maternal uncle who is a potential reunification resource but currently has no contact.
+
+A judge or psychologist receiving this diagram must, at a glance, correctly conclude:
+
+1. Isaías is the **biological son** of Víctor and Mónica — solid parent-child line down from the bio couple.
+2. He **currently lives** with Don Pablo and Doña Priscila as a foster child — *secondary dotted link* from the foster couple, drawn without pulling Isaías away from his bio-parent position.
+3. He was **removed due to physical abuse** from both bio parents — directional red zigzag arrows.
+4. The **maternal uncle** is Mónica's brother (`sibling-of: monica`) with **no current relationship** to Isaías — dashed bracket between Mónica and Tío + `nevermet` line.
+5. Isaías has **unknown-count siblings** still with the bio parents — single `?` diamond placeholder.
+6. **Isaías is the index person** — concentric outer border highlight.
+
+## Annotation key
+
+- `~/~` — cohabitation ended (never-married); standard for LATAM caseloads where bio parents lived together unmarried and the relationship has broken. Distinct from `-x-` divorce (no marriage) and `-/-` separation (still married).
+- Re-declaring `isaias [foster]` under the foster couple after declaring him under the bio couple → engine treats the second declaration as a **secondary "current caregiver" link** (dotted), preserving all attributes from the first declaration.
+- `?` on a child line → a single diamond with `?` glyph meaning "≥1 siblings, count and identities unknown" (standard pedigree convention).
+- `[sibling-of: monica]` → places Tío materno on Mónica's generation with a dashed bracket between them, **without** synthesizing phantom maternal grandparents.
+- `-physical-abuse->` → directional red arrow; the `>` indicates the perpetrator (left side) and victim (right side).
+
+## Why this matters
+
+A genogram engine that quietly rendered Isaías as a third biological child of Don Pablo + Doña Priscila — or dropped his sex and label when the `[foster]` redeclaration overwrote the original — would invert the case story. This example exercises every fix from the 2026-04 foster-care brief: dual-parent rendering, same-id merge, sibling-of, cohabiting-ended, and the unknown-siblings placeholder.

--- a/website/content/examples/genogram-foster-care.mdx
+++ b/website/content/examples/genogram-foster-care.mdx
@@ -5,7 +5,7 @@ diagram: genogram
 standard: McGoldrick 2020 + Bennett 2022 (adopted-out / dual-parent convention)
 industry: [social-work, child-protection, legal]
 persona: For the foster-care social worker
-complexity: 4
+complexity: 3
 tags: [foster-care, dual-parent, abuse, sibling-of, unknown-siblings, latam]
 featured: true
 relatedLink:


### PR DESCRIPTION
## Summary

Closes the 5 P0 capability gaps from the foster-care brief — surfaced by a real Chilean child-protection caseworker (Fundación Talita Kum) whose 5 attempts produced SVGs that told the *opposite* of the case story.

- **Gap 1 — Dual-parent rendering.** New `Relationship.secondary?: boolean` flag. Re-declaring a child under a foster/adopted/guardian couple keeps the bio couple as the structural anchor and draws the second link as a dotted "current caregiver" line. Single primitive serves foster + adoption + guardianship — order-insensitive (bio is preferred regardless of declaration order).
- **Gap 2 — Same-id merge.** `mergeIndividual` now preserves sex / birthYear / label / markers across declarations. Conflicting non-default sex / status / year throws `ParseError` instead of silently dropping data.
- **Gap 3 — `sibling-of: <id>` property.** Pins same generation, draws dashed bracket. Standard pedigree convention for "known relative, unknown ancestry" — no phantom parents synthesized.
- **Gap 4 — `~/~` operator → `cohabiting-ended`.** New rel type for LATAM never-married cohabitation that has ended ("quiebre"). Distinct from `-x-` (no marriage) and `-/-` (still married). `-//` accepted as alias for `-/-`.
- **Gap 5 — `?` placeholder + `[unknown-siblings]` marker.** Diamond with "?" glyph for ≥1 siblings of unknown count.

**Bonus bug fix found in review:** the pre-existing `childSpecialProps` global map contaminated rel types across declarations (a child declared once with `[foster]` and again as plain bio caused the bio rel to be typed `foster`). Now derived per-line.

**Schema additions are purely additive** (no breaking changes):
- `Relationship.secondary?: boolean`
- `Individual.siblingOf?: string`
- `RelationshipType += "cohabiting-ended"`
- `IndividualMarker += "unknown-siblings"`

Coverage: 20 new tests in [tests/genogram/foster-care.test.ts](https://github.com/SchemaTex/SchemaTex/blob/feat/genogram-foster-care/tests/genogram/foster-care.test.ts) cover each gap individually + the full Isaías integration case asserting all 6 success criteria from the brief. **541/541 repo tests pass**; existing 13 reference fixtures untouched.

## Visual proof — Isaías rendered SVG

The full Isaías case (preview/genogram.html → "Foster Care · Isaías"):

> A stranger reading the rendered diagram correctly concludes:
> 1. Isaías is the bio son of Víctor + Mónica (under their drop-line)
> 2. Currently fostered with Don Pablo + Doña Priscila (long dotted secondary link)
> 3. Removed due to physical abuse from both bio parents (red curved arrows)
> 4. Tío materno is Mónica's brother, no contact with Isaías (dashed bracket + grey nevermet line)
> 5. Has unknown-count siblings still with bio parents (`?` diamond)
> 6. Isaías is the index person (orange concentric border)

Static SVG saved at [examples/genogram/foster-care-isaias.svg](https://github.com/SchemaTex/SchemaTex/blob/feat/genogram-foster-care/examples/genogram/foster-care-isaias.svg).

## Docs updated

- `docs/reference/01-GENOGRAM-STANDARD.md` — new §3.4.1 (dual-parent), §3.4.2 (sibling-of), §3.4.3 (unknown-siblings), Test Case 14 (foster care), updated EBNF + couple-op tables
- `website/content/docs/genogram.mdx` — new §4.3.1/§4.3.2/§4.3.3 with `<Playground>` snippets, attribute table + EBNF + reserved tokens updated
- `website/content/examples/genogram-foster-care.mdx` — new gallery entry

## Anti-pattern checklist (per brief)

- ✅ Single `secondary` flag handles foster + adopted + guardian — no per-type layout branches
- ✅ Zero new runtime deps
- ✅ No existing fixtures broken (all 13 standard cases still pass)
- ✅ Standard-compliance preserved (McGoldrick 2020 / Bennett 2022 conventions)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 541/541 pass
- [x] `npm run build` — clean
- [x] Browser verification — DOM-asserted all 6 success criteria render correctly in `preview/genogram.html`
- [x] Visual inspection of rendered SVG against brief's success criteria
- [x] Order-insensitivity regression test (foster-first / bio-second still resolves bio as primary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
