### PR TITLE
feat(website): add /api/pseo/manifest endpoint (read-only, 3 types)

### DIFF
--- a/website/app/api/pseo/[action]/route.ts
+++ b/website/app/api/pseo/[action]/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic';
+
+export function POST() {
+  return Response.json({ ok: false, error: 'not_implemented' }, { status: 501 });
+}

--- a/website/app/api/pseo/manifest/route.ts
+++ b/website/app/api/pseo/manifest/route.ts
@@ -1,0 +1,59 @@
+import { source } from '@/lib/source';
+import { allExamples } from '@/lib/examples-source';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NOW = new Date().toISOString();
+
+export function GET(request: Request) {
+  const token = request.headers.get('x-pseo-auth');
+  if (!token || token !== process.env.PSEO_AUTH_TOKEN) {
+    return Response.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const manifest = {
+    product: 'schematex',
+    fetchedAt: new Date().toISOString(),
+    locales: { supported: ['en'], default: 'en' },
+    types: [
+      {
+        id: 'home',
+        name: 'Home',
+        urlSegment: '',
+        schemaJson: null,
+        slugs: [
+          { slug: '/', locale: 'en', status: 'live' as const, kind: 'page' as const, updatedAt: NOW },
+        ],
+      },
+      {
+        id: 'doc',
+        name: 'Documentation',
+        urlSegment: 'docs',
+        schemaJson: null,
+        slugs: source.getPages().map((page) => ({
+          slug: page.slugs.join('/') || 'index',
+          locale: 'en',
+          status: 'live' as const,
+          kind: 'page' as const,
+          updatedAt: NOW,
+        })),
+      },
+      {
+        id: 'example',
+        name: 'Examples',
+        urlSegment: 'examples',
+        schemaJson: null,
+        slugs: allExamples.map((ex) => ({
+          slug: ex.slug,
+          locale: 'en',
+          status: 'live' as const,
+          kind: 'page' as const,
+          updatedAt: NOW,
+        })),
+      },
+    ],
+  };
+
+  return Response.json(manifest);
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/pseo/manifest` so pSEO Cockpit can read Schematex page inventory
- Exposes 3 types: `home` (1 slug), `doc` (all fumadocs pages), `example` (88 published examples)
- All slugs are `status: live` — no DB needed, manifest is computed from static MDX collections at request time
- Auth via `X-PSEO-AUTH` header checked against `PSEO_AUTH_TOKEN` env var
- Adds stub `POST /api/pseo/[action]` returning 501 for write endpoints (keywords/claim/content/release/status) — wired once DB layer is added

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `GET /api/pseo/manifest` with correct `X-PSEO-AUTH` returns JSON with 3 types
- [ ] `GET /api/pseo/manifest` without header returns 401
- [ ] `home` type has 1 slug (`/`)
- [ ] `doc` type slug count matches `content/docs/*.mdx` file count
- [ ] `example` type has 88 slugs (all published examples)
- [ ] Add `PSEO_AUTH_TOKEN=<secret>` to Vercel env vars before registering in Cockpit

🤖 Generated with [Claude Code](https://claude.com/claude-code)