### PR TITLE
docs(matrix): add monohybrid + test-cross Punnett gallery examples

### DIFF
--- a/examples/matrix/punnett-testcross.svg
+++ b/examples/matrix/punnett-testcross.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="sx-matrix sx-punnett" data-diagram-type="matrix" data-mode="punnett" width="360" height="362" viewBox="0 0 360 362" role="graphics-document"><title>Punnett square — Test cross  (Bb × bb)</title>
+<desc>Punnett square — monohybrid cross Bb × bb; phenotype ratio 1:1</desc>
+<defs><style>.sx-matrix { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+.sx-matrix-title { font: 600 16px sans-serif; fill: #111; }
+.sx-matrix-grid { stroke: #e5e7eb; stroke-width: 1; fill: none; }
+.sx-matrix-mid { stroke: #9ca3af; stroke-width: 1.2; stroke-dasharray: 4 3; fill: none; }
+.sx-matrix-plot-border { stroke: #374151; stroke-width: 1.2; fill: none; }
+.sx-matrix-axis-label { font: 500 12px sans-serif; fill: #374151; }
+.sx-matrix-axis-end { font: 500 11px sans-serif; fill: #6b7280; }
+.sx-matrix-quad-annot { font: 600 13px sans-serif; fill: #475569; opacity: 0.75; }
+.sx-matrix-quad-desc { font: 400 10.5px sans-serif; fill: #64748b; opacity: 0.85; }
+.sx-matrix-corr-header { font: 600 11.5px sans-serif; fill: #1f2937; text-anchor: middle; }
+.sx-matrix-corr-rowlabel { font: 500 11.5px sans-serif; fill: #1f2937; text-anchor: end; dominant-baseline: central; }
+.sx-matrix-corr-margin { font: 500 11px sans-serif; fill: #374151; text-anchor: middle; dominant-baseline: central; }
+.sx-matrix-corr-margin-best { font: 700 11.5px sans-serif; fill: #111; text-anchor: middle; dominant-baseline: central; }
+.sx-matrix-corr-grid { stroke: #d1d5db; stroke-width: 0.8; fill: none; }
+.sx-matrix-corr-rowbg-a { fill: #f0fdf4; }
+.sx-matrix-corr-rowbg-b { fill: #fff; }
+.sx-matrix-cell-label { font: 500 12px sans-serif; fill: #1f2937; text-anchor: middle; }
+.sx-matrix-cell-title { font: 600 13px sans-serif; fill: #111827; }
+.sx-matrix-cell-subtitle { font: 400 11px sans-serif; fill: #6b7280; }
+.sx-matrix-cell-item { font: 500 12px sans-serif; fill: #1f2937; }
+.sx-matrix-cell-value { font: 600 18px sans-serif; fill: #111; text-anchor: middle; }
+.sx-matrix-bubble { stroke-width: 1.5; }
+.sx-matrix-label { font: 500 11px sans-serif; fill: #111827; text-anchor: middle; dominant-baseline: central; pointer-events: none; }
+.sx-matrix-leader { stroke: #94a3b8; stroke-width: 0.6; opacity: 0.7; fill: none; }
+.sx-matrix-legend-text { font: 500 11px sans-serif; fill: #374151; }
+.sx-matrix-offchart { fill: #ea580c; }
+.sx-sipoc-header { font: 700 13px sans-serif; fill: #fff; text-anchor: middle; dominant-baseline: central; }
+.sx-sipoc-headbox { stroke: #fff; stroke-width: 1; }
+.sx-sipoc-cell { fill: #fff; stroke: #cbd5e1; stroke-width: 1; }
+.sx-sipoc-cell-alt { fill: #f8fafc; stroke: #cbd5e1; stroke-width: 1; }
+.sx-sipoc-process { fill: #eff6ff; stroke: #cbd5e1; stroke-width: 1; }
+.sx-sipoc-item { font: 500 12px sans-serif; fill: #1f2937; text-anchor: middle; dominant-baseline: central; }
+.sx-sipoc-step { font: 600 12px sans-serif; fill: #1e3a8a; text-anchor: middle; dominant-baseline: central; }
+.sx-qfd-grid { stroke: #cbd5e1; stroke-width: 1; fill: none; }
+.sx-qfd-cellbg { fill: #fff; }
+.sx-qfd-cellbg-alt { fill: #f8fafc; }
+.sx-qfd-what { font: 500 12px sans-serif; fill: #1f2937; text-anchor: end; dominant-baseline: central; }
+.sx-qfd-how { font: 500 11.5px sans-serif; fill: #1f2937; }
+.sx-qfd-weight { font: 600 12px sans-serif; fill: #111; text-anchor: middle; dominant-baseline: central; }
+.sx-qfd-weight-head { font: 600 10px sans-serif; fill: #475569; text-anchor: middle; dominant-baseline: central; }
+.sx-qfd-rel-strong { fill: #2563eb; }
+.sx-qfd-rel-medium { fill: #93c5fd; stroke: #2563eb; stroke-width: 1.4; }
+.sx-qfd-rel-weak { fill: none; stroke: #2563eb; stroke-width: 1.4; }
+.sx-qfd-roof-cell { fill: #f8fafc; stroke: #94a3b8; stroke-width: 0.8; }
+.sx-qfd-roof-cell-filled { fill: #eef2ff; stroke: #64748b; stroke-width: 0.9; }
+.sx-qfd-corr { font: 700 13px sans-serif; text-anchor: middle; dominant-baseline: central; }
+.sx-qfd-corr-strong-pos { fill: #15803d; }
+.sx-qfd-corr-pos { fill: #16a34a; }
+.sx-qfd-corr-neg { fill: #dc2626; }
+.sx-qfd-corr-strong-neg { fill: #b91c1c; }
+.sx-qfd-imp-band { fill: #eff6ff; stroke: #cbd5e1; stroke-width: 1; }
+.sx-qfd-imp-head { font: 600 11px sans-serif; fill: #1e3a8a; text-anchor: end; dominant-baseline: central; }
+.sx-qfd-imp-value { font: 700 13px sans-serif; fill: #1e3a8a; text-anchor: middle; dominant-baseline: central; }
+.sx-qfd-imp-value-top { font: 800 14px sans-serif; fill: #dc2626; text-anchor: middle; dominant-baseline: central; }
+.sx-qfd-dir { font: 700 13px sans-serif; fill: #475569; text-anchor: middle; dominant-baseline: central; }
+.sx-punnett-corner { fill: #f1f5f9; stroke: #94a3b8; stroke-width: 1; }
+.sx-punnett-cornerline { stroke: #cbd5e1; stroke-width: 1; }
+.sx-punnett-corner-p1 { font: 600 11px sans-serif; fill: #1e3a8a; dominant-baseline: hanging; }
+.sx-punnett-corner-p2 { font: 600 11px sans-serif; fill: #1e3a8a; }
+.sx-punnett-header { fill: #e2e8f0; stroke: #94a3b8; stroke-width: 1; }
+.sx-punnett-gamete { font: 700 14px ui-monospace, "SF Mono", Menlo, monospace; fill: #0f172a; text-anchor: middle; dominant-baseline: central; }
+.sx-punnett-cell { stroke: #94a3b8; stroke-width: 1; }
+.sx-punnett-genotype { font: 700 15px ui-monospace, "SF Mono", Menlo, monospace; fill: #0f172a; text-anchor: middle; dominant-baseline: central; }
+.sx-punnett-footer-head { font: 700 13px sans-serif; fill: #111; }
+.sx-punnett-legend { font: 500 12.5px sans-serif; fill: #1f2937; dominant-baseline: central; }
+.sx-punnett-geno-ratio { font: 500 12px sans-serif; fill: #475569; }
+.sx-punnett-hint { font: 500 13px sans-serif; fill: #64748b; text-anchor: middle; }</style></defs>
+<text x="180" y="24" class="sx-matrix-title" text-anchor="middle">Test cross  (Bb × bb)</text>
+<rect x="24" y="64" width="52" height="52" class="sx-punnett-corner"/>
+<line x1="24" y1="64" x2="76" y2="116" class="sx-punnett-cornerline"/>
+<text x="70" y="72" class="sx-punnett-corner-p1" text-anchor="end">Bb</text>
+<text x="30" y="108" class="sx-punnett-corner-p2" text-anchor="start">bb</text>
+<rect x="76" y="64" width="52" height="52" class="sx-punnett-header"/>
+<text x="102" y="90" class="sx-punnett-gamete">B</text>
+<rect x="128" y="64" width="52" height="52" class="sx-punnett-header"/>
+<text x="154" y="90" class="sx-punnett-gamete">b</text>
+<rect x="24" y="116" width="52" height="52" class="sx-punnett-header"/>
+<text x="50" y="142" class="sx-punnett-gamete">b</text>
+<rect x="24" y="168" width="52" height="52" class="sx-punnett-header"/>
+<text x="50" y="194" class="sx-punnett-gamete">b</text>
+<rect x="76" y="116" width="52" height="52" fill="#dcfce7" class="sx-punnett-cell"/>
+<text x="102" y="142" class="sx-punnett-genotype">Bb</text>
+<rect x="128" y="116" width="52" height="52" fill="#dbeafe" class="sx-punnett-cell"/>
+<text x="154" y="142" class="sx-punnett-genotype">bb</text>
+<rect x="76" y="168" width="52" height="52" fill="#dcfce7" class="sx-punnett-cell"/>
+<text x="102" y="194" class="sx-punnett-genotype">Bb</text>
+<rect x="128" y="168" width="52" height="52" fill="#dbeafe" class="sx-punnett-cell"/>
+<text x="154" y="194" class="sx-punnett-genotype">bb</text>
+<text x="24" y="256" class="sx-punnett-footer-head">Phenotype ratio  1:1</text>
+<rect x="24" y="270" width="14" height="14" fill="#dbeafe" stroke="#2563eb" stroke-width="1.4"/>
+<text x="46" y="278" class="sx-punnett-legend">2 × Blue</text>
+<rect x="24" y="292" width="14" height="14" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
+<text x="46" y="300" class="sx-punnett-legend">2 × Brown</text>
+<text x="24" y="326" class="sx-punnett-geno-ratio">Genotype ratio  1:1  —  2 bb, 2 Bb</text></svg>

--- a/scripts/gen-examples.mjs
+++ b/scripts/gen-examples.mjs
@@ -134,6 +134,10 @@ roof (1,2): +`],
 cross: Bb x Bb
 trait B: "Brown eyes" / "Blue eyes"`],
 
+  ['examples/matrix/punnett-testcross.svg', `matrix punnett "Test cross  (Bb × bb)"
+cross: Bb x bb
+trait B: "Brown" / "Blue"`],
+
   ['examples/matrix/punnett-dihybrid.svg', `matrix punnett "Seed shape & colour  (RrYy × RrYy)"
 cross: RrYy x RrYy
 trait R: "Round" / "Wrinkled"

--- a/src/ai/_generated.ts
+++ b/src/ai/_generated.ts
@@ -1380,6 +1380,44 @@ export const EXAMPLES: readonly GeneratedExample[] = [
     "notes": "## What this shows\n\nA **Punnett square** predicts the offspring of a genetic cross. You write only the two parental genotypes — the engine does the Mendelian bookkeeping: it enumerates each parent's **gametes** (one allele per gene locus), fills the grid with every gamete combination, and counts the resulting **genotype and phenotype ratios**.\n\nThis is a **dihybrid** cross (two genes at once) — Mendel's classic pea experiment crossing seed shape (`R` round dominant / `r` wrinkled) with seed colour (`Y` yellow dominant / `y` green). Two heterozygous parents each produce four gametes (RY, Ry, rY, ry), so the grid is 4×4 = 16 boxes. The engine computes the famous **9:3:3:1** phenotype ratio — 9 round-yellow : 3 wrinkled-yellow : 3 round-green : 1 wrinkled-green — and tints each box by its phenotype class so the ratio is visible at a glance. Case sets dominance (uppercase = dominant), and the optional `trait` lines name each phenotype so the legend reads in plain English."
   },
   {
+    "slug": "matrix-punnett-monohybrid",
+    "diagram": "matrix",
+    "title": "Monohybrid cross Punnett square (3:1)",
+    "description": "The classic single-gene Punnett square — two heterozygous parents (Bb × Bb) crossed for eye colour. The engine computes the gametes, the 2×2 grid, and the canonical 3:1 dominant-to-recessive phenotype ratio with a 1:2:1 genotype ratio.",
+    "standard": "Mendelian genetics (Punnett square)",
+    "tags": [
+      "matrix",
+      "punnett",
+      "genetics",
+      "mendel",
+      "monohybrid",
+      "biology"
+    ],
+    "complexity": 1,
+    "featured": false,
+    "dsl": "matrix punnett \"Eye color  (Bb × Bb)\"\ncross: Bb x Bb\ntrait B: \"Brown eyes\" / \"Blue eyes\"",
+    "notes": "## What this shows\n\nThe **monohybrid cross** is where every genetics course starts: one gene, two heterozygous parents. Here both parents are `Bb` for eye colour — `B` (brown) is dominant, `b` (blue) recessive. You write only the cross; the engine does the Mendelian bookkeeping.\n\nEach `Bb` parent makes two gametes, `B` and `b`, so the grid is 2×2. The engine fills it — `BB`, `Bb`, `Bb`, `bb` — and computes the two ratios every student memorises: a **3:1 phenotype ratio** (3 brown-eyed : 1 blue-eyed) and a **1:2:1 genotype ratio** (1 `BB` : 2 `Bb` : 1 `bb`). The single recessive `bb` box is tinted apart from the three dominant boxes, and the `trait` line names the phenotypes so the legend reads in plain English. Allele case sets dominance — uppercase is dominant — so the notation is exactly what a textbook uses."
+  },
+  {
+    "slug": "matrix-punnett-testcross",
+    "diagram": "matrix",
+    "title": "Test cross Punnett square (1:1)",
+    "description": "A genetic test cross — crossing an organism of unknown genotype against a homozygous-recessive parent (Bb × bb) to reveal whether it is heterozygous. The engine computes the 1:1 phenotype ratio that signals a heterozygous parent.",
+    "standard": "Mendelian genetics (Punnett square)",
+    "tags": [
+      "matrix",
+      "punnett",
+      "genetics",
+      "mendel",
+      "test-cross",
+      "biology"
+    ],
+    "complexity": 2,
+    "featured": false,
+    "dsl": "matrix punnett \"Test cross  (Bb × bb)\"\ncross: Bb x bb\ntrait B: \"Brown\" / \"Blue\"",
+    "notes": "## What this shows\n\nA **test cross** answers a practical genetics question: an organism shows the dominant trait, but is it `BB` or `Bb`? Cross it against a **homozygous-recessive** partner (`bb`) and read the offspring. You write only the cross; the engine computes the outcome that gives the answer.\n\nThe recessive `bb` parent contributes only `b` gametes, so the offspring genotypes come straight from the unknown parent's gametes. Crossing `Bb × bb` yields a **1:1 phenotype ratio** — half `Bb` (dominant phenotype), half `bb` (recessive) — the tell-tale signature of a heterozygous parent. (A `BB` parent would instead give all dominant offspring.) The engine fills the 2×1 grid, tints the two phenotype classes apart, and reports the 1:1 ratio, so the diagnostic result is immediate."
+  },
+  {
     "slug": "matrix-qfd-coffee-maker",
     "diagram": "matrix",
     "title": "Coffee maker House of Quality",

--- a/website/content/docs/matrix.mdx
+++ b/website/content/docs/matrix.mdx
@@ -647,5 +647,7 @@ Ready-to-use scenarios from the examples gallery:
   'matrix-johari-window',
   'matrix-9-box-talent',
   'matrix-bcg-portfolio',
+  'matrix-punnett-monohybrid',
   'matrix-punnett-dihybrid',
+  'matrix-punnett-testcross',
 ]} />

--- a/website/content/examples/matrix-punnett-monohybrid.mdx
+++ b/website/content/examples/matrix-punnett-monohybrid.mdx
@@ -1,0 +1,25 @@
+---
+title: Monohybrid cross Punnett square (3:1)
+description: The classic single-gene Punnett square — two heterozygous parents (Bb × Bb) crossed for eye colour. The engine computes the gametes, the 2×2 grid, and the canonical 3:1 dominant-to-recessive phenotype ratio with a 1:2:1 genotype ratio.
+diagram: matrix
+standard: Mendelian genetics (Punnett square)
+industry: [education, genetics, biology]
+persona: For the biology teacher or student learning Mendelian inheritance
+complexity: 1
+tags: [matrix, punnett, genetics, mendel, monohybrid, biology]
+featured: false
+relatedLink:
+  label: Matrix syntax
+  href: /docs/matrix
+status: published
+dsl: |
+  matrix punnett "Eye color  (Bb × Bb)"
+  cross: Bb x Bb
+  trait B: "Brown eyes" / "Blue eyes"
+---
+
+## What this shows
+
+The **monohybrid cross** is where every genetics course starts: one gene, two heterozygous parents. Here both parents are `Bb` for eye colour — `B` (brown) is dominant, `b` (blue) recessive. You write only the cross; the engine does the Mendelian bookkeeping.
+
+Each `Bb` parent makes two gametes, `B` and `b`, so the grid is 2×2. The engine fills it — `BB`, `Bb`, `Bb`, `bb` — and computes the two ratios every student memorises: a **3:1 phenotype ratio** (3 brown-eyed : 1 blue-eyed) and a **1:2:1 genotype ratio** (1 `BB` : 2 `Bb` : 1 `bb`). The single recessive `bb` box is tinted apart from the three dominant boxes, and the `trait` line names the phenotypes so the legend reads in plain English. Allele case sets dominance — uppercase is dominant — so the notation is exactly what a textbook uses.

--- a/website/content/examples/matrix-punnett-testcross.mdx
+++ b/website/content/examples/matrix-punnett-testcross.mdx
@@ -1,0 +1,25 @@
+---
+title: Test cross Punnett square (1:1)
+description: A genetic test cross — crossing an organism of unknown genotype against a homozygous-recessive parent (Bb × bb) to reveal whether it is heterozygous. The engine computes the 1:1 phenotype ratio that signals a heterozygous parent.
+diagram: matrix
+standard: Mendelian genetics (Punnett square)
+industry: [education, genetics, biology]
+persona: For the geneticist or student determining an unknown genotype
+complexity: 2
+tags: [matrix, punnett, genetics, mendel, test-cross, biology]
+featured: false
+relatedLink:
+  label: Matrix syntax
+  href: /docs/matrix
+status: published
+dsl: |
+  matrix punnett "Test cross  (Bb × bb)"
+  cross: Bb x bb
+  trait B: "Brown" / "Blue"
+---
+
+## What this shows
+
+A **test cross** answers a practical genetics question: an organism shows the dominant trait, but is it `BB` or `Bb`? Cross it against a **homozygous-recessive** partner (`bb`) and read the offspring. You write only the cross; the engine computes the outcome that gives the answer.
+
+The recessive `bb` parent contributes only `b` gametes, so the offspring genotypes come straight from the unknown parent's gametes. Crossing `Bb × bb` yields a **1:1 phenotype ratio** — half `Bb` (dominant phenotype), half `bb` (recessive) — the tell-tale signature of a heterozygous parent. (A `BB` parent would instead give all dominant offspring.) The engine fills the 2×1 grid, tints the two phenotype classes apart, and reports the 1:1 ratio, so the diagnostic result is immediate.


### PR DESCRIPTION
## What

Follow-up to #29. The dihybrid (9:3:3:1) was the only Punnett **gallery** example. This adds the two most-taught and most-searched Mendelian cases so they are discoverable on the gallery + LLM path, not just as static SVGs:

- **matrix-punnett-monohybrid** — `Bb x Bb` → **3:1** (the canonical intro cross; SVG already existed, now a gallery example)
- **matrix-punnett-testcross** — `Bb x bb` → **1:1** (reveals whether a dominant-looking organism is heterozygous)

## Surfaces
- 2 new `website/content/examples/matrix-punnett-*.mdx`
- test-cross static SVG via `scripts/gen-examples.mjs` → `examples/matrix/punnett-testcross.svg`
- both wired into the matrix doc Related-examples list
- regenerated AI bundle (152 examples)

Examples-only — no engine change. Both rendered and eyeballed in a browser preview (3:1 and 1:1 ratios correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)