### PR TITLE
fix(publish): point repository URL to SchemaTex/SchemaTex (unblock npm provenance)

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,11 +172,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/victorzhrn/Schematex"
+    "url": "https://github.com/SchemaTex/SchemaTex"
   },
   "homepage": "https://schematex.js.org",
   "bugs": {
-    "url": "https://github.com/victorzhrn/Schematex/issues"
+    "url": "https://github.com/SchemaTex/SchemaTex/issues"
   },
   "peerDependencies": {
     "ai": ">=5.0.0",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -49,4 +49,4 @@ Example Claude Desktop config (`~/Library/Application Support/Claude/claude_desk
 
 ## License
 
-AGPL-3.0-only. See the root [Schematex repo](https://github.com/victorzhrn/Schematex) for commercial licensing.
+AGPL-3.0-only. See the root [Schematex repo](https://github.com/SchemaTex/SchemaTex) for commercial licensing.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -38,12 +38,12 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/victorzhrn/Schematex",
+    "url": "https://github.com/SchemaTex/SchemaTex",
     "directory": "packages/mcp"
   },
   "homepage": "https://schematex.js.org",
   "bugs": {
-    "url": "https://github.com/victorzhrn/Schematex/issues"
+    "url": "https://github.com/SchemaTex/SchemaTex/issues"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Schematex website
 
-Landing + docs + examples site for [Schematex](https://github.com/victorzhrn/Schematex).
+Landing + docs + examples site for [Schematex](https://github.com/SchemaTex/SchemaTex).
 
 Built with **Next.js 15** + **Fumadocs** + **Tailwind v4**. Deployed to
 Vercel at [schematex.dev](https://schematex.dev).

--- a/website/lib/github-stats.ts
+++ b/website/lib/github-stats.ts
@@ -1,4 +1,4 @@
-const REPO = 'victorzhrn/Schematex';
+const REPO = 'SchemaTex/SchemaTex';
 const NPM_PKG = 'schematex';
 const REVALIDATE = 3600; // 1 hour
 


### PR DESCRIPTION
## Why

The v0.6.9 auto-publish to npm **failed** — that's why `schematex@0.6.9` isn't on npm (latest is still 0.6.8) even though main is at 0.6.9.

Root cause (from the failed `Publish` workflow run):

```
npm error 422 Unprocessable Entity — Error verifying sigstore provenance bundle:
package.json "repository.url" is "git+https://github.com/victorzhrn/Schematex.git",
expected to match "https://github.com/SchemaTex/SchemaTex" from provenance.
```

`npm publish --provenance` requires `package.json` `repository.url` to match the GitHub repo it builds from. It still pointed at the old personal repo `victorzhrn/Schematex`.

## What

Replace all stale `victorzhrn/Schematex` repo references with `SchemaTex/SchemaTex`:
- root `package.json` — `repository.url` + `bugs.url` (the provenance blocker)
- `packages/mcp/package.json` — same fields (so the MCP package can publish with provenance too)
- `website/README.md`, `packages/mcp/README.md` — doc links
- `website/lib/github-stats.ts` — `REPO` constant (so star counts read the canonical repo)

Victor's personal `@victorzhrn` profile link in `CONTRIBUTING.md` is intentionally left unchanged.

## Release

No version bump. The publish workflow republishes **0.6.9** on the next push to `main` (it gates on "is this version already on npm?" — 0.6.9 is not). Merging this PR triggers that push and should publish 0.6.9 with valid provenance.

(Separately, the `CI` workflow is red on the 5 pre-existing P&ID layout tests tracked in `docs/issues/06-pid-layout-quality.md` — unrelated to publish, which builds independently.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
