### PR TITLE
feat(v0.3.4): background-agnostic SVG output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.4] — 2026-05-02
+
+### Changed — background handling
+
+SVG output is now background-agnostic. The diagram inherits whatever color
+its host element provides, so the same SVG embeds cleanly in light pages,
+dark canvases, and print PDFs without `!important` overrides.
+
+- **Removed `background:` from inline `<style>` blocks** across all 19
+  diagram renderers (genogram, ecomap, pedigree, phylo, sociogram, flowchart,
+  circuit, logic, timing, ladder, sld, blockdiagram, entity, decisiontree,
+  orgchart, venn, matrix, fishbone, timeline). Stroke / fill / text colors
+  are unchanged — only the canvas fill is no longer baked in.
+- **PNG export (`svgToPngBlob`) defaults to transparent.** Previously
+  defaulted to `'white'`. Pass `{ background: 'white' }` (or any color) to
+  keep the old behavior.
+- **Dark theme requires a dark host wrapper.** When using `theme: "dark"`,
+  wrap the SVG in a container with a dark background. README has an example.
+
+No DSL changes. No layout changes. All 569 tests pass.
+
+---
+
 ## [0.3.3] — 2026-05-01
 
 ### Fixed — production-audit findings (4 items)

--- a/README.md
+++ b/README.md
@@ -534,11 +534,30 @@ import { SchematexDiagram } from 'schematex/react';
 
 // Export (browser Canvas)
 import { svgToPngBlob, downloadBlob, printSvgAsPdf } from 'schematex/export';
-const blob = await svgToPngBlob(svg, { scale: 2 });
+const blob = await svgToPngBlob(svg, { scale: 2 });           // transparent PNG
+const opaque = await svgToPngBlob(svg, { background: 'white' }); // opt-in fill
 downloadBlob(blob, 'diagram.png');
 ```
 
 See the [API reference →](https://schematex.dev/docs/api).
+
+### Backgrounds & dark mode
+
+Schematex SVGs are **background-agnostic by default** — no fill is baked into the
+output, so a diagram inherits whatever color its host element provides. This
+keeps the same SVG embeddable in light pages, dark canvases, or print PDFs.
+
+When using `theme: "dark"`, the diagram's strokes and text are designed for a
+dark surface — wrap the SVG in a container with a dark background, e.g.:
+
+```html
+<div style="background: #0f172a; padding: 16px;">
+  <!-- schematex SVG with theme: "dark" -->
+</div>
+```
+
+PNG export (`svgToPngBlob`) defaults to a transparent background. Pass
+`background: 'white'` (or any color) to bake one in.
 
 ## Ecosystem
 

--- a/examples/genogram/childless-couple.svg
+++ b/examples/genogram/childless-couple.svg
@@ -20,7 +20,6 @@
   --schematex-stroke-thin: 1;
   --schematex-stroke-normal: 2;
   --schematex-stroke-thick: 3;
-  background: #ffffff;
 }
 .schematex-genogram-shape { fill: #ffffff; stroke: #334155; stroke-width: 2; stroke-linejoin: round; }
 .schematex-genogram-male .schematex-genogram-shape { fill: #dbeafe; }

--- a/examples/genogram/divorce-remarriage.svg
+++ b/examples/genogram/divorce-remarriage.svg
@@ -20,7 +20,6 @@
   --schematex-stroke-thin: 1;
   --schematex-stroke-normal: 2;
   --schematex-stroke-thick: 3;
-  background: #ffffff;
 }
 .schematex-genogram-shape { fill: #ffffff; stroke: #334155; stroke-width: 2; stroke-linejoin: round; }
 .schematex-genogram-male .schematex-genogram-shape { fill: #dbeafe; }

--- a/examples/genogram/medical-conditions.svg
+++ b/examples/genogram/medical-conditions.svg
@@ -22,7 +22,6 @@
   --schematex-stroke-thin: 1;
   --schematex-stroke-normal: 2;
   --schematex-stroke-thick: 3;
-  background: #ffffff;
 }
 .schematex-genogram-shape { fill: #ffffff; stroke: #334155; stroke-width: 2; stroke-linejoin: round; }
 .schematex-genogram-male .schematex-genogram-shape { fill: #dbeafe; }

--- a/examples/genogram/nuclear-family.svg
+++ b/examples/genogram/nuclear-family.svg
@@ -20,7 +20,6 @@
   --schematex-stroke-thin: 1;
   --schematex-stroke-normal: 2;
   --schematex-stroke-thick: 3;
-  background: #ffffff;
 }
 .schematex-genogram-shape { fill: #ffffff; stroke: #334155; stroke-width: 2; stroke-linejoin: round; }
 .schematex-genogram-male .schematex-genogram-shape { fill: #dbeafe; }

--- a/examples/genogram/single-individual.svg
+++ b/examples/genogram/single-individual.svg
@@ -20,7 +20,6 @@
   --schematex-stroke-thin: 1;
   --schematex-stroke-normal: 2;
   --schematex-stroke-thick: 3;
-  background: #ffffff;
 }
 .schematex-genogram-shape { fill: #ffffff; stroke: #334155; stroke-width: 2; stroke-linejoin: round; }
 .schematex-genogram-male .schematex-genogram-shape { fill: #dbeafe; }

--- a/examples/genogram/three-generation.svg
+++ b/examples/genogram/three-generation.svg
@@ -20,7 +20,6 @@
   --schematex-stroke-thin: 1;
   --schematex-stroke-normal: 2;
   --schematex-stroke-thick: 3;
-  background: #ffffff;
 }
 .schematex-genogram-shape { fill: #ffffff; stroke: #334155; stroke-width: 2; stroke-linejoin: round; }
 .schematex-genogram-male .schematex-genogram-shape { fill: #dbeafe; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 22 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, P&ID, UML state diagram, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/blockdiagram/renderer.ts
+++ b/src/diagrams/blockdiagram/renderer.ts
@@ -30,7 +30,7 @@ export function renderBlockDiagram(ast: BlockAST): string {
   const height = layout.height + titleOffset;
 
   const css = `
-.schematex-bd { background: #fff; font-family: system-ui, -apple-system, sans-serif; }
+.schematex-bd { font-family: system-ui, -apple-system, sans-serif; }
 .schematex-bd-block { stroke: #333; stroke-width: 2; }
 .schematex-bd-tf { font: italic 14px serif; fill: #111; }
 .schematex-bd-block-name { font: 10px sans-serif; fill: #666; }

--- a/src/diagrams/circuit/renderer.ts
+++ b/src/diagrams/circuit/renderer.ts
@@ -136,7 +136,7 @@ export function renderCircuit(ast: CircuitAST, config?: RenderConfig): string {
   const items = layout.items.map((it) => renderItem(it, offsetX, offsetY)).join("");
 
   const css = `
-.schematex-circuit { background: ${t.bg}; font-family: system-ui, -apple-system, sans-serif; }
+.schematex-circuit { font-family: system-ui, -apple-system, sans-serif; }
 .schematex-circuit-body { stroke: ${t.stroke}; stroke-width: 1.75; fill: none; stroke-linejoin: round; stroke-linecap: round; }
 .schematex-circuit-fill { stroke: ${t.stroke}; stroke-width: 1.5; fill: ${t.stroke}; }
 .schematex-circuit-wire { stroke: ${t.stroke}; stroke-width: 1.75; fill: none; stroke-linecap: square; }

--- a/src/diagrams/decisiontree/renderer.ts
+++ b/src/diagrams/decisiontree/renderer.ts
@@ -23,7 +23,7 @@ const CLASS_PALETTE = [
 
 function buildCss(t: BaseTheme): string {
   return `
-.lt-dtree { background: ${t.bg}; font-family: system-ui, -apple-system, sans-serif; }
+.lt-dtree { font-family: system-ui, -apple-system, sans-serif; }
 .lt-dtree-title { font: 500 16px sans-serif; fill: ${t.text}; }
 .lt-dtree-edge { fill: none; stroke: ${t.stroke}; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
 .lt-dtree-edge-optimal { fill: none; stroke: ${t.positive}; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }

--- a/src/diagrams/ecomap/renderer.ts
+++ b/src/diagrams/ecomap/renderer.ts
@@ -142,7 +142,6 @@ function buildDefs(t: BaseTheme): string {
 function buildStyles(config: RenderConfig, t: BaseTheme): string {
   let css = `
 .schematex-ecomap {${cssCustomProperties(t)}
-  background: ${t.bg};
 }
 .schematex-ecomap-center-shape { fill: ${t.fill}; stroke: ${t.stroke}; stroke-width: ${STROKE_WIDTH.thick}; }
 .schematex-ecomap-center-label { font-family: ${config.fontFamily}; font-size: ${config.fontSize + 2}px; text-anchor: middle; dominant-baseline: central; fill: ${t.text}; font-weight: 600; }

--- a/src/diagrams/entity/renderer.ts
+++ b/src/diagrams/entity/renderer.ts
@@ -23,7 +23,7 @@ import {
 
 function buildCss(t: BaseTheme): string {
   return `
-.lt-entity { background: ${t.bg}; font-family: system-ui, -apple-system, sans-serif; }
+.lt-entity { font-family: system-ui, -apple-system, sans-serif; }
 .lt-entity-title { font: bold 16px sans-serif; fill: ${t.text}; }
 .lt-entity-name { font: 600 12px sans-serif; fill: ${t.text}; text-anchor: middle; }
 .lt-entity-type { font: 500 10px sans-serif; fill: ${t.textMuted}; text-anchor: middle; }

--- a/src/diagrams/fishbone/renderer.ts
+++ b/src/diagrams/fishbone/renderer.ts
@@ -16,7 +16,7 @@ import { layoutFishbone, type FishboneLayoutResult, type FishboneBBox } from "./
 import { resolveFishboneTheme } from "../../core/theme";
 
 const CSS = `
-.sx-fb { background: var(--schematex-fb-bg, #ffffff); font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+.sx-fb { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
 .sx-fb-title { font: 600 16px sans-serif; fill: #111; }
 .sx-fb-spine { stroke: var(--schematex-fb-spine, #141413); stroke-width: 2; stroke-linecap: butt; fill: none; }
 .sx-fb-tail { stroke: var(--schematex-fb-spine, #141413); stroke-width: 2; stroke-linecap: round; fill: none; }

--- a/src/diagrams/flowchart/renderer.ts
+++ b/src/diagrams/flowchart/renderer.ts
@@ -38,7 +38,7 @@ const CSS_TEMPLATE = (themeName: ThemeName): string => {
   const t = resolveFlowchartTheme(themeName);
   const c = t.classes;
   return `
-.sx-fc { background: ${t.bg}; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+.sx-fc { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
 .sx-fc-node { fill: ${t.fillMuted}; stroke: ${t.stroke}; stroke-width: 1.5; stroke-linejoin: round; }
 .sx-fc-node-stadium { fill: ${t.stadiumFill}; stroke: ${t.stroke}; }
 .sx-fc-node-diamond { fill: ${t.diamondFill}; stroke: ${t.stroke}; }

--- a/src/diagrams/genogram/renderer.ts
+++ b/src/diagrams/genogram/renderer.ts
@@ -140,7 +140,6 @@ function buildStyles(config: RenderConfig): string {
   const t = resolveGenogramTheme(config.theme);
   const css = `
 .schematex-genogram {${cssCustomProperties(t)}
-  background: ${t.bg};
 }
 .schematex-genogram-shape { fill: ${t.fill}; stroke: ${t.stroke}; stroke-width: ${STROKE_WIDTH.normal}; stroke-linejoin: round; }
 .schematex-genogram-male .schematex-genogram-shape { fill: ${t.maleFill}; }

--- a/src/diagrams/ladder/renderer.ts
+++ b/src/diagrams/ladder/renderer.ts
@@ -21,7 +21,7 @@ type IT = ResolvedTheme<IndustrialTokens>;
 
 function buildCss(t: IT): string {
   return `
-.lt-ladder { background: ${t.bg}; font-family: system-ui, -apple-system, sans-serif; }
+.lt-ladder { font-family: system-ui, -apple-system, sans-serif; }
 .lt-ladder-rail { stroke: ${t.strokeHeavy}; stroke-width: 4; stroke-linecap: square; }
 .lt-ladder-wire { stroke: ${t.stroke}; stroke-width: 1.5; fill: none; }
 .lt-ladder-element { stroke: ${t.stroke}; stroke-width: 2; fill: none; }

--- a/src/diagrams/logic/renderer.ts
+++ b/src/diagrams/logic/renderer.ts
@@ -271,7 +271,7 @@ export function renderLogic(ast: LogicGateAST, config?: RenderConfig): string {
   });
 
   const css = `
-.schematex-logic { background: ${t.bg}; font-family: system-ui, -apple-system, sans-serif; }
+.schematex-logic { font-family: system-ui, -apple-system, sans-serif; }
 .schematex-logic-gate-body { fill: none; stroke: ${t.strokeHeavy}; stroke-width: 1.75; stroke-linejoin: round; }
 .schematex-logic-bubble { fill: ${t.bg}; stroke: ${t.strokeHeavy}; stroke-width: 1.5; }
 .schematex-logic-clock-tri { fill: none; stroke: ${t.strokeHeavy}; stroke-width: 1.5; stroke-linejoin: round; }

--- a/src/diagrams/matrix/renderer.ts
+++ b/src/diagrams/matrix/renderer.ts
@@ -32,7 +32,7 @@ const HEAT_RAMP = [
 ];
 
 const CSS = `
-.sx-matrix { background: #fff; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+.sx-matrix { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
 .sx-matrix-title { font: 600 16px sans-serif; fill: #111; }
 .sx-matrix-grid { stroke: #e5e7eb; stroke-width: 1; fill: none; }
 .sx-matrix-mid { stroke: #9ca3af; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; }

--- a/src/diagrams/orgchart/renderer.ts
+++ b/src/diagrams/orgchart/renderer.ts
@@ -17,7 +17,7 @@ import type { OrgchartAST, OrgchartLayoutNode, OrgchartRoleIcon } from "./types"
 
 function buildCss(t: BaseTheme): string {
   return `
-.lt-org { background: ${t.bg}; font-family: system-ui, -apple-system, sans-serif; }
+.lt-org { font-family: system-ui, -apple-system, sans-serif; }
 .lt-org-title { font: 500 16px sans-serif; fill: ${t.text}; }
 .lt-org-card { fill: ${t.bg}; stroke: ${t.neutral}; stroke-width: 1; }
 .lt-org-card-vacant { fill: ${t.bg}; stroke: ${t.warn}; stroke-width: 1; stroke-dasharray: 4,3; }

--- a/src/diagrams/pedigree/renderer.ts
+++ b/src/diagrams/pedigree/renderer.ts
@@ -149,7 +149,6 @@ function buildDefs(nodes: LayoutNode[], t: ResolvedTheme<PersonTokens>): string 
 function buildStyles(config: RenderConfig, t: ResolvedTheme<PersonTokens>): string {
   const css = `
 .schematex-pedigree {${cssCustomProperties(t)}
-  background: ${t.bg};
 }
 .schematex-pedigree-shape { fill: ${t.fill}; stroke: ${t.stroke}; stroke-width: ${STROKE_WIDTH.normal}; stroke-linejoin: round; }
 .schematex-pedigree-label { font-family: ${config.fontFamily}; font-size: ${config.fontSize}px; text-anchor: middle; fill: ${t.text}; }

--- a/src/diagrams/phylo/renderer.ts
+++ b/src/diagrams/phylo/renderer.ts
@@ -45,7 +45,6 @@ function buildCSS(ast: PhyloTreeAST, t: ResolvedTheme<BiologyTokens>): string {
   return `
 .schematex-phylo {${cssCustomProperties(t)}
   font-family: system-ui, -apple-system, sans-serif;
-  background: ${t.bg};
 }
 .schematex-phylo-branch { fill: none; stroke: ${t.text}; stroke-width: ${STROKE_WIDTH.normal}; stroke-linecap: round; }
 .schematex-phylo-branch-connector { fill: none; stroke: ${t.text}; stroke-width: ${STROKE_WIDTH.normal}; }

--- a/src/diagrams/sld/renderer.ts
+++ b/src/diagrams/sld/renderer.ts
@@ -27,7 +27,7 @@ function buildCss(t: IT): string {
   const bandOdd = isDark ? BAND_ODD_DARK : BAND_ODD_LIGHT;
   const bandEven = isDark ? BAND_EVEN_DARK : BAND_EVEN_LIGHT;
   return `
-.lt-sld { background: ${t.bg}; font-family: system-ui, -apple-system, sans-serif; }
+.lt-sld { font-family: system-ui, -apple-system, sans-serif; }
 .lt-sld-stroke { stroke: ${t.stroke}; stroke-width: 1.8; fill: none; }
 .lt-sld-stroke-thick { stroke: ${t.stroke}; stroke-width: 2.4; fill: none; stroke-linecap: round; }
 .lt-sld-fill { fill: ${t.bg}; stroke: ${t.stroke}; stroke-width: 2; }

--- a/src/diagrams/sociogram/renderer.ts
+++ b/src/diagrams/sociogram/renderer.ts
@@ -41,7 +41,6 @@ function buildCSS(ast: SociogramAST, t: BaseTheme): string {
   return `
 .schematex-sociogram {${cssCustomProperties(t)}
   font-family: system-ui, -apple-system, sans-serif;
-  background: ${t.bg};
 }
 .schematex-sociogram-node { fill: ${t.accent}; stroke: ${t.accent}; stroke-width: ${STROKE_WIDTH.normal}; }
 .schematex-sociogram-node-star { fill: ${rf.star}; stroke: ${t.warn}; stroke-width: ${STROKE_WIDTH.thick}; }

--- a/src/diagrams/timeline/renderer.ts
+++ b/src/diagrams/timeline/renderer.ts
@@ -87,7 +87,7 @@ function styleForTheme(theme: Theme, fontFamily?: string): string {
       --st-card-text: ${theme.cardText};
       --st-legend-bg: ${theme.legendBg};
       --st-legend-stroke: ${theme.legendStroke};
-      font-family: ${font}; background: var(--schematex-bg); }
+      font-family: ${font}; }
     .st-title { font-size: 16px; font-weight: 600; fill: var(--schematex-text); }
     .st-axis-line { stroke: var(--st-axis); stroke-width: 1.5; fill: none; }
     .st-axis-tick { stroke: var(--st-axis); stroke-width: 1; opacity: 0.55; }

--- a/src/diagrams/timing/renderer.ts
+++ b/src/diagrams/timing/renderer.ts
@@ -375,7 +375,7 @@ export function renderTiming(ast: TimingAST): string {
   );
 
   const css = `
-.schematex-timing { background: #fff; font-family: system-ui, -apple-system, sans-serif; }
+.schematex-timing { font-family: system-ui, -apple-system, sans-serif; }
 .schematex-timing-name { font: 12px monospace; fill: #111; }
 .schematex-timing-name-activelow { text-decoration: overline; }
 .schematex-timing-group-label { font: bold 12px sans-serif; fill: #111; }

--- a/src/diagrams/venn/renderer.ts
+++ b/src/diagrams/venn/renderer.ts
@@ -35,7 +35,7 @@ function idSlug(id: string): string {
 
 function buildCss(tokens: ReturnType<typeof resolveVennTheme>): string {
   return `
-.schematex-venn { background: ${tokens.bg}; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+.schematex-venn { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
 .schematex-venn-title { font: 600 16px sans-serif; fill: ${tokens.text}; }
 .schematex-venn-set { stroke: ${tokens.vennSetStroke}; stroke-width: 1.25; }
 .schematex-venn-blend-multiply { mix-blend-mode: multiply; }

--- a/src/export.ts
+++ b/src/export.ts
@@ -18,7 +18,7 @@
 export interface PngExportOptions {
   /** Pixel ratio multiplier. Default: 2 (retina/2×). */
   scale?: number;
-  /** Background fill color. Default: 'white'. Pass null for transparent. */
+  /** Background fill color. Default: null (transparent). Pass a color string (e.g. 'white') to fill. */
   background?: string | null;
 }
 
@@ -30,7 +30,7 @@ export function svgToPngBlob(
   svgString: string,
   options: PngExportOptions = {}
 ): Promise<Blob> {
-  const { scale = 2, background = "white" } = options;
+  const { scale = 2, background = null } = options;
 
   return new Promise((resolve, reject) => {
     const blob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });

--- a/website/app/(home)/page.tsx
+++ b/website/app/(home)/page.tsx
@@ -331,7 +331,10 @@ export default async function HomePage() {
                     <span className="opacity-40">·</span>
                     <span style={{ color: 'var(--accent)' }}>§ {ex.standard}</span>
                   </div>
-                  <div className="dot-grid flex aspect-[4/3] items-center justify-center overflow-hidden p-4">
+                  <div
+                    className="dot-grid flex aspect-[4/3] items-center justify-center overflow-hidden p-4"
+                    style={{ background: '#ffffff' }}
+                  >
                     <div
                       className="flex h-full w-full items-center justify-center [&_svg]:block [&_svg]:h-auto [&_svg]:max-h-full [&_svg]:w-auto [&_svg]:max-w-full"
                       dangerouslySetInnerHTML={{ __html: svg }}

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -48,7 +48,16 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider
+          theme={{
+            // Light by default, no `prefers-color-scheme` follow. Users can
+            // still toggle to dark via the header switch.
+            defaultTheme: 'light',
+            enableSystem: false,
+          }}
+        >
+          {children}
+        </RootProvider>
         <Script
           defer
           data-domain="schematex.js.org"

--- a/website/components/DiagramFrame.tsx
+++ b/website/components/DiagramFrame.tsx
@@ -25,7 +25,9 @@ export function DiagramFrame({
       style={{
         border: '1px solid var(--fill-muted)',
         borderRadius: 'var(--r)',
-        background: 'var(--bg)',
+        // Force white surface so the always-light-theme schematex SVG (with dark
+        // strokes/text) stays readable when the site is in dark mode.
+        background: '#ffffff',
         ...style,
       }}
     >

--- a/website/components/GalleryGrid.tsx
+++ b/website/components/GalleryGrid.tsx
@@ -36,10 +36,12 @@ function GalleryCard({ ex }: { ex: GalleryExample }) {
           <span className="truncate">§ {ex.standard}</span>
         </div>
 
-        {/* Diagram preview — dot-grid background, fixed height */}
+        {/* Diagram preview — dot-grid background, fixed height.
+            Force white surface so the always-light-theme schematex SVG remains
+            readable when the site is in dark mode. */}
         <div
           className="dot-grid flex items-center justify-center p-4"
-          style={{ height: 180, color: 'var(--stroke)' }}
+          style={{ height: 180, color: 'var(--stroke)', background: '#ffffff' }}
         >
           {svg ? (
             <div


### PR DESCRIPTION
## Summary

**v0.3.4 — background-agnostic SVG output + website light-default**

### Library

- SVG output is now **background-agnostic** — no canvas fill is baked into the inline `<style>`. Diagrams inherit whatever color their host element provides, so the same SVG embeds cleanly in light pages, dark canvases, and print PDFs without `!important` overrides.
- **PNG export defaults to transparent.** `svgToPngBlob(svg)` previously baked a white background; now it's transparent. Pass `{ background: 'white' }` (or any color) to keep the old behavior.
- **Dark theme** (`theme: "dark"`) now requires the user to provide a dark wrapper. Documented in README.

### Website

The transparent-SVG change exposed a latent issue: the website calls `render()` without a `theme` argument, so the SVG always emits light-theme strokes. A dark site surface made diagrams unreadable. Two coupled fixes:

1. **Default to light, no `prefers-color-scheme` follow.** `RootProvider` now passes `defaultTheme: 'light'` + `enableSystem: false`. Users can still toggle dark via the existing header switch.
2. **Force diagram surfaces to `#ffffff`** regardless of site theme — `DiagramFrame` (Hero, Playground main + preview), gallery card stage, homepage card stage. Visual = "white card on dark page" when user toggles dark, which is what the pre-v0.3.4 accidental baked-bg used to produce.

## Why

Mermaid bakes a `primaryBkg` into its output and is regularly criticized for it (`mermaid-cli#969`, `mermaid#1553`). Schematex's "Made for AI / embed anywhere" positioning is better served by transparent-by-default. The user can always wrap with `<div style="background:#fff">`; reversing a baked-in white requires CSS hacks.

## Scope

- 19 diagram renderers — only the `background:` declaration removed from inline `<style>`. Strokes, fills, text colors unchanged.
- `src/export.ts` — `PngExportOptions.background` default flipped from `"white"` to `null`.
- `README.md` — new "Backgrounds & dark mode" section with the dark-wrapper example.
- `CHANGELOG.md` — 0.3.4 entry.
- `package.json` — version 0.3.3 → 0.3.4.
- 6 example SVGs regenerated (auto-generated, only the `background:` line removed).
- **Website**: `app/layout.tsx`, `components/DiagramFrame.tsx`, `components/GalleryGrid.tsx`, `app/(home)/page.tsx`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 569/569 pass
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] `npm run build` — succeeds
- [x] Verified example SVG diff is `background: #ffffff;` removal only
- [x] **Website**: `npx tsc --noEmit` clean, `next build` succeeds (80/80 static pages)
- [x] **Website browser verify**: forced light default working; dark mode toggle works and persists via `localStorage`; gallery cards, playground, hero all show white diagram surfaces with readable strokes in both modes
- [ ] Visual smoke-test embedding in MyMap / ChatDiagram before publishing v0.3.4 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
