### PR TITLE
fix(pid): implement the 5 pending P&ID layout-quality features (v0.6.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.10] — 2026-06-02
+
+### Fixed — P&ID layout quality: the 5 long-pending renderer tests now pass
+
+Implemented (not skipped) the five P&ID visual-quality features written in v0.6.4 as acceptance tests and tracked in `docs/issues/06-pid-layout-quality.md`. The full suite is now green (was 100 files pass / 1 fail).
+
+- **Minor-process line class** (`src/diagrams/pid/renderer.ts`): line types now map to explicit CSS classes — `process` → `lt-pid-process`, `process_minor` → `lt-pid-process-min` (was the unstyled `lt-pid-process-minor`).
+- **No-fill guard class**: every line `<path>` now carries a shared `lt-pid-line-path` class (with `.lt-pid-line-path { fill: none; }`), so no line can inherit a fill.
+- **Z-order layering**: render split into ordered groups — process pipes (`lt-pid-process-lines`) behind equipment (`lt-pid-equipment`), with signal lines (`lt-pid-signal-lines`) + instruments above.
+- **Line-mounted instrument placement** (`src/diagrams/pid/layout.ts`): an instrument that `measures`/`controls` a *pipe* (not equipment) now anchors to that pipe's midpoint x instead of a fixed offset.
+- **Instrument fan-out**: fixed the de-overlap sweep so 3+ instruments that collapse onto the same anchor (e.g. several on one vessel) all spread ≥40px apart — previously only the second one moved.
+
+P&ID-engine-internal; no other engine touched. All 21 P&ID tests + the full 1140-test suite pass.
+
+---
+
 ## [0.6.9] — 2026-06-01
 
 ### Added — LLM input recovery: code-fence stripping + abbreviated-header normalization (`src/core/api.ts`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/pid/layout.ts
+++ b/src/diagrams/pid/layout.ts
@@ -139,6 +139,28 @@ export function layoutPid(ast: PidAST): PidLayoutResult {
     cursorX += geo.width + EQUIP_GAP_X;
   }
 
+  // 1b. Pre-compute pipe midpoints (equipment→equipment lines only) so that a
+  // line-mounted instrument can anchor to the pipe it measures, not a fixed
+  // offset. Signal lines (instrument→instrument) are excluded — they have no
+  // anchor until instruments are placed.
+  const lineMidById = new Map<string, { x: number; y: number }>();
+  for (const ln of ast.lines) {
+    const from = equipById.get(ln.from.id);
+    const to = equipById.get(ln.to.id);
+    if (!from || !to) continue;
+    const fa = getAnchor(from, ln.from.port, "out");
+    const ta = getAnchor(to, ln.to.port, "in");
+    lineMidById.set(ln.id, { x: (fa.x + ta.x) / 2, y: (fa.y + ta.y) / 2 });
+  }
+  // Resolve a target id (equipment or pipe) to an x anchor, else a fallback.
+  const targetX = (tgt: string, fallback: number): number => {
+    const eq = equipById.get(tgt);
+    if (eq) return eq.cx;
+    const lm = lineMidById.get(tgt);
+    if (lm) return lm.x;
+    return fallback;
+  };
+
   // 2. Place instruments.
   // Field instruments → near their measured equipment (below it).
   // Control-room instruments → above the equipment row (in a virtual control-room band).
@@ -154,21 +176,18 @@ export function layoutPid(ast: PidAST): PidLayoutResult {
     if (inst.category.startsWith("cr_")) {
       // place in CR band; x aligns roughly to the controlled valve or the measured equipment.
       const tgt = inst.controls ?? inst.measures ?? "";
-      const tgtEq = equipById.get(tgt);
-      cx = tgtEq ? tgtEq.cx : PADDING + 80 + crSlot * (INST_RADIUS * 2 + 28);
+      cx = targetX(tgt, PADDING + 80 + crSlot * (INST_RADIUS * 2 + 28));
       cy = crBandY;
       crSlot += 1;
     } else if (inst.category.startsWith("local_")) {
       cy = rowY + maxH / 2 + INST_OFFSET + INST_RADIUS;
       const tgt = inst.measures ?? inst.controls ?? "";
-      const tgtEq = equipById.get(tgt);
-      cx = tgtEq ? tgtEq.cx : PADDING + 80;
+      cx = targetX(tgt, PADDING + 80);
     } else {
-      // field — directly below the related equipment
+      // field — below the equipment or pipe it monitors
       cy = rowY + maxH / 2 + INST_OFFSET;
       const tgt = inst.measures ?? inst.controls ?? "";
-      const tgtEq = equipById.get(tgt);
-      cx = tgtEq ? tgtEq.cx : PADDING + 80;
+      cx = targetX(tgt, PADDING + 80);
     }
 
     const lay: PidLayoutInstrument = {
@@ -181,15 +200,20 @@ export function layoutPid(ast: PidAST): PidLayoutResult {
     instById.set(inst.tag, lay);
   }
 
-  // Avoid overlapping field/local instruments by nudging their x where needed.
-  const sameRow = (a: PidLayoutInstrument, b: PidLayoutInstrument) =>
-    Math.abs(a.cy - b.cy) < INST_RADIUS && Math.abs(a.cx - b.cx) < INST_RADIUS * 2 + 8;
+  // Fan out instruments that share a row (e.g. several instruments on the same
+  // equipment all anchor to its center). Sweep left→right and push each one to
+  // at least INST_FANOUT past the previous on the same row. Comparing against
+  // the *running* position (not the original) is what lets 3+ collapsed
+  // instruments all spread, instead of only the second one moving.
+  const INST_FANOUT = INST_RADIUS * 2 + 12; // 40px ≥ the 38px min separation
+  const sameYRow = (a: PidLayoutInstrument, b: PidLayoutInstrument) =>
+    Math.abs(a.cy - b.cy) < INST_RADIUS;
   const sortedByX = [...instruments].sort((a, b) => a.cx - b.cx);
   for (let i = 1; i < sortedByX.length; i++) {
     const prev = sortedByX[i - 1]!;
     const cur = sortedByX[i]!;
-    if (sameRow(prev, cur)) {
-      cur.cx = prev.cx + INST_RADIUS * 2 + 14;
+    if (sameYRow(prev, cur) && cur.cx < prev.cx + INST_FANOUT) {
+      cur.cx = prev.cx + INST_FANOUT;
     }
   }
 

--- a/src/diagrams/pid/renderer.ts
+++ b/src/diagrams/pid/renderer.ts
@@ -27,6 +27,7 @@ const STYLE = `
 .lt-inst-local-line { stroke: #1d1d1d; stroke-width: 1; stroke-dasharray: 2 2; }
 .lt-pid-valve-body { fill: #ffffff; stroke: #1d1d1d; stroke-width: 1.4; }
 
+.lt-pid-line-path { fill: none; }
 .lt-pid-line-tag-bg { fill: #ffffff; stroke: #1d1d1d; stroke-width: 0.6; }
 .lt-pid-line-tag-text { font: 9px ui-monospace, monospace; fill: #1d1d1d; }
 
@@ -39,8 +40,29 @@ const STYLE = `
 
 const ARROW_ID = "lt-pid-arrow";
 
+/** Line-type → CSS class. `process_minor` → `lt-pid-process-min` (matches STYLE). */
+const LINE_CLASS: Record<string, string> = {
+  process: "lt-pid-process",
+  process_minor: "lt-pid-process-min",
+  pneumatic: "lt-pid-pneumatic",
+  electric: "lt-pid-electric",
+  hydraulic: "lt-pid-hydraulic",
+  capillary: "lt-pid-capillary",
+  software: "lt-pid-software",
+  mechanical: "lt-pid-mechanical",
+};
+
+/** Signal (instrument) line types — rendered above equipment in z-order. */
+const SIGNAL_LINE_TYPES = new Set([
+  "pneumatic", "electric", "hydraulic", "capillary", "software", "mechanical",
+]);
+
 function lineClass(t: PidLayoutLine["line"]["lineType"]): string {
-  return `lt-pid-${t.replace("_", "-")}`;
+  return LINE_CLASS[t] ?? `lt-pid-${String(t).replace(/_/g, "-")}`;
+}
+
+function isSignalLine(l: PidLayoutLine): boolean {
+  return SIGNAL_LINE_TYPES.has(l.line.lineType);
 }
 
 function renderLine(l: PidLayoutLine): string {
@@ -48,7 +70,8 @@ function renderLine(l: PidLayoutLine): string {
   const parts: string[] = [
     pathEl({
       d: l.path,
-      class: cls,
+      // Type class + a shared no-fill guard class on every line path.
+      class: `${cls} lt-pid-line-path`,
       "data-line-id": l.line.id,
       "data-service": l.line.service ?? "",
     }),
@@ -239,9 +262,16 @@ function renderLayout(layout: PidLayoutResult): string {
         el("style", {}, STYLE),
       ]),
       titleNode,
+      // Z-order: process pipes behind equipment; signal lines + instruments above.
+      group(
+        { class: "lt-pid-lines lt-pid-process-lines" },
+        layout.lines.filter((l) => !isSignalLine(l)).map(renderLine)
+      ),
       group({ class: "lt-pid-equipment" }, equipNodes),
-      group({ class: "lt-pid-lines" }, layout.lines.map(renderLine)),
-      group({ class: "lt-pid-signals" }, autoSignals),
+      group(
+        { class: "lt-pid-lines lt-pid-signal-lines" },
+        [...layout.lines.filter(isSignalLine).map(renderLine), ...autoSignals]
+      ),
       group({ class: "lt-pid-instruments" }, instNodes),
     ]
   );


### PR DESCRIPTION
## What

**Properly implements** the 5 long-pending P&ID layout-quality features (no `skip`). These were written as acceptance tests in v0.6.4 and have kept CI red ever since. The full suite is now green: **101 files / 1140 tests pass** (was 100 pass / 1 fail).

## The 5 fixes

**`src/diagrams/pid/renderer.ts`**
1. **Minor-process line class** — line types map to explicit CSS classes; `process_minor` → `lt-pid-process-min` (was the unstyled `lt-pid-process-minor`).
2. **No-fill guard class** — every line `<path>` carries a shared `lt-pid-line-path` class (`.lt-pid-line-path { fill: none; }`), so no line inherits a fill.
3. **Z-order layering** — render split into ordered groups: process pipes (`lt-pid-process-lines`) **behind** equipment (`lt-pid-equipment`), signal lines (`lt-pid-signal-lines`) + instruments **above**.

**`src/diagrams/pid/layout.ts`**
4. **Line-mounted instrument placement** — an instrument that `measures`/`controls` a *pipe* (not equipment) now anchors to that pipe's midpoint x, not a fixed offset.
5. **Instrument fan-out** — fixed the de-overlap sweep so 3+ instruments collapsing onto the same anchor (e.g. several on one vessel) all spread ≥40px apart. Previously only the second one moved (it compared each instrument against the *original* neighbour position instead of the running one).

## Why not skip

The tests describe real visual-quality behaviour (correct CSS, draw order, instrument placement) that P&ID users see. Skipping would hide it; this implements it. Changes are **P&ID-engine-internal** — no other engine touched, so cross-engine regression risk is nil.

## Verification

- 21 P&ID tests pass (the 6 renderer + 8 lint + 7 graceful-degradation).
- Full suite: **101 files / 1140 tests pass, 0 failures** → CI goes green.
- typecheck clean · lint 0 errors · build rc=0.

## Release

Bumps **0.6.9 → 0.6.10** + CHANGELOG (the render output changes, so it warrants a version). Merging triggers the auto-publish workflow to ship 0.6.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
