### PR TITLE
v0.6.9: LLM input recovery (fence strip + abbrev header) + circuit ERC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.9] — 2026-06-01
+
+### Added — LLM input recovery: code-fence stripping + abbreviated-header normalization (`src/core/api.ts`)
+
+Two cross-engine `preprocess`/detection passes that recover the most common ways an LLM mangles otherwise-valid DSL, instead of returning "cannot detect diagram type" / a header parse error. Both are pure input rewrites — no per-engine grammar changed.
+
+- **Markdown code-fence stripping.** Input wrapped in ```` ```mermaid … ``` ````, ```` ```schematex … ``` ````, or a bare ```` ``` … ``` ```` fence now has the fence lines removed before detection. Previously the opening fence line (` ```mermaid `) was read as the diagram header and the whole diagram failed to detect. A leading fence line and a trailing fence line are stripped independently, so a truncated artifact with only an opening fence is still recovered; unfenced input is untouched.
+- **Abbreviated-header normalization.** Once the target engine is known, a first-token header that is a prefix (≥3 chars) of the resolved diagram type is rewritten to the canonical keyword — `flow`→`flowchart`, `org`→`orgchart`, `gen`→`genogram`, `ped`→`pedigree`, `seq`→`sequence`, `socio`→`sociogram`, `eco`→`ecomap`. Headerless grammars (mindmap's `# Title`), already-canonical headers, and unrelated first tokens (e.g. flowchart's alternate `graph` keyword) are left untouched.
+- New test suite `tests/core/input-recovery.test.ts` (14 cases across fence stripping, abbreviation recovery, and the two combined).
+
+### Added — Circuit ERC (electrical-rule check) expansion (`src/diagrams/circuit/lint.ts`)
+
+The circuit `lint()` hook grew from the single under-specified-pin warning to a four-rule ERC pass. Every finding is **non-fatal** — the schematic still renders, the result is flagged `partial`, and the author gets an actionable message (degrade-not-reject).
+
+- **`CIRCUIT_DUPLICATE_ID`** — a reference designator declared twice (silently overwrites a pinMap entry). Runs in both positional and netlist modes.
+- **`CIRCUIT_NO_GROUND`** — the circuit has a source (`voltage_source` / `ac_source` / `battery` / `current_source`) but no ground reference anywhere; node voltages are undefined.
+- **`CIRCUIT_FLOATING_NET`** — a net only one pin connects to (dangling node), excluding intentional single-terminal reference symbols (ground / vcc / port / label / test_point / no_connect / antenna) and auto no-connect padding.
+- **`CIRCUIT_NET_TYPO`** — a dangling net whose name is one edit (Levenshtein) from a properly wired net (e.g. `vot` vs `vout`) — surfaced as a likely misspelled connection with a rename suggestion, in place of the generic floating-net warning.
+- Connectivity rules (no-ground / floating / typo) run only in netlist mode, where the net graph is authoritative; duplicate-id runs in both. New tests in `tests/circuit/erc.test.ts` (12 cases).
+
+---
+
 ## [0.6.8] — 2026-05-31
 
 ### Fixed — Block diagram: dangling output signals now render with label

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -155,8 +155,54 @@ function detectPlugin(text: string, config?: SchematexConfig): DiagramPlugin {
  * appended title are left alone — the frontmatter is silently dropped rather
  * than producing a misleading parse error.
  */
+/**
+ * Strip a Markdown code fence wrapping the whole input. LLMs very frequently
+ * wrap their diagram output in ```` ```mermaid … ``` ```` / ```` ``` … ``` ````
+ * fences; left in place the first line (` ```mermaid `) is treated as the
+ * diagram header and the entire diagram fails to detect/parse. We remove a
+ * leading fence line and a trailing fence line independently (so a truncated
+ * artifact with only an opening fence is still recovered). A bare ```` ``` ````
+ * line is never valid diagram syntax, so this is safe; inputs with no fence are
+ * returned untouched.
+ */
+function stripCodeFences(text: string): string {
+  let t = text;
+  t = t.replace(/^\uFEFF?[ \t]*```[A-Za-z0-9_-]*[ \t]*\r?\n/, "");
+  t = t.replace(/\r?\n[ \t]*```[ \t]*$/, "");
+  return t;
+}
+
+/**
+ * Forgive an abbreviated header keyword once the target engine is known.
+ * LLMs routinely shorten the type line (`flow` → flowchart, `org` → orgchart,
+ * `gen` → genogram, `ped` → pedigree, `seq` → sequence, `socio` → sociogram,
+ * `eco` → ecomap). When the first token is a prefix (≥3 chars) of the resolved
+ * diagram type, rewrite just that token to the canonical keyword so the
+ * per-engine header check passes. Headerless grammars (mindmap's `# Title`) and
+ * already-canonical / unrelated first tokens are left untouched.
+ */
+function normalizeHeader(text: string, type: string): string {
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i]!.trim();
+    if (!trimmed) continue;
+    const m = trimmed.match(/^([A-Za-z][A-Za-z0-9_-]*)/);
+    if (!m) return text;
+    const tok = m[1]!;
+    const lower = tok.toLowerCase();
+    if (lower === type) return text;
+    if (lower.length >= 3 && type.startsWith(lower)) {
+      const idx = lines[i]!.indexOf(tok);
+      lines[i] = lines[i]!.slice(0, idx) + type + lines[i]!.slice(idx + tok.length);
+      return lines.join("\n");
+    }
+    return text;
+  }
+  return text;
+}
+
 function preprocess(text: string): string {
-  const { data, body } = parseFrontmatter(text);
+  const { data, body } = parseFrontmatter(stripCodeFences(text));
   if (!data.title) return body;
   // Strip the title here — `data.title` was already unquoted by parseFrontmatter.
   const safeTitle = data.title.replace(/"/g, '\\"');
@@ -185,8 +231,9 @@ function preprocess(text: string): string {
  * ```
  */
 export function parse(text: string, config?: SchematexConfig): unknown {
-  const prepared = preprocess(text);
-  const plugin = detectPlugin(prepared, config);
+  const prepared0 = preprocess(text);
+  const plugin = detectPlugin(prepared0, config);
+  const prepared = normalizeHeader(prepared0, plugin.type);
   if (plugin.parse) return plugin.parse(prepared);
   throw new Error(
     `Diagram type '${plugin.type}' does not yet expose a parse() method.`
@@ -199,13 +246,14 @@ export function parseResult(
 ): SchematexParseResult {
   let plugin: DiagramPlugin | undefined;
   try {
-    const prepared = preprocess(text);
-    plugin = detectPlugin(prepared, config);
+    const prepared0 = preprocess(text);
+    plugin = detectPlugin(prepared0, config);
     if (!plugin.parse) {
       throw new Error(
         `Diagram type '${plugin.type}' does not yet expose a parse() method.`
       );
     }
+    const prepared = normalizeHeader(prepared0, plugin.type);
     const ast = plugin.parse(prepared);
     const diagnostics = runLint(plugin, prepared);
     return {
@@ -241,8 +289,9 @@ function runLint(plugin: DiagramPlugin, prepared: string): SchematexDiagnostic[]
 export function render(text: string, config?: SchematexConfig): string {
   if (config?.mode === "preview") return renderResult(text, config).svg;
 
-  const prepared = preprocess(text);
-  const plugin = detectPlugin(prepared, config);
+  const prepared0 = preprocess(text);
+  const plugin = detectPlugin(prepared0, config);
+  const prepared = normalizeHeader(prepared0, plugin.type);
   return renderWithPlugin(prepared, plugin, config);
 }
 
@@ -252,8 +301,9 @@ export function renderResult(
 ): SchematexRenderResult {
   let plugin: DiagramPlugin | undefined;
   try {
-    const prepared = preprocess(text);
-    plugin = detectPlugin(prepared, config);
+    const prepared0 = preprocess(text);
+    plugin = detectPlugin(prepared0, config);
+    const prepared = normalizeHeader(prepared0, plugin.type);
     const svg = renderWithPlugin(prepared, plugin, config);
     const diagnostics = runLint(plugin, prepared);
     return {

--- a/src/diagrams/circuit/lint.ts
+++ b/src/diagrams/circuit/lint.ts
@@ -1,16 +1,78 @@
 import type { SchematexDiagnostic } from "../../core/diagnostics";
-import type { CircuitAST } from "../../core/types";
+import type {
+  CircuitAST,
+  CircuitComponent,
+  CircuitComponentType,
+} from "../../core/types";
 import { parseCircuit } from "./parser";
 
 /**
- * Circuit recoverable-input lint.
+ * Circuit electrical-rule check (ERC) + recoverable-input lint.
  *
- * The netlist parser no longer throws when a multi-terminal component is given
- * fewer nets than it has pins — it binds the missing pins to floating
- * no-connect nets and draws the part anyway. This surfaces that recovery as a
- * warning so the render reports `partial` and the author can wire the open
- * terminals, without ever blanking a schematic that is otherwise complete.
+ * Every diagnostic here is **non-fatal** — the schematic still renders. Their
+ * only effect is to flip the result status to `partial` and surface the issue
+ * to the author. This follows Schematex's degrade-not-reject philosophy: we
+ * never blank a drawable schematic just because it is electrically suspect.
+ *
+ * Connectivity-based rules (floating nets, missing ground, net-name typos) need
+ * the authoritative net graph that only the **netlist** mode builds (`pinMap` +
+ * fully-populated `nets`). In positional mode connectivity is implicit in the
+ * direction chain and not captured in `nets`, so those rules are skipped there
+ * to avoid false positives. The duplicate-id rule runs in both modes.
+ *
+ * Rules:
+ *   - CIRCUIT_PIN_UNDERSPECIFIED — multi-terminal part given fewer nets than
+ *     pins (missing pins left floating). [both modes via recovered]
+ *   - CIRCUIT_DUPLICATE_ID        — same component id declared twice. [both]
+ *   - CIRCUIT_NO_GROUND           — has a source but no ground reference. [netlist]
+ *   - CIRCUIT_FLOATING_NET        — a node only one pin connects to. [netlist]
+ *   - CIRCUIT_NET_TYPO            — a dangling net one edit away from a wired
+ *     net (likely a misspelled connection). [netlist]
  */
+
+/** Symbols for which a net with a single connection is normal (reference/flag). */
+const INTENTIONAL_SINGLE_PIN = new Set<CircuitComponentType>([
+  "ground", "gnd_signal", "gnd_chassis", "gnd_digital",
+  "vcc", "antenna", "no_connect", "test_point", "label", "port",
+]);
+
+/** Energy sources that demand a ground/return reference. */
+const SOURCE_TYPES = new Set<CircuitComponentType>([
+  "voltage_source", "ac_source", "battery", "current_source",
+]);
+
+const GROUND_TYPES = new Set<CircuitComponentType>([
+  "ground", "gnd_signal", "gnd_chassis", "gnd_digital",
+]);
+
+/** Auto-synthesized floating no-connect nets from pin under-specification. */
+const NC_NET = /_nc\d+$/;
+
+function componentIdOfAnchor(anchor: string): string {
+  const dot = anchor.lastIndexOf(".");
+  return dot < 0 ? anchor : anchor.slice(0, dot);
+}
+
+/** Levenshtein distance, bailing out as soon as it provably exceeds `max`. */
+function editDistanceWithin(a: string, b: string, max: number): boolean {
+  if (Math.abs(a.length - b.length) > max) return false;
+  const prev = new Array<number>(b.length + 1);
+  const curr = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    let rowMin = curr[0];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > max) return false;
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+  return prev[b.length] <= max;
+}
+
 export function lintCircuit(text: string): SchematexDiagnostic[] {
   let ast: CircuitAST;
   try {
@@ -18,7 +80,30 @@ export function lintCircuit(text: string): SchematexDiagnostic[] {
   } catch {
     return [];
   }
+
   const out: SchematexDiagnostic[] = [];
+
+  // ── Duplicate component id (both modes) ───────────────────────────────────
+  // Auto-synthesized ids (auto ground, positional auto-ids) are unique by
+  // construction; user-authored collisions silently overwrite a pinMap entry.
+  const idCounts = new Map<string, number>();
+  for (const c of ast.components) {
+    if (c.id.startsWith("_")) continue; // engine-internal (e.g. _GND0)
+    idCounts.set(c.id, (idCounts.get(c.id) ?? 0) + 1);
+  }
+  for (const [id, n] of idCounts) {
+    if (n > 1) {
+      out.push({
+        severity: "error",
+        code: "CIRCUIT_DUPLICATE_ID",
+        message: `component id "${id}" is declared ${n} times; each reference designator must be unique`,
+        hint: `Rename the duplicates (e.g. ${id}, ${id}B). With a repeated id only the last line's connections are kept.`,
+        fatal: false,
+      });
+    }
+  }
+
+  // ── Under-specified multi-terminal parts (recovered during parse) ─────────
   for (const u of ast.recovered?.underspecified ?? []) {
     out.push({
       severity: "warning",
@@ -28,5 +113,72 @@ export function lintCircuit(text: string): SchematexDiagnostic[] {
       fatal: false,
     });
   }
+
+  // Connectivity ERC needs the authoritative netlist graph.
+  if (ast.mode !== "netlist") return out;
+
+  const compById = new Map<string, CircuitComponent>();
+  for (const c of ast.components) compById.set(c.id, c);
+
+  // ── No ground reference ───────────────────────────────────────────────────
+  // The netlist parser auto-creates a GND net + ground symbol whenever any pin
+  // references ground, so this only fires when the author never grounded at all.
+  const hasGround =
+    ast.nets.some((n) => n.id === "GND") ||
+    ast.components.some((c) => GROUND_TYPES.has(c.componentType));
+  const sources = ast.components.filter((c) => SOURCE_TYPES.has(c.componentType));
+  if (sources.length > 0 && !hasGround) {
+    out.push({
+      severity: "warning",
+      code: "CIRCUIT_NO_GROUND",
+      message: `circuit has ${sources.length} source(s) (e.g. ${sources[0].id}) but no ground reference; node voltages are undefined`,
+      hint: `Tie a return node to ground — name a net \`0\`/\`GND\` (e.g. \`${sources[0].id} ${sources[0].id.toLowerCase()}_out 0\`) or add a ground symbol.`,
+      fatal: false,
+    });
+  }
+
+  // ── Floating nets + likely net-name typos ─────────────────────────────────
+  // A net only one pin touches is a dangling node. Before flagging it as
+  // generically floating, check whether it is one edit away from a properly
+  // wired net — that points at a misspelled connection, which is far more
+  // actionable than "floating".
+  const wired = ast.nets.filter(
+    (n) => n.anchors.length >= 2 && !NC_NET.test(n.id)
+  );
+  for (const net of ast.nets) {
+    if (net.id === "GND") continue;            // ground rail fans out by nature
+    if (NC_NET.test(net.id)) continue;         // already covered by underspecified
+    if (net.anchors.length !== 1) continue;
+
+    const comp = compById.get(componentIdOfAnchor(net.anchors[0]));
+    if (comp && INTENTIONAL_SINGLE_PIN.has(comp.componentType)) continue;
+
+    const lower = net.id.toLowerCase();
+    const typoTarget = wired.find(
+      (w) =>
+        w.id.toLowerCase() !== lower &&
+        Math.max(w.id.length, net.id.length) >= 3 &&
+        editDistanceWithin(lower, w.id.toLowerCase(), 1)
+    );
+
+    if (typoTarget) {
+      out.push({
+        severity: "warning",
+        code: "CIRCUIT_NET_TYPO",
+        message: `net "${net.id}" connects to only one pin and is one character from "${typoTarget.id}" — likely a misspelled connection`,
+        hint: `If they are the same node, rename "${net.id}" to "${typoTarget.id}" so the pins join.`,
+        fatal: false,
+      });
+    } else {
+      out.push({
+        severity: "warning",
+        code: "CIRCUIT_FLOATING_NET",
+        message: `net "${net.id}" connects to only one pin (${net.anchors[0]}); nothing else joins this node`,
+        hint: `Wire "${net.id}" to another pin, or mark the pin as intentionally open with a no-connect.`,
+        fatal: false,
+      });
+    }
+  }
+
   return out;
 }

--- a/tests/circuit/erc.test.ts
+++ b/tests/circuit/erc.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "vitest";
+import { lintCircuit } from "../../src/diagrams/circuit/lint";
+import { renderResult } from "../../src/core/api";
+
+const codes = (dsl: string) => lintCircuit(dsl).map((d) => d.code);
+
+describe("circuit ERC — duplicate id", () => {
+  test("flags a reference designator declared twice", () => {
+    const diags = lintCircuit(
+      'circuit "dup" netlist\nV1 vin 0 5V\nR1 vin out 1k\nR1 out 0 2k'
+    );
+    const dup = diags.find((d) => d.code === "CIRCUIT_DUPLICATE_ID");
+    expect(dup).toBeDefined();
+    expect(dup!.severity).toBe("error");
+    expect(dup!.fatal).toBe(false);
+    expect(dup!.message).toContain("R1");
+  });
+
+  test("does not flag the auto-synthesized ground id", () => {
+    // GND reference auto-creates a `_GND0` ground symbol — must not count as dup.
+    const diags = lintCircuit('circuit "g" netlist\nV1 vin 0 5V\nR1 vin 0 1k');
+    expect(diags.map((d) => d.code)).not.toContain("CIRCUIT_DUPLICATE_ID");
+  });
+
+  test("unique ids produce no duplicate warning", () => {
+    expect(
+      codes('circuit "ok" netlist\nV1 vin 0 5V\nR1 vin out 1k\nR2 out 0 2k')
+    ).not.toContain("CIRCUIT_DUPLICATE_ID");
+  });
+});
+
+describe("circuit ERC — no ground reference", () => {
+  test("source present but never grounded is flagged", () => {
+    const diags = lintCircuit('circuit "fly" netlist\nV1 a b 5V\nR1 b a 1k');
+    const ng = diags.find((d) => d.code === "CIRCUIT_NO_GROUND");
+    expect(ng).toBeDefined();
+    expect(ng!.message).toContain("V1");
+  });
+
+  test("grounded circuit is clean", () => {
+    expect(
+      codes('circuit "ok" netlist\nV1 vin 0 5V\nR1 vin 0 1k')
+    ).not.toContain("CIRCUIT_NO_GROUND");
+  });
+
+  test("a source-less network is not forced to have ground", () => {
+    expect(
+      codes('circuit "passive" netlist\nR1 a b 1k\nR2 b c 1k')
+    ).not.toContain("CIRCUIT_NO_GROUND");
+  });
+});
+
+describe("circuit ERC — floating net", () => {
+  test("a net touched by only one pin is flagged", () => {
+    // R1.end -> `out` goes nowhere else.
+    const diags = lintCircuit('circuit "fl" netlist\nV1 vin 0 5V\nR1 vin out 1k');
+    const fl = diags.find((d) => d.code === "CIRCUIT_FLOATING_NET");
+    expect(fl).toBeDefined();
+    expect(fl!.message).toContain('"out"');
+  });
+
+  test("a fully wired divider has no floating nets", () => {
+    expect(
+      codes('circuit "div" netlist\nV1 vin 0 5V\nR1 vin mid 10k\nR2 mid 0 10k')
+    ).not.toContain("CIRCUIT_FLOATING_NET");
+  });
+
+  test("single-pin reference symbols (port) are not floating", () => {
+    expect(
+      codes(
+        'circuit "p" netlist\nV1 vin 0 5V\nR1 vin out 1k\nP1 out type=port'
+      )
+    ).not.toContain("CIRCUIT_FLOATING_NET");
+  });
+});
+
+describe("circuit ERC — net-name typo", () => {
+  test("a dangling net one edit from a wired net is reported as a typo, not floating", () => {
+    // `vot` is one deletion from the wired `vout` node.
+    const diags = lintCircuit(
+      'circuit "typo" netlist\nV1 vin 0 5V\nR1 vin vout 10k\nR2 vout 0 10k\nC1 vot 0 100n'
+    );
+    const codesList = diags.map((d) => d.code);
+    expect(codesList).toContain("CIRCUIT_NET_TYPO");
+    const typo = diags.find((d) => d.code === "CIRCUIT_NET_TYPO")!;
+    expect(typo.message).toContain('"vot"');
+    expect(typo.message).toContain('"vout"');
+    // the same net must not also be double-reported as generically floating
+    expect(
+      diags.filter(
+        (d) => d.code === "CIRCUIT_FLOATING_NET" && d.message.includes('"vot"')
+      )
+    ).toHaveLength(0);
+  });
+});
+
+describe("circuit ERC — status + non-fatal integration", () => {
+  test("ERC findings make render partial, never invalid, and SVG still renders", () => {
+    const r = renderResult('circuit "fly" netlist\nV1 a b 5V\nR1 b a 1k');
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe("partial");
+    expect(r.svg).toContain("<svg");
+  });
+
+  test("a clean grounded circuit reports valid", () => {
+    const r = renderResult(
+      'circuit "ok" netlist\nV1 vin 0 5V\nR1 vin mid 10k\nR2 mid 0 10k'
+    );
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe("valid");
+  });
+});

--- a/tests/core/input-recovery.test.ts
+++ b/tests/core/input-recovery.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "vitest";
+import { renderResult } from "../../src/core/api";
+
+const ok = (dsl: string, type?: import("../../src/core/api").SchematexConfig["type"]) =>
+  renderResult(dsl, type ? { type } : undefined);
+
+describe("markdown code-fence stripping (cross-engine)", () => {
+  test("```mermaid-wrapped flowchart still renders", () => {
+    const r = ok("```mermaid\nflowchart TD\n  A --> B\n```");
+    expect(r.ok).toBe(true);
+    expect(r.svg).toContain("<svg");
+  });
+
+  test("bare ```-wrapped genogram still renders", () => {
+    const r = ok("```\ngenogram\n  a [male]\n  b [female]\n  a -- b\n```");
+    expect(r.ok).toBe(true);
+    expect(r.type).toBe("genogram");
+  });
+
+  test("truncated artifact with only an opening fence is recovered", () => {
+    const r = ok("```mermaid\nflowchart LR\n  X --> Y");
+    expect(r.ok).toBe(true);
+  });
+
+  test("unfenced input is unaffected", () => {
+    const r = ok("flowchart TD\n  A --> B");
+    expect(r.ok).toBe(true);
+  });
+
+  test("a fence with a language tag (```schematex) is stripped", () => {
+    const r = ok("```schematex\norgchart\n  CEO\n  CEO -> CTO\n```");
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("abbreviated header recovery (engine known via config.type)", () => {
+  const CASES: [string, NonNullable<import("../../src/core/api").SchematexConfig["type"]>][] = [
+    ["flow\n  A --> B", "flowchart"],
+    ["org\n  CEO\n  CEO -> CTO", "orgchart"],
+    ["gen\n  a [male]\n  b [female]\n  a -- b", "genogram"],
+    ["ped\n  a [male]\n  b [female]", "pedigree"],
+    ["socio\n  alice\n  bob\n  alice -> bob", "sociogram"],
+    ["eco\n  center: maria [female]\n  work [label: \"Job\"]\n  maria --- work", "ecomap"],
+  ];
+  test.each(CASES)("%j recovers to its canonical header", (dsl, type) => {
+    const r = renderResult(dsl, { type });
+    expect(r.ok, JSON.stringify(r.diagnostics)).toBe(true);
+    expect(r.type).toBe(type);
+  });
+
+  test("canonical header is untouched (no double-rewrite)", () => {
+    const r = renderResult("flowchart TD\n  A --> B", { type: "flowchart" });
+    expect(r.ok).toBe(true);
+  });
+
+  test("an unrelated first token is not rewritten", () => {
+    // 'graph' is a valid flowchart header and not a prefix of 'flowchart' —
+    // must pass through unchanged.
+    const r = renderResult("graph TD\n  A --> B", { type: "flowchart" });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("fence + abbreviation combined", () => {
+  test("fenced AND abbreviated input both recovered", () => {
+    const r = renderResult("```\nflow\n  A --> B\n```", { type: "flowchart" });
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Two cross-engine LLM-input-recovery passes + a circuit ERC expansion. Bumps to **v0.6.9**. All additive / backward-compatible.

Grounded in ChatDiagram production telemetry (`diagram_errors`): these target the largest *recoverable* schematex error buckets — abbreviated headers (~446 errors / 279 users), code-fence-wrapped input ("no diagram type detected"), and silent-pass electrical mistakes.

## Changes

### `src/core/api.ts` — input recovery (cross-engine `preprocess` / detection)

- **Markdown code-fence stripping.** Input wrapped in ` ```mermaid … ``` `, ` ```schematex … ``` `, or a bare ` ``` … ``` ` fence has the fence lines removed before detection. Previously the opening fence line was read as the diagram header and the whole diagram failed to detect. Leading and trailing fence lines are stripped independently (a truncated artifact with only an opening fence is still recovered); unfenced input is untouched.
- **Abbreviated-header normalization.** Once the engine is known, a first-token header that is a prefix (≥3 chars) of the resolved type is rewritten to the canonical keyword: `flow`→`flowchart`, `org`→`orgchart`, `gen`→`genogram`, `ped`→`pedigree`, `seq`→`sequence`, `socio`→`sociogram`, `eco`→`ecomap`. Headerless grammars (mindmap `# Title`), already-canonical headers, and unrelated tokens (flowchart's alternate `graph`) are left untouched.

### `src/diagrams/circuit/lint.ts` — circuit ERC (electrical-rule check)

Grew the circuit `lint()` from the single under-specified-pin warning to a four-rule ERC pass. Every finding is **non-fatal** — the schematic still renders, status is `partial`, the author gets an actionable message (degrade-not-reject):

- `CIRCUIT_DUPLICATE_ID` — reference designator declared twice (both modes).
- `CIRCUIT_NO_GROUND` — has a source but no ground reference anywhere.
- `CIRCUIT_FLOATING_NET` — a net only one pin connects to (excludes intentional single-terminal symbols + auto no-connect padding).
- `CIRCUIT_NET_TYPO` — a dangling net one edit (Levenshtein) from a wired net (e.g. `vot` vs `vout`) → rename suggestion instead of the generic floating-net warning.

Connectivity rules run in netlist mode (authoritative net graph); duplicate-id runs in both.

## Tests / gate

- New: `tests/core/input-recovery.test.ts` (14), `tests/circuit/erc.test.ts` (12).
- Full suite: **100 files pass**; the only failures are the 5 pre-existing P&ID layout tests (unrelated, tracked in `docs/issues/06-pid-layout-quality.md`).
- typecheck rc=0 · lint 0 errors · build rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
