### PR TITLE
Track A: 4 existing-engine improvements (flowchart + timeline + circuit)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -856,6 +856,12 @@ export type CircuitComponentType =
   | "relay_no"          // Relay contact normally-open (like switch_spst)
   | "relay_nc"          // Relay contact normally-closed (with slash)
 
+  // ── Industrial control / Power electrical (IEC 60617 §07/§14) ──
+  | "contactor"         // Heavy-load switching (KM*) — bold contact + dash actuator
+  | "solenoid_valve"    // Pneumatic / hydraulic control (EV*) — coil + valve symbol
+  | "thermal_overload"  // Motor protection (F2*) — hashed rectangle + heat marks
+  | "disconnect_switch" // Service disconnect / isolator (Q1*) — switch with disconnect bracket
+
   // ── Electromechanical ─────────────────────────────────────────
   | "motor"             // Circle + M + shaft line
   | "speaker"           // Triangle + box + radiating lines

--- a/src/diagrams/circuit/parser.ts
+++ b/src/diagrams/circuit/parser.ts
@@ -32,6 +32,7 @@ const COMPONENT_TYPES = new Set<CircuitComponentType>([
   "ground", "gnd_signal", "gnd_chassis", "gnd_digital",
   "switch_spst", "switch_spdt", "switch_dpdt", "push_no", "push_nc",
   "relay_coil", "relay_no", "relay_nc",
+  "contactor", "solenoid_valve", "thermal_overload", "disconnect_switch",
   "motor", "speaker", "microphone", "buzzer",
   "ammeter", "voltmeter", "wattmeter", "oscilloscope",
   "wire", "dot", "label", "port", "test_point", "no_connect", "antenna",
@@ -59,6 +60,16 @@ const ALIASES: Record<string, CircuitComponentType> = {
   ntc: "thermistor_ntc",
   ptc: "thermistor_ptc",
   ths: "thermistor_ntc",
+  // Industrial control aliases (IEC letter codes)
+  coil: "relay_coil",
+  relay: "relay_coil",
+  km: "contactor",
+  solenoid: "solenoid_valve",
+  ev: "solenoid_valve",
+  overload: "thermal_overload",
+  thermal: "thermal_overload",
+  disconnect: "disconnect_switch",
+  isolator: "disconnect_switch",
 };
 
 /** Component types that exist as symbols but aren't listed in CircuitComponentType. */

--- a/src/diagrams/circuit/symbols.ts
+++ b/src/diagrams/circuit/symbols.ts
@@ -916,6 +916,130 @@ const terminal_block: SymbolDef = {
   },
 };
 
+// ─── Industrial control / Power electrical (IEC 60617) ───────
+
+// Relay coil — rectangle with diagonal line indicating coil winding.
+// Mechanical-link convention: contacts elsewhere sharing the same label
+// (e.g. K1) are conceptually driven by this coil; rendering of the link
+// itself is deferred to a future enhancement.
+const relay_coil: SymbolDef = {
+  length: 40,
+  anchors: { start: { x: 0, y: 0 }, end: { x: 40, y: 0 } },
+  svg: () =>
+    [
+      lineWire(0, 0, 8, 0),
+      `<rect x="8" y="-10" width="24" height="20" fill="white" ${BODY}/>`,
+      // Diagonal slash inside the box = coil winding indicator
+      `<line x1="8" y1="-10" x2="32" y2="10" ${BODY}/>`,
+      lineWire(32, 0, 40, 0),
+    ].join(""),
+};
+
+// Relay contact normally-open — same as a switch contact but visually
+// paired (small rect indicator above) to mark "controlled by a coil".
+const relay_no: SymbolDef = {
+  length: 40,
+  anchors: { start: { x: 0, y: 0 }, end: { x: 40, y: 0 } },
+  svg: () =>
+    [
+      lineWire(0, 0, 10, 0),
+      `<line x1="10" y1="0" x2="30" y2="-10" ${BODY}/>`,
+      `<circle cx="10" cy="0" r="2" ${FILL}/>`,
+      `<circle cx="30" cy="0" r="2" ${FILL}/>`,
+      // Small dashed bar above to denote actuator-driven (vs hand switch)
+      `<line x1="14" y1="-14" x2="26" y2="-14" stroke-dasharray="2,2" ${BODY}/>`,
+      lineWire(30, 0, 40, 0),
+    ].join(""),
+};
+
+// Relay contact normally-closed — bar drawn across the contact gap.
+const relay_nc: SymbolDef = {
+  length: 40,
+  anchors: { start: { x: 0, y: 0 }, end: { x: 40, y: 0 } },
+  svg: () =>
+    [
+      lineWire(0, 0, 10, 0),
+      `<line x1="10" y1="-10" x2="30" y2="-10" ${BODY}/>`,
+      // NC slash: line crosses both contact endpoints (closed by default)
+      `<line x1="8" y1="2" x2="32" y2="-12" ${BODY}/>`,
+      `<circle cx="10" cy="0" r="2" ${FILL}/>`,
+      `<circle cx="30" cy="0" r="2" ${FILL}/>`,
+      `<line x1="14" y1="-14" x2="26" y2="-14" stroke-dasharray="2,2" ${BODY}/>`,
+      lineWire(30, 0, 40, 0),
+    ].join(""),
+};
+
+// Contactor (KM*) — heavy-load switching, drawn with a bolder contact +
+// horizontal dash row indicating the mechanical bridge.
+const contactor: SymbolDef = {
+  length: 44,
+  anchors: { start: { x: 0, y: 0 }, end: { x: 44, y: 0 } },
+  svg: () =>
+    [
+      lineWire(0, 0, 10, 0),
+      // Two parallel diagonal contacts = double-break (typical of contactors)
+      `<line x1="10" y1="0" x2="30" y2="-10" stroke-width="2.5" ${BODY}/>`,
+      `<line x1="14" y1="2" x2="34" y2="-8" stroke-width="2.5" ${BODY}/>`,
+      `<circle cx="10" cy="0" r="2" ${FILL}/>`,
+      `<circle cx="34" cy="0" r="2" ${FILL}/>`,
+      // Solid bar above = electromagnetic-driven actuator
+      `<line x1="14" y1="-14" x2="30" y2="-14" stroke-width="2" ${BODY}/>`,
+      lineWire(34, 0, 44, 0),
+    ].join(""),
+};
+
+// Solenoid valve (EV*) — rectangle with coil winding indicator and a
+// valve-body arrow pointing along the flow path. Simplified IEC 60617-14.
+const solenoid_valve: SymbolDef = {
+  length: 50,
+  anchors: { start: { x: 0, y: 0 }, end: { x: 50, y: 0 } },
+  svg: () =>
+    [
+      lineWire(0, 0, 8, 0),
+      // Solenoid box on top
+      `<rect x="8" y="-22" width="14" height="12" fill="white" ${BODY}/>`,
+      `<line x1="8" y1="-22" x2="22" y2="-10" ${BODY}/>`,
+      // Valve body (triangle pair = IEC valve symbol)
+      `<polygon points="22,0 38,-8 38,8" fill="white" ${BODY}/>`,
+      `<polygon points="22,0 8,-8 8,8" fill="white" ${BODY}/>`,
+      // Connect solenoid to valve body (actuator line)
+      `<line x1="15" y1="-10" x2="22" y2="0" ${BODY}/>`,
+      lineWire(38, 0, 50, 0),
+    ].join(""),
+};
+
+// Thermal overload relay (F2*) — hashed rectangle with heat-element
+// indicators; the small bent line denotes the bimetal element.
+const thermal_overload: SymbolDef = {
+  length: 40,
+  anchors: { start: { x: 0, y: 0 }, end: { x: 40, y: 0 } },
+  svg: () =>
+    [
+      lineWire(0, 0, 8, 0),
+      `<rect x="8" y="-12" width="24" height="24" fill="white" ${BODY}/>`,
+      // Bimetal element: bent line inside box
+      `<path d="M 12,-6 L 16,4 L 20,-6 L 24,4 L 28,-6" fill="none" ${BODY}/>`,
+      lineWire(32, 0, 40, 0),
+    ].join(""),
+};
+
+// Disconnect switch / isolator (Q1*) — switch with a hollow square at
+// the moving contact end to indicate visible-break disconnect device.
+const disconnect_switch: SymbolDef = {
+  length: 48,
+  anchors: { start: { x: 0, y: 0 }, end: { x: 48, y: 0 } },
+  svg: () =>
+    [
+      lineWire(0, 0, 10, 0),
+      `<line x1="10" y1="0" x2="34" y2="-12" ${BODY}/>`,
+      `<circle cx="10" cy="0" r="2" ${FILL}/>`,
+      // Hollow square at top of arm = visible-isolation indicator
+      `<rect x="30" y="-16" width="8" height="8" fill="white" ${BODY}/>`,
+      `<circle cx="38" cy="0" r="2" ${FILL}/>`,
+      lineWire(38, 0, 48, 0),
+    ].join(""),
+};
+
 // ─── Registry ─────────────────────────────────────────────────
 
 export const SYMBOLS: Partial<Record<CircuitComponentType, SymbolDef>> = {
@@ -973,6 +1097,14 @@ export const SYMBOLS: Partial<Record<CircuitComponentType, SymbolDef>> = {
   terminal_block,
   "555_timer": timer_555,
   voltage_regulator,
+  // Industrial control / power electrical (IEC 60617)
+  relay_coil,
+  relay_no,
+  relay_nc,
+  contactor,
+  solenoid_valve,
+  thermal_overload,
+  disconnect_switch,
   // Lamp reuses buzzer slot? No, needs its own entry but our CircuitComponentType
   // doesn't have "lamp". We map it via parser alias to "buzzer" or add specifically.
 };

--- a/src/diagrams/flowchart/layout.ts
+++ b/src/diagrams/flowchart/layout.ts
@@ -776,6 +776,114 @@ function laneBasedXCoords(
  * range, like a multi-phase pipeline) BK gives a clean straight spine
  * and the bboxes wrap naturally with no interference.
  */
+/**
+ * Detect sequential cluster chains and rewrite layerMap to enforce strict
+ * vertical separation between them. A "sequential chain" is a maximal run
+ * of top-level clusters in DSL order where each adjacent pair S_i → S_i+1
+ * has at least one forward edge between their members. The chain heuristic
+ * fires for PRISMA-style top-to-bottom pipelines where branching pushes
+ * later-cluster nodes onto the same DAG layer as earlier-cluster terminals
+ * (the cascade trigger from docs/issues/01).
+ *
+ * For each chain, walk in DSL order and ensure cluster i's min layer >
+ * cluster i-1's max layer; shift the cluster's nodes AND their DAG
+ * descendants by the deficit when needed. Parallel pipelines (no forward
+ * edge between siblings) are NOT shifted — they continue to use the lane
+ * fallback in assignLaneXCoords.
+ */
+function enforceSequentialClusterLayers(
+  ast: FlowchartAST,
+  layerMap: Map<string, number>,
+  edges: LEdge[]
+): void {
+  const sgParent = new Map<string, string | undefined>();
+  for (const sg of ast.subgraphs) {
+    for (const childSg of sg.subgraphs) sgParent.set(childSg, sg.id);
+    if (!sgParent.has(sg.id)) sgParent.set(sg.id, undefined);
+  }
+  const topLevel = ast.subgraphs.filter((sg) => !sgParent.get(sg.id));
+  if (topLevel.length < 2) return;
+
+  const collect = (sgId: string): string[] => {
+    const sg = ast.subgraphs.find((s) => s.id === sgId);
+    if (!sg) return [];
+    const ids = [...sg.children];
+    for (const childSgId of sg.subgraphs) ids.push(...collect(childSgId));
+    return ids;
+  };
+
+  const adjOut = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!adjOut.has(e.from)) adjOut.set(e.from, []);
+    adjOut.get(e.from)!.push(e.to);
+  }
+
+  const hasForwardEdge = (srcSgId: string, dstSgId: string): boolean => {
+    const srcIds = new Set(collect(srcSgId));
+    const dstIds = new Set(collect(dstSgId));
+    for (const id of srcIds) {
+      for (const t of adjOut.get(id) ?? []) {
+        if (dstIds.has(t)) return true;
+      }
+    }
+    return false;
+  };
+
+  // Build maximal sequential chains
+  const chains: string[][] = [];
+  let cur: string[] = [];
+  for (let i = 0; i < topLevel.length; i++) {
+    const sg = topLevel[i]!;
+    if (i === 0 || !hasForwardEdge(topLevel[i - 1]!.id, sg.id)) {
+      if (cur.length > 1) chains.push(cur);
+      cur = [sg.id];
+    } else {
+      cur.push(sg.id);
+    }
+  }
+  if (cur.length > 1) chains.push(cur);
+  if (chains.length === 0) return;
+
+  // Apply shifts per chain
+  for (const chain of chains) {
+    let prevMax = -Infinity;
+    for (const clusterId of chain) {
+      const ids = collect(clusterId);
+      if (ids.length === 0) continue;
+      let curMin = Infinity;
+      let curMax = -Infinity;
+      for (const id of ids) {
+        const l = layerMap.get(id) ?? 0;
+        if (l < curMin) curMin = l;
+        if (l > curMax) curMax = l;
+      }
+      const requiredMin = prevMax === -Infinity ? curMin : prevMax + 1;
+      if (curMin < requiredMin) {
+        const shift = requiredMin - curMin;
+        // Shift cluster nodes + all DAG descendants (so downstream layers
+        // stay consistent with their cluster's new position).
+        const toShift = new Set(ids);
+        const queue = [...ids];
+        while (queue.length > 0) {
+          const u = queue.shift()!;
+          for (const t of adjOut.get(u) ?? []) {
+            if (!toShift.has(t)) {
+              toShift.add(t);
+              queue.push(t);
+            }
+          }
+        }
+        for (const id of toShift) {
+          layerMap.set(id, (layerMap.get(id) ?? 0) + shift);
+        }
+        prevMax = curMax + shift;
+      } else {
+        prevMax = curMax;
+      }
+    }
+  }
+}
+
 function hasOverlappingTopLevelClusters(
   ast: FlowchartAST,
   layerMap: Map<string, number>,
@@ -910,6 +1018,13 @@ export function layoutFlowchart(ast: FlowchartAST): FlowchartLayoutResult {
 
   // ── Phase 2: layer assignment ────────────────────────────
   const layerMap = longestPathLayers(allIds, ledges);
+
+  // ── Phase 2.5: sequential cluster separation (fixes #01) ─
+  // For PRISMA-style sequential top-level clusters (each connected to the
+  // next by a forward edge in DSL order), rewrite layers so each cluster
+  // gets its own strictly-disjoint layer range. Parallel sibling clusters
+  // (no forward edge) are untouched and continue to use the lane fallback.
+  enforceSequentialClusterLayers(ast, layerMap, ledges);
 
   // ── Phase 3: dummy insertion ─────────────────────────────
   let dummyCounter = 0;

--- a/src/diagrams/flowchart/layout.ts
+++ b/src/diagrams/flowchart/layout.ts
@@ -100,15 +100,38 @@ function isFullWidth(code: number): boolean {
   return false;
 }
 
-export function measureLabelWidth(label: string): number {
+/** Split a label on <br/> / <br> / \n. Strips inline <b>/<i> tags per line. */
+export function labelLines(label: string): string[] {
+  return String(label)
+    .split(/<br\s*\/?>|\n/i)
+    .map((line) => line.replace(/<\/?[bi]>/gi, ""));
+}
+
+/** Measure one plain-text line (after markup stripping). */
+function measureLineWidth(line: string): number {
   let w = 0;
-  // Iterate by codepoint so astral chars count once.
-  for (const ch of label) {
+  for (const ch of line) {
     const code = ch.codePointAt(0) ?? 0;
     if (isFullWidth(code)) w += FC_CONST.cjkCharWidth;
     else w += FC_CONST.charWidth;
   }
   return w;
+}
+
+/**
+ * Measure the rendered width of a label. Multi-line labels (via `<br/>` or
+ * `\n`) measure as the widest line, NOT the concatenated string. Inline
+ * `<b>` / `<i>` markup is stripped before measurement so emphasis tags do
+ * not inflate node width.
+ */
+export function measureLabelWidth(label: string): number {
+  const lines = labelLines(label);
+  let max = 0;
+  for (const line of lines) {
+    const w = measureLineWidth(line);
+    if (w > max) max = w;
+  }
+  return max;
 }
 
 // ─── Internal working types ────────────────────────────────
@@ -800,7 +823,11 @@ export function layoutFlowchart(ast: FlowchartAST): FlowchartLayoutResult {
       Math.ceil(rawTextW) + FC_CONST.labelHPad * 2
     );
     let shapeW = Math.max(FC_CONST.minNodeWidth, labelW);
-    let shapeH: number = FC_CONST.nodeHeight;
+    // Grow shape height for multi-line labels. lineHeight matches the value
+    // used by core/svg.ts:multilineText (14px) so the rendered tspans fit.
+    const nLines = labelLines(n.label).length;
+    const multilineH = nLines > 1 ? FC_CONST.nodeHeight + (nLines - 1) * 14 : FC_CONST.nodeHeight;
+    let shapeH: number = multilineH;
     if (n.shape === "diamond") {
       // Diamond's inner usable width at y=h/2 equals the full width, but text
       // near the vertical extents is clipped by the rhombus edges. Bump 1.4×

--- a/src/diagrams/timeline/dates.ts
+++ b/src/diagrams/timeline/dates.ts
@@ -75,6 +75,20 @@ export function parseDate(raw: string): TimelineDate {
   throw new Error(`Cannot parse date: "${raw}"`);
 }
 
+/**
+ * Non-throwing variant of `parseDate`. Returns `null` when the raw token
+ * cannot be parsed as any of the supported date forms — callers can fall
+ * back to ordinal mode (using the raw string as a row label and the
+ * declaration index for layout positioning).
+ */
+export function tryParseDate(raw: string): TimelineDate | null {
+  try {
+    return parseDate(raw);
+  } catch {
+    return null;
+  }
+}
+
 function daysInYear(y: number): number {
   const leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
   return leap ? 366 : 365;

--- a/src/diagrams/timeline/parser.ts
+++ b/src/diagrams/timeline/parser.ts
@@ -10,7 +10,7 @@ import type {
   TimelineSide,
   TimelineStyle,
 } from "./types";
-import { parseDate } from "./dates";
+import { parseDate, tryParseDate } from "./dates";
 
 export class TimelineParseError extends Error {
   constructor(
@@ -108,14 +108,32 @@ function splitTopLevel(s: string, sep: string): string[] {
  * date-range separator (space-hyphen-space or `..`) from an intra-date minus.
  */
 function splitDateAndBody(s: string, lineNum: number): { date: string; end?: string; body: string } {
-  // Find unquoted colon that ends the date spec
+  // Find the unquoted colon that separates row-key from body. Prefer a
+  // colon with whitespace on both sides (matching the canonical ` : `
+  // separator) — that way ordinal time-of-day keys like `14:30 : "Standup"`
+  // stay intact instead of splitting at the colon inside the key. Fall
+  // back to the first unquoted colon for back-compat with no-space forms.
   let inQuote = false;
   let colon = -1;
   for (let i = 0; i < s.length; i++) {
     const c = s[i]!;
     if (c === '"') inQuote = !inQuote;
     if (inQuote) continue;
-    if (c === ":") { colon = i; break; }
+    if (c === ":") {
+      const lhsSpace = i === 0 || s[i - 1] === " " || s[i - 1] === "\t";
+      const rhsSpace = i === s.length - 1 || s[i + 1] === " " || s[i + 1] === "\t";
+      if (lhsSpace && rhsSpace) { colon = i; break; }
+    }
+  }
+  if (colon < 0) {
+    // Fallback: first unquoted colon regardless of spacing.
+    inQuote = false;
+    for (let i = 0; i < s.length; i++) {
+      const c = s[i]!;
+      if (c === '"') inQuote = !inQuote;
+      if (inQuote) continue;
+      if (c === ":") { colon = i; break; }
+    }
   }
   if (colon < 0) throw new TimelineParseError(`Expected ':' after date: ${s}`, lineNum);
   const datePart = s.slice(0, colon).trim();
@@ -161,6 +179,9 @@ export function parseTimeline(src: string): TimelineAST {
   let i = 0;
   let autoId = 0;
   const nextId = (prefix: string) => `${prefix}-${++autoId}`;
+  // Shared ordinal counter — incremented whenever a row key fails date
+  // parsing and falls back to a string label.
+  const ordinal = { index: 0 };
 
   // ─── header: `timeline "Title"` or `timeline` ───
   const first = lines[0]!;
@@ -240,7 +261,7 @@ export function parseTimeline(src: string): TimelineAST {
         if (child.indent <= baseIndent && /^(section|track)\b/i.test(child.text)) break;
         if (isTrack && child.indent <= baseIndent) break;
         if (/^note\s*:/i.test(child.text)) { i++; continue; }
-        const parsed = parseEventLine(child.text, child.line, nextId);
+        const parsed = parseEventLine(child.text, child.line, nextId, ordinal);
         if (!parsed) throw new TimelineParseError(`Unrecognized line in ${keyword}: ${child.text}`, child.line);
         parsed.event.trackId = trackId;
         ast.events.push(parsed.event);
@@ -256,7 +277,7 @@ export function parseTimeline(src: string): TimelineAST {
     }
 
     // Otherwise: flat event line
-    const parsed = parseEventLine(text, L.line, nextId);
+    const parsed = parseEventLine(text, L.line, nextId, ordinal);
     if (parsed) {
       ast.events.push(parsed.event);
       i++;
@@ -283,6 +304,26 @@ function safeParseDate(raw: string, line: number): TimelineDate {
     const msg = e instanceof Error ? e.message : String(e);
     throw new TimelineParseError(msg, line);
   }
+}
+
+/**
+ * Parse a row key, falling back to ordinal mode when the token is not a
+ * recognisable date (e.g. "Phase 1", "Q1 2024", "Spring", non-Latin
+ * season names). Ordinal events are positioned in declaration order via
+ * a shared counter; the raw key is preserved as the display label.
+ */
+function parseRowKey(
+  raw: string,
+  ordinal: { index: number }
+): TimelineDate {
+  const parsed = tryParseDate(raw);
+  if (parsed) return parsed;
+  ordinal.index += 1;
+  return {
+    value: ordinal.index,
+    raw,
+    precision: "ordinal",
+  };
 }
 
 function applyConfig(ast: TimelineAST, k: string, v: string, line: number): void {
@@ -325,7 +366,8 @@ function applyConfig(ast: TimelineAST, k: string, v: string, line: number): void
 function parseEventLine(
   text: string,
   line: number,
-  nextId: (p: string) => string
+  nextId: (p: string) => string,
+  ordinal: { index: number }
 ): { event: TimelineEvent; hasNote: boolean } | null {
   const { props, rest } = parseProperties(text, line);
   const { date, end, body } = splitDateAndBody(rest, line);
@@ -350,8 +392,8 @@ function parseEventLine(
     id: nextId("ev"),
     label,
     kind,
-    start: safeParseDate(date, line),
-    end: end ? safeParseDate(end, line) : undefined,
+    start: parseRowKey(date, ordinal),
+    end: end ? parseRowKey(end, ordinal) : undefined,
     icon: props["icon"],
     shape: props["shape"] as TimelineEventShape | undefined,
     color: props["color"],

--- a/src/diagrams/timeline/types.ts
+++ b/src/diagrams/timeline/types.ts
@@ -35,8 +35,13 @@ export interface TimelineDate {
   value: number;
   /** Original raw string from DSL, for display. */
   raw: string;
-  /** Precision — affects tick granularity + display formatter. */
-  precision: "day" | "month" | "year" | "ma";
+  /**
+   * Precision — affects tick granularity + display formatter. `ordinal`
+   * means the row key did not parse as a date (e.g. "Phase 1", "Q1 2024",
+   * a non-Latin season name): the raw string is shown as the label and
+   * `value` is the row's declaration index for layout-purposes only.
+   */
+  precision: "day" | "month" | "year" | "ma" | "ordinal";
 }
 
 export interface TimelineEvent {

--- a/tests/circuit/industrial-symbols.test.ts
+++ b/tests/circuit/industrial-symbols.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from "vitest";
+import { parseCircuit } from "../../src/diagrams/circuit/parser";
+import { renderCircuit } from "../../src/diagrams/circuit/renderer";
+import { getSymbol } from "../../src/diagrams/circuit/symbols";
+
+describe("circuit industrial primitives (Track A Unit 3)", () => {
+  // Each new IEC 60617 symbol must (a) exist in the SYMBOLS registry,
+  // (b) parse via the DSL with its canonical name or designator alias,
+  // and (c) render to SVG without errors.
+  const NEW_TYPES = [
+    "relay_coil",
+    "relay_no",
+    "relay_nc",
+    "contactor",
+    "solenoid_valve",
+    "thermal_overload",
+    "disconnect_switch",
+  ] as const;
+
+  for (const type of NEW_TYPES) {
+    test(`${type} symbol exists and has start+end anchors`, () => {
+      const sym = getSymbol(type);
+      expect(sym).toBeDefined();
+      expect(sym!.anchors["start"]).toBeDefined();
+      expect(sym!.anchors["end"]).toBeDefined();
+      expect(sym!.length).toBeGreaterThan(0);
+      // SVG fragment is non-empty and well-formed enough to contain at
+      // least one element tag.
+      const svg = sym!.svg();
+      expect(svg.length).toBeGreaterThan(0);
+      expect(svg).toMatch(/<(line|rect|circle|path|polygon)/);
+    });
+  }
+
+  test("positional DSL accepts the new types via id:type form", () => {
+    const dsl = `circuit "control"
+Q1: disconnect_switch right
+F1: fuse right
+KM1: contactor right
+F2: thermal_overload right
+M1: motor right`;
+    const ast = parseCircuit(dsl);
+    expect(ast.components.find((c) => c.id === "Q1")?.componentType).toBe("disconnect_switch");
+    expect(ast.components.find((c) => c.id === "KM1")?.componentType).toBe("contactor");
+    expect(ast.components.find((c) => c.id === "F2")?.componentType).toBe("thermal_overload");
+  });
+
+  test("aliases route to canonical types in positional DSL", () => {
+    // Short DSL aliases must resolve to the canonical IEC types.
+    const dsl = `circuit "aliased"
+K1: coil right
+K2: relay right
+KM1: km right
+EV1: solenoid right
+EV2: ev right
+F2: thermal right
+F3: overload right
+Q1: disconnect right
+Q2: isolator right`;
+    const ast = parseCircuit(dsl);
+    expect(ast.components.find((c) => c.id === "K1")?.componentType).toBe("relay_coil");
+    expect(ast.components.find((c) => c.id === "K2")?.componentType).toBe("relay_coil");
+    expect(ast.components.find((c) => c.id === "KM1")?.componentType).toBe("contactor");
+    expect(ast.components.find((c) => c.id === "EV1")?.componentType).toBe("solenoid_valve");
+    expect(ast.components.find((c) => c.id === "EV2")?.componentType).toBe("solenoid_valve");
+    expect(ast.components.find((c) => c.id === "F2")?.componentType).toBe("thermal_overload");
+    expect(ast.components.find((c) => c.id === "F3")?.componentType).toBe("thermal_overload");
+    expect(ast.components.find((c) => c.id === "Q1")?.componentType).toBe("disconnect_switch");
+    expect(ast.components.find((c) => c.id === "Q2")?.componentType).toBe("disconnect_switch");
+  });
+
+  test("motor-starter pattern renders end-to-end without error", () => {
+    // Typical motor starter: disconnect → fuse → contactor → thermal → motor.
+    const dsl = `circuit "motor starter"
+Q1: disconnect_switch right
+F1: fuse right
+KM1: contactor right
+F2: thermal_overload right
+M1: motor right`;
+    const ast = parseCircuit(dsl);
+    const svg = renderCircuit(ast);
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+    expect(svg).toContain("schematex-circuit");
+  });
+
+  test("relay coil + NO contact + NC contact all coexist", () => {
+    const dsl = `circuit "relay logic"
+K1: relay_coil right
+K1A: relay_no right
+K1B: relay_nc right`;
+    const ast = parseCircuit(dsl);
+    expect(ast.components).toHaveLength(3);
+    const svg = renderCircuit(ast);
+    expect(svg).toContain("<svg");
+  });
+});

--- a/tests/flowchart/layout.test.ts
+++ b/tests/flowchart/layout.test.ts
@@ -199,6 +199,81 @@ A -->|no| C[Reject]`);
     expect(usableInner).toBeGreaterThanOrEqual(labelW);
   });
 
+  // ─── Sequential cluster vertical stacking (Track A Unit 2 / issue #01) ─
+  describe("sequential cluster stacking (PRISMA pattern)", () => {
+    test("PRISMA-style cascade resolves to vertical stack", () => {
+      // From docs/issues/01-flowchart-subgraph-lane-cascade.md — d branches
+      // to e (in ELIG) AND f (in INCL), putting both on layer 3. Before the
+      // sequential-cluster fix this triggered lane mode and cascaded the
+      // four clusters diagonally; after the fix INCL shifts down so its
+      // layer range is strictly below ELIG.
+      const ast = parseFlowchart(`flowchart TD
+  subgraph ID [Identification]
+    a[A]
+    b[B]
+  end
+  subgraph SCREEN [Screening]
+    c[C]
+  end
+  subgraph ELIG [Eligibility]
+    d[D]
+    e[E]
+  end
+  subgraph INCL [Included]
+    f[F]
+    g[G]
+  end
+  a --> c
+  b --> c
+  c --> d
+  d --> e
+  d --> f
+  f --> g`);
+      const r = layoutFlowchart(ast);
+      const cs = [...r.clusters].sort((a, b) => a.y - b.y);
+      expect(cs.length).toBe(4);
+      // Clusters must stack top-to-bottom in DSL order without horizontal
+      // cascade: y-spread must dominate x-spread.
+      const xs = cs.map((c) => c.x);
+      const ys = cs.map((c) => c.y);
+      const dx = Math.max(...xs) - Math.min(...xs);
+      const dy = Math.max(...ys) - Math.min(...ys);
+      expect(dy).toBeGreaterThan(dx);
+      // Bboxes must be strictly disjoint vertically (no y-range overlap).
+      for (let i = 0; i < cs.length - 1; i++) {
+        const aBottom = cs[i]!.y + cs[i]!.height;
+        const bTop = cs[i + 1]!.y;
+        expect(bTop).toBeGreaterThanOrEqual(aBottom);
+      }
+    });
+
+    test("parallel sibling clusters (no forward edge) still use lane fallback", () => {
+      // Two top-level subgraphs that share a layer via branching from a
+      // common root but have NO direct edge between them — these are
+      // genuinely parallel pipelines and must NOT be vertically stacked.
+      const ast = parseFlowchart(`flowchart TD
+Start --> L1
+Start --> R1
+subgraph Left [LeftPath]
+  L1
+  L1 --> L2
+end
+subgraph Right [RightPath]
+  R1
+  R1 --> R2
+end`);
+      const r = layoutFlowchart(ast);
+      const cs = r.clusters;
+      expect(cs.length).toBe(2);
+      // Parallel mode: clusters should be side-by-side, so x-spread should
+      // dominate or match y-spread. Stacking them vertically would be
+      // wrong for this topology.
+      const dx = Math.abs(cs[0]!.x - cs[1]!.x);
+      const dy = Math.abs(cs[0]!.y - cs[1]!.y);
+      expect(dx).toBeGreaterThan(dy);
+    });
+  });
+
   test("sequential clusters (TB) keep a centered straight spine", () => {
     // Pre / Intervention / Post each occupy a distinct layer range — lane
     // mode would push each cluster sideways. BK should keep the spine

--- a/tests/flowchart/layout.test.ts
+++ b/tests/flowchart/layout.test.ts
@@ -137,6 +137,55 @@ A -->|no| C[Reject]`);
     expect(cjkW).toBeGreaterThan(latinW);
   });
 
+  // ─── Multi-line label sizing (Track A Unit 1) ────────────────
+  describe("multi-line label sizing", () => {
+    test("<b>/<i> tags do not inflate measured width", () => {
+      const plain = measureLabelWidth("Important");
+      const bold = measureLabelWidth("<b>Important</b>");
+      const italic = measureLabelWidth("<i>Important</i>");
+      const mixed = measureLabelWidth("<b>Bold</b> and <i>italic</i>");
+      expect(bold).toBeCloseTo(plain, 1);
+      expect(italic).toBeCloseTo(plain, 1);
+      expect(mixed).toBeCloseTo(measureLabelWidth("Bold and italic"), 1);
+    });
+
+    test("<br/> width is max-of-lines, not concatenated", () => {
+      const oneLine = measureLabelWidth("aaaaaaaaaaaa");
+      const twoLines = measureLabelWidth("aaaaaaaaaaaa<br/>aaaaaaaaaaaa");
+      // Two-line label of identical lines should measure same width, not 2x
+      expect(twoLines).toBeCloseTo(oneLine, 1);
+    });
+
+    test("<br/> width picks widest line", () => {
+      const w = measureLabelWidth("short<br/>much longer line here");
+      const longerOnly = measureLabelWidth("much longer line here");
+      expect(w).toBeCloseTo(longerOnly, 1);
+    });
+
+    test("node height grows for multi-line <br/> labels", () => {
+      const single = layoutFlowchart(parseFlowchart('flowchart TD\nA["One line"]'));
+      const dual = layoutFlowchart(parseFlowchart('flowchart TD\nA["Line one<br/>Line two"]'));
+      const triple = layoutFlowchart(parseFlowchart('flowchart TD\nA["L1<br/>L2<br/>L3"]'));
+      const hSingle = single.nodes.find((n) => n.node.id === "A")!.height;
+      const hDual = dual.nodes.find((n) => n.node.id === "A")!.height;
+      const hTriple = triple.nodes.find((n) => n.node.id === "A")!.height;
+      // Each extra line adds ~lineHeight (14px). Allow tolerance for rounding.
+      expect(hDual - hSingle).toBeGreaterThanOrEqual(12);
+      expect(hTriple - hDual).toBeGreaterThanOrEqual(12);
+    });
+
+    test("multi-line label combined with <b> renders correct height", () => {
+      const ast = parseFlowchart(
+        'flowchart TD\nA["<b>Total</b><br/>n = 1,234"]'
+      );
+      const r = layoutFlowchart(ast);
+      const n = r.nodes.find((nn) => nn.node.id === "A")!;
+      // Two-line PRISMA-style label: bold header + count. Height must exceed
+      // single-line baseline.
+      expect(n.height).toBeGreaterThan(50);
+    });
+  });
+
   test("parallelogram with long CJK label fits inside slanted body", () => {
     const ast = parseFlowchart(
       "flowchart TD\nP[/基本資料、POMS量表、個人儀式感量表、配戴HRV/]"

--- a/tests/timeline/parser.test.ts
+++ b/tests/timeline/parser.test.ts
@@ -11,6 +11,65 @@ describe("timeline parser", () => {
     expect(ast.events[0]?.label).toBe("Eliezer born");
   });
 
+  // ─── Track A Unit 4: non-date row keys (ordinal mode) ────────
+  describe("ordinal row keys", () => {
+    test("non-date row key does not throw", () => {
+      expect(() => {
+        parseTimeline(`timeline "Roadmap"
+Phase 1 : "Discovery"
+Phase 2 : "Design"
+Phase 3 : "Build"`);
+      }).not.toThrow();
+    });
+
+    test("ordinal keys preserve raw label and assign sequential values", () => {
+      const ast = parseTimeline(`timeline
+Phase 1 : "Discovery"
+Phase 2 : "Design"
+Phase 3 : "Build"`);
+      expect(ast.events).toHaveLength(3);
+      expect(ast.events[0]!.start.precision).toBe("ordinal");
+      expect(ast.events[0]!.start.raw).toBe("Phase 1");
+      expect(ast.events[1]!.start.raw).toBe("Phase 2");
+      // Values are sequential so layout can still sort them.
+      expect(ast.events[1]!.start.value).toBeGreaterThan(ast.events[0]!.start.value);
+      expect(ast.events[2]!.start.value).toBeGreaterThan(ast.events[1]!.start.value);
+    });
+
+    test("multiple colons: only first separates key from body", () => {
+      const ast = parseTimeline(`timeline
+14:30 : "Standup : daily team meeting"`);
+      expect(ast.events).toHaveLength(1);
+      // Key was "14:30" which is not a valid date → ordinal mode preserving it.
+      expect(ast.events[0]!.start.precision).toBe("ordinal");
+      expect(ast.events[0]!.start.raw).toBe("14:30");
+      // Body kept the second colon intact.
+      expect(ast.events[0]!.label).toBe("Standup : daily team meeting");
+    });
+
+    test("mixing date and ordinal keys: both kinds parse", () => {
+      const ast = parseTimeline(`timeline "Mixed"
+2024 : "Real year"
+Phase X : "Ordinal label"
+2025 : "Another real year"`);
+      expect(ast.events).toHaveLength(3);
+      expect(ast.events[0]!.start.precision).toBe("year");
+      expect(ast.events[1]!.start.precision).toBe("ordinal");
+      expect(ast.events[2]!.start.precision).toBe("year");
+    });
+
+    test("ordinal keys inside a section/track work", () => {
+      const ast = parseTimeline(`timeline
+section "Project Phases"
+  Phase 1 : "Discovery"
+  Phase 2 : "Design"`);
+      expect(ast.tracks).toHaveLength(1);
+      expect(ast.events).toHaveLength(2);
+      expect(ast.events[0]!.start.precision).toBe("ordinal");
+      expect(ast.events[0]!.trackId).toBe(ast.tracks[0]!.id);
+    });
+  });
+
   test("track keyword groups events", () => {
     const ast = parseTimeline(`timeline
 track "Generation 1":


### PR DESCRIPTION
## Summary

Implements the 4 existing-engine improvements scoped in the private Track A impl plan. Each is committed as a separate atomic commit so reviewers can read them independently.

| Commit | Engine | What |
|---|---|---|
| `fix(flowchart): grow node height...` | flowchart | `<br/>` and `<b>`/`<i>` already rendered correctly, but layout sizing didn't strip markup from width measurement and didn't grow shape height for multi-line labels — fixed both |
| `fix(flowchart): vertical-stack sequential...` | flowchart | Sequential top-level subgraph chains (PRISMA pattern) now stack top-to-bottom instead of cascading diagonally. Parallel sibling clusters still use the lane fallback |
| `feat(timeline): accept non-date row keys` | timeline | Rows whose key fails date parsing fall back to ordinal mode with sequential layout values; `splitDateAndBody` now prefers `" : "` so `14:30 : "Standup"` parses correctly |
| `feat(circuit): add 7 industrial primitives` | circuit | `relay_coil` / `relay_no` / `relay_nc` / `contactor` / `solenoid_valve` / `thermal_overload` / `disconnect_switch` (IEC 60617) + DSL aliases (`coil`, `km`, `ev`, `thermal`, `disconnect`, ...) |

## Why now

- Flowchart label sizing + sequential cluster stacking are **hard prerequisites for the upcoming PRISMA engine** (4-row vertical layout, count on line 1, label on line 2). Without these, PRISMA cannot ship.
- Timeline ordinal keys had 3 documented user incidents (BR / HE / ES locales) hitting the same date-parse failure.
- Circuit industrial primitives serve 152+ industrial users from telemetry — schematics like motor starters were unrenderable without these symbols.

The Track A pre-implementation audit found that several items the original strategic report flagged as missing were **already implemented** (flowchart `classDef`, timeline `section`, genogram per-couple sibship, BPMN swimlane, circuit `terminal_block` / `voltage_regulator`). This PR includes only the verified-real gaps.

## What's NOT in this PR (deferred)

- Circuit `enclosure` dashed-rectangle container with `inside:` keyword — needs a new layout-grouping mechanic; follow-up PR.
- Coil↔contact mechanical-link dashed line for separated relay parts sharing a designator — small follow-up.
- BPMN swimlane audit — visual verification only, no code change expected.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 697 pass (was 674 at baseline; 23 new tests added across 4 units)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — produces valid dist/
- [x] PRISMA-style 4-cluster TD cascade case now stacks top-to-bottom (regression test added)
- [x] Parallel sibling clusters still use lane fallback (regression test added)
- [x] All 7 new circuit symbols register, parse via aliases, and render end-to-end
- [x] Timeline non-date keys parse without throwing; date+ordinal mix works
- [ ] Manual visual verification in website preview (recommended before merge)

## Files touched

```
src/core/types.ts                         (+5 lines — 4 new circuit types)
src/diagrams/flowchart/layout.ts          (+135 lines — labelLines helper, sizeOf height growth, enforceSequentialClusterLayers pass)
src/diagrams/timeline/types.ts            (+1 union member — "ordinal")
src/diagrams/timeline/dates.ts            (+14 lines — tryParseDate)
src/diagrams/timeline/parser.ts           (+30 lines — parseRowKey + counter threading + splitDateAndBody preference)
src/diagrams/circuit/parser.ts            (+10 lines — new COMPONENT_TYPES + aliases)
src/diagrams/circuit/symbols.ts           (+115 lines — 7 SymbolDefs + registry)

tests/flowchart/layout.test.ts            (+106 lines — multi-line sizing + sequential cluster cases)
tests/timeline/parser.test.ts             (+47 lines — ordinal mode)
tests/circuit/industrial-symbols.test.ts  (NEW — 11 tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
