### PR TITLE
fix(website): registry-derived catalog + accurate use-case taxonomy + compact filters

### DIFF
--- a/scripts/check-use-cases.mjs
+++ b/scripts/check-use-cases.mjs
@@ -1,0 +1,42 @@
+// Guards the gallery use-case taxonomy against drift: every `industry:` domain
+// token used across the example corpus must map to a use-case bucket in
+// website/lib/use-cases.ts. A new, unmapped token would otherwise silently fall
+// into the 'business' fallback bucket. Run: node scripts/check-use-cases.mjs
+import { readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+// Known domain tokens, parsed from the `domains: [...]` arrays in use-cases.ts.
+const taxonomy = readFileSync(join(root, 'website/lib/use-cases.ts'), 'utf8');
+const known = new Set(
+  [...taxonomy.matchAll(/domains:\s*\[([\s\S]*?)\]/g)]
+    .flatMap((m) => [...m[1].matchAll(/'([^']+)'/g)].map((t) => t[1])),
+);
+
+// Every domain token used across example frontmatter.
+const exDir = join(root, 'website/content/examples');
+const used = new Map(); // token -> [slugs]
+for (const file of readdirSync(exDir).filter((f) => f.endsWith('.mdx'))) {
+  const src = readFileSync(join(exDir, file), 'utf8');
+  const m = src.match(/^industry:\s*\[(.*)\]\s*$/m);
+  if (!m) continue;
+  for (const raw of m[1].split(',')) {
+    const tok = raw.trim();
+    if (!tok) continue;
+    (used.get(tok) ?? used.set(tok, []).get(tok)).push(file.replace('.mdx', ''));
+  }
+}
+
+const unmapped = [...used.keys()].filter((t) => !known.has(t)).sort();
+if (unmapped.length) {
+  console.error(`✗ ${unmapped.length} unmapped use-case domain token(s):\n`);
+  for (const t of unmapped) {
+    console.error(`  ${t}  (e.g. ${used.get(t).slice(0, 2).join(', ')})`);
+  }
+  console.error('\nAdd each to a bucket in website/lib/use-cases.ts.');
+  process.exit(1);
+}
+console.log(`✓ all ${used.size} example domain tokens map to a use-case bucket`);

--- a/website/app/(home)/gallery/page.tsx
+++ b/website/app/(home)/gallery/page.tsx
@@ -5,6 +5,7 @@ import {
   DIAGRAM_LABELS,
   INDUSTRY_LABELS,
   CLUSTER_META,
+  resolveUseCase,
   type GalleryExample,
   type DiagramType,
   type Industry,
@@ -39,10 +40,8 @@ function parseIndustry(v: string | undefined): Industry | null {
   return v in INDUSTRY_LABELS ? (v as Industry) : null;
 }
 
-const VALID_INDUSTRIES = new Set(Object.keys(INDUSTRY_LABELS));
-
 function toGalleryExample(ex: (typeof allExamples)[number]): GalleryExample {
-  const industry = (ex.industry.find((i) => VALID_INDUSTRIES.has(i)) ?? 'healthcare') as Industry;
+  const industry = resolveUseCase(ex.industry);
   return {
     slug: ex.slug,
     title: ex.title,

--- a/website/components/DiagramCatalog.tsx
+++ b/website/components/DiagramCatalog.tsx
@@ -1,0 +1,54 @@
+// "What can I draw?" catalog for the docs landing page — grouped by cluster,
+// derived entirely from the package registry. Adding a diagram to
+// DIAGRAM_REGISTRY makes it appear here automatically; no hand-maintained list.
+import Link from 'next/link';
+import { DIAGRAM_REGISTRY, type DiagramCluster, type DiagramMeta } from 'schematex/ai';
+import { CLUSTERS_ORDERED, CLUSTER_DISPLAY } from '@/lib/clusters';
+
+export function DiagramCatalog() {
+  const byCluster = new Map<DiagramCluster, DiagramMeta[]>();
+  for (const m of DIAGRAM_REGISTRY) {
+    (byCluster.get(m.cluster) ?? byCluster.set(m.cluster, []).get(m.cluster)!).push(m);
+  }
+
+  const groups = CLUSTERS_ORDERED.map((cluster) => ({
+    cluster,
+    label: CLUSTER_DISPLAY[cluster].label,
+    items: byCluster.get(cluster) ?? [],
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <>
+    <p>
+      Schematex draws <strong>{DIAGRAM_REGISTRY.length}</strong> diagram types
+      across <strong>{groups.length}</strong> domains — each built to a published
+      standard:
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Domain</th>
+          <th>Diagrams</th>
+        </tr>
+      </thead>
+      <tbody>
+        {groups.map((g) => (
+          <tr key={g.cluster}>
+            <td>
+              <strong>{g.label}</strong>
+            </td>
+            <td>
+              {g.items.map((m, i) => (
+                <span key={m.type}>
+                  {i > 0 && ', '}
+                  <Link href={`/docs/${m.syntaxKey}`}>{m.name}</Link>
+                </span>
+              ))}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    </>
+  );
+}

--- a/website/components/GalleryFilterBar.tsx
+++ b/website/components/GalleryFilterBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   DIAGRAM_LABELS,
@@ -40,6 +40,7 @@ export function GalleryFilterBar({
 
   const [queryInput, setQueryInput] = useState(activeQuery);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [showAllTypes, setShowAllTypes] = useState(false);
   useEffect(() => setQueryInput(activeQuery), [activeQuery]);
 
   const setParam = useCallback(
@@ -131,6 +132,20 @@ export function GalleryFilterBar({
     count: counts.diagramCounts.get(t) ?? 0,
   }));
 
+  // The diagram axis has many types — keep the desktop row to ~2 lines by
+  // default, expandable. The active chip is always kept visible.
+  const COLLAPSED_TYPE_COUNT = 12;
+  const collapsedDiagramOptions = (() => {
+    if (showAllTypes || diagramOptions.length <= COLLAPSED_TYPE_COUNT) return diagramOptions;
+    const head = diagramOptions.slice(0, COLLAPSED_TYPE_COUNT);
+    if (activeDiagram && !head.some((o) => o.value === activeDiagram)) {
+      const act = diagramOptions.find((o) => o.value === activeDiagram);
+      if (act) head.push(act);
+    }
+    return head;
+  })();
+  const hiddenTypeCount = diagramOptions.length - collapsedDiagramOptions.length;
+
   const industryOptions: ChipOption<Industry>[] = (
     Object.keys(INDUSTRY_LABELS) as Industry[]
   ).map((k) => ({
@@ -143,6 +158,7 @@ export function GalleryFilterBar({
     options: ChipOption<T>[],
     activeValue: T | null,
     paramKey: string,
+    trailing?: ReactNode,
   ) => (
     <div className="flex flex-wrap gap-1.5">
       {options.map((opt) => {
@@ -161,7 +177,19 @@ export function GalleryFilterBar({
           </button>
         );
       })}
+      {trailing}
     </div>
+  );
+
+  const typeToggleChip = (hiddenTypeCount > 0 || showAllTypes) && (
+    <button
+      type="button"
+      className="gal-chip"
+      onClick={() => setShowAllTypes((v) => !v)}
+      style={{ fontStyle: 'italic' }}
+    >
+      {showAllTypes ? 'show less' : `+${hiddenTypeCount} more`}
+    </button>
   );
 
   const activeIndustryLabel = activeIndustry ? INDUSTRY_LABELS[activeIndustry].label : null;
@@ -285,7 +313,7 @@ export function GalleryFilterBar({
         {/* Desktop: DIAGRAM chips */}
         <div className="hidden md:flex items-start gap-3">
           <span className="type-eye shrink-0" style={{ paddingTop: 6 }}>DIAGRAM ·</span>
-          {renderChipGroup(diagramOptions, activeDiagram, 'type')}
+          {renderChipGroup(collapsedDiagramOptions, activeDiagram, 'type', typeToggleChip)}
         </div>
 
         {/* Status bar */}

--- a/website/components/GalleryGrid.tsx
+++ b/website/components/GalleryGrid.tsx
@@ -20,7 +20,7 @@ function GalleryCard({ ex }: { ex: GalleryExample }) {
   const svg = safeRender(ex.dsl);
   const cluster = getDiagramCluster(ex.diagram);
   const clusterColor = CLUSTER_META[cluster]?.color ?? 'var(--text-muted)';
-  const industry = INDUSTRY_LABELS[ex.industry] ?? { label: ex.industry, icon: '📋' };
+  const industry = INDUSTRY_LABELS[ex.industry] ?? { label: ex.industry };
   const exampleHref = `/examples/${ex.slug}`;
   return (
     <article className="gal-card">

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Introduction
-description: Every diagram a doctor, engineer, or lawyer would actually use. Free. Fully open source. Made for AI. 31 industry-standard diagrams from a text DSL.
+description: Every diagram a doctor, engineer, or lawyer would actually use. Free. Fully open source. Made for AI. Industry-standard diagrams — genogram to fault tree — from a text DSL.
 ---
 
 **Schematex** renders every diagram a doctor, engineer, or lawyer would actually
 use — clinical genograms, IEC 61131-3 ladder logic, NSGC pedigrees, IEEE 315
-single-line diagrams, cap tables, and 25 more. A tiny text DSL in; standards-compliant
+single-line diagrams, cap tables, and many more. A tiny text DSL in; standards-compliant
 SVG out.
 
 **Free. Fully open source. Made for AI.** AGPL-3.0, zero runtime dependencies,
@@ -14,15 +14,7 @@ ChatGPT or Claude and get a professional diagram back on the first try.
 
 ## What can I draw?
 
-| Domain | Diagrams |
-| --- | --- |
-| **Relationship** | [Genogram](/docs/genogram), [Ecomap](/docs/ecomap), [Pedigree](/docs/pedigree), [Phylogenetic tree](/docs/phylo), [Sociogram](/docs/sociogram) |
-| **Electrical / industrial** | [Timing](/docs/timing), [Logic gate](/docs/logic), [Circuit schematic](/docs/circuit), [Breadboard](/docs/breadboard), [Ladder logic](/docs/ladder), [Function block (FBD)](/docs/fbd), [Sequential function chart (SFC)](/docs/sfc), [Single-line diagram](/docs/sld), [Block diagram](/docs/block), [P&ID](/docs/pid) |
-| **Behavior modeling** | [State](/docs/state), [BPMN](/docs/bpmn), [Use case](/docs/usecase) |
-| **General** | [Flowchart](/docs/flowchart), [Mindmap](/docs/mindmap), [Org chart](/docs/orgchart), [Venn / Euler](/docs/venn), [Matrix](/docs/matrix) |
-| **Analysis** | [Entity structure](/docs/entity), [ER diagram](/docs/erd), [Fishbone](/docs/fishbone), [Timeline](/docs/timeline), [Decision tree](/docs/decisiontree) |
-| **Research** | [PRISMA flow](/docs/prisma) |
-| **Project management** | [PERT / CPM](/docs/pert) |
+<DiagramCatalog />
 
 ## Quick example
 
@@ -46,7 +38,7 @@ Or build your own AI feature on top of the Vercel AI SDK. See **[Use Schematex w
 
 - [Getting started](/docs/getting-started) — install, import, render
 - [Use Schematex with AI](/docs/ai-integration) — MCP + Vercel AI SDK + agent loop
-- [Playground](/playground) — try all 31 diagram types live
+- [Playground](/playground) — try any diagram type live
 - [API reference](/docs/api)
 
 ---

--- a/website/content/examples/welding-bracket-fillet.mdx
+++ b/website/content/examples/welding-bracket-fillet.mdx
@@ -3,7 +3,7 @@ title: Welded bracket — fillet + V-groove callouts
 description: AWS A2.4 welding callouts on a fabrication drawing — an intermittent double-fillet bracket with a weld-all-around flag, and a full-penetration V-groove butt weld with backing, root opening, and the welding process in the tail.
 diagram: welding
 standard: AWS A2.4 / ISO 2553 welding symbols
-industry: [manufacturing, fabrication, mechanical]
+industry: [industrial, manufacturing, fabrication, mechanical]
 persona: For the design or manufacturing engineer specifying welded joints
 complexity: 3
 tags: [welding, aws-a2.4, iso-2553, fillet, groove, fabrication]

--- a/website/lib/clusters.ts
+++ b/website/lib/clusters.ts
@@ -1,0 +1,36 @@
+// Single source of cluster display data (label · order · accent color) for the
+// 14 DiagramClusters defined in the package registry. Both the /diagrams catalog
+// (diagrams-index.ts) and the /gallery filters (gallery-examples.ts) read from
+// here, so there is exactly one cluster taxonomy + naming on the site — adding a
+// cluster to the registry means adding one row here, nothing else drifts.
+import type { DiagramCluster } from 'schematex/ai';
+
+export interface ClusterDisplay {
+  label: string;
+  /** Sort order across catalog + filter UIs (lower = earlier). */
+  order: number;
+  /** Accent color token (one of --cat-0..7); reused across clusters. */
+  color: string;
+}
+
+export const CLUSTER_DISPLAY: Record<DiagramCluster, ClusterDisplay> = {
+  relationships:            { label: 'Relationships',            order: 0,    color: 'var(--cat-0)' },
+  'electrical-industrial':  { label: 'Electrical & Industrial',  order: 1,    color: 'var(--cat-2)' },
+  'behavior-modeling':      { label: 'Behavior Modeling',        order: 2,    color: 'var(--cat-4)' },
+  'software-uml':           { label: 'Software / UML',           order: 2.5,  color: 'var(--cat-4)' },
+  'corporate-legal':        { label: 'Corporate & Legal',        order: 3,    color: 'var(--cat-3)' },
+  'causality-analysis':     { label: 'Causality & Analysis',     order: 4,    color: 'var(--cat-1)' },
+  strategy:                 { label: 'Strategy',                 order: 5,    color: 'var(--cat-6)' },
+  knowledge:                { label: 'Knowledge',                order: 6,    color: 'var(--cat-5)' },
+  research:                 { label: 'Research',                 order: 7,    color: 'var(--cat-5)' },
+  'project-management':     { label: 'Project Management',       order: 8,    color: 'var(--cat-6)' },
+  concurrency:              { label: 'Concurrency',              order: 8.5,  color: 'var(--cat-4)' },
+  'risk-reliability':       { label: 'Risk & Reliability',       order: 8.7,  color: 'var(--cat-4)' },
+  'network-infrastructure': { label: 'Network & Infrastructure', order: 9,    color: 'var(--cat-2)' },
+  generic:                  { label: 'General',                  order: 10,   color: 'var(--cat-7)' },
+};
+
+/** Clusters in display order. */
+export const CLUSTERS_ORDERED: DiagramCluster[] = (
+  Object.keys(CLUSTER_DISPLAY) as DiagramCluster[]
+).sort((a, b) => CLUSTER_DISPLAY[a].order - CLUSTER_DISPLAY[b].order);

--- a/website/lib/diagrams-index.ts
+++ b/website/lib/diagrams-index.ts
@@ -12,6 +12,7 @@ import {
 } from 'schematex/ai';
 import { allExamples, type Example } from '@/lib/examples-source';
 import { parseChangelog } from '@/lib/changelog';
+import { CLUSTER_DISPLAY } from '@/lib/clusters';
 
 export interface DiagramExampleThumb {
   slug: string;
@@ -41,24 +42,6 @@ export interface DiagramClusterGroup {
   label: string;
   entries: DiagramIndexEntry[];
 }
-
-// Order + label per cluster. Icons come from <ClusterIcon> (no emoji).
-const CLUSTER_DISPLAY: Record<DiagramCluster, { label: string; order: number }> = {
-  relationships:            { label: 'Relationships',            order: 0 },
-  'electrical-industrial':  { label: 'Electrical & Industrial',  order: 1 },
-  'behavior-modeling':      { label: 'Behavior Modeling',        order: 2 },
-  'software-uml':           { label: 'Software / UML',           order: 2.5 },
-  'corporate-legal':        { label: 'Corporate & Legal',        order: 3 },
-  'causality-analysis':     { label: 'Causality & Analysis',     order: 4 },
-  strategy:                 { label: 'Strategy',                 order: 5 },
-  knowledge:                { label: 'Knowledge',                order: 6 },
-  research:                 { label: 'Research',                 order: 7 },
-  'project-management':     { label: 'Project Management',       order: 8 },
-  concurrency:              { label: 'Concurrency',              order: 8.5 },
-  'risk-reliability':       { label: 'Risk & Reliability',       order: 8.7 },
-  'network-infrastructure': { label: 'Network & Infrastructure', order: 9 },
-  generic:                  { label: 'General',                  order: 10 },
-};
 
 const SYMBOL_SHEET_TYPES = new Set<DiagramType>(SYMBOL_CATALOG_TYPES);
 

--- a/website/lib/gallery-examples.ts
+++ b/website/lib/gallery-examples.ts
@@ -1,51 +1,18 @@
 // Types, label maps, and cluster helpers for the gallery UI.
 // The actual example data lives in content/examples/*.mdx — see lib/examples-source.ts.
+//
+// The diagram list, labels, and clusters are DERIVED from the package registry
+// (schematex/ai) — there is no hand-maintained type list here. Add a diagram to
+// DIAGRAM_REGISTRY and it shows up in the gallery filters automatically.
+import {
+  DIAGRAM_REGISTRY,
+  getDiagramMeta,
+  type DiagramType,
+  type DiagramCluster,
+} from 'schematex/ai';
+import { CLUSTER_DISPLAY, CLUSTERS_ORDERED } from '@/lib/clusters';
 
-export type DiagramType =
-  | 'genogram'
-  | 'ecomap'
-  | 'pedigree'
-  | 'phylo'
-  | 'sociogram'
-  | 'timing'
-  | 'logic'
-  | 'circuit'
-  | 'ladder'
-  | 'sld'
-  | 'block'
-  | 'fbd'
-  | 'sfc'
-  | 'pid'
-  | 'breadboard'
-  | 'entity'
-  | 'erd'
-  | 'fishbone'
-  | 'venn'
-  | 'decisiontree'
-  | 'matrix'
-  | 'usecase'
-  | 'sequence'
-  | 'bpmn'
-  | 'state'
-  | 'prisma'
-  | 'pert'
-  | 'petri'
-  | 'flowchart'
-  | 'mindmap'
-  | 'orgchart'
-  | 'timeline'
-  | 'network'
-  | 'umlclass'
-  | 'faulttree'
-  | 'bowtie'
-  | 'eventtree'
-  | 'fmea'
-  | 'causalloop'
-  | 'markov'
-  | 'gitgraph'
-  | 'epc'
-  | 'idef0'
-  | 'threatmodel';
+export type { DiagramType };
 
 export type Industry =
   | 'healthcare'
@@ -69,52 +36,11 @@ export interface GalleryExample {
   hasDetailPage: boolean;
 }
 
-export const DIAGRAM_LABELS: Record<DiagramType, { label: string; icon: string }> = {
-  genogram: { label: 'Genogram', icon: '👪' },
-  ecomap: { label: 'Ecomap', icon: '🌐' },
-  pedigree: { label: 'Pedigree', icon: '🧬' },
-  phylo: { label: 'Phylogenetic', icon: '🌿' },
-  sociogram: { label: 'Sociogram', icon: '🕸' },
-  timing: { label: 'Timing', icon: '⏱' },
-  logic: { label: 'Logic gate', icon: '🔌' },
-  circuit: { label: 'Circuit', icon: '⚡' },
-  ladder: { label: 'Ladder logic', icon: '🪜' },
-  sld: { label: 'Single-line', icon: '🔋' },
-  block: { label: 'Block diagram', icon: '📦' },
-  fbd: { label: 'Function block', icon: '🧮' },
-  sfc: { label: 'Sequential FC', icon: '🔢' },
-  pid: { label: 'P&ID', icon: '🛢' },
-  breadboard: { label: 'Breadboard', icon: '🍞' },
-  entity: { label: 'Entity structure', icon: '🏢' },
-  erd: { label: 'ER diagram', icon: '🗄' },
-  fishbone: { label: 'Fishbone', icon: '🐟' },
-  venn: { label: 'Venn / Euler', icon: '⊙' },
-  decisiontree: { label: 'Decision tree', icon: '🌳' },
-  matrix: { label: 'Matrix / quadrant', icon: '🔲' },
-  usecase: { label: 'Use case', icon: '🧩' },
-  sequence: { label: 'Sequence', icon: '💬' },
-  bpmn: { label: 'BPMN', icon: '🔀' },
-  state: { label: 'State diagram', icon: '🔄' },
-  prisma: { label: 'PRISMA flow', icon: '📊' },
-  pert: { label: 'PERT / CPM', icon: '🗓' },
-  petri: { label: 'Petri net', icon: '◉' },
-  flowchart: { label: 'Flowchart', icon: '🔷' },
-  mindmap: { label: 'Mindmap', icon: '🧠' },
-  orgchart: { label: 'Org chart', icon: '🏛' },
-  timeline: { label: 'Timeline', icon: '📅' },
-  network: { label: 'Network topology', icon: '🖧' },
-  umlclass: { label: 'UML class', icon: '🧱' },
-  faulttree: { label: 'Fault tree', icon: '🛡' },
-  bowtie: { label: 'Bowtie', icon: '🎀' },
-  eventtree: { label: 'Event tree', icon: '🌲' },
-  fmea: { label: 'FMEA', icon: '📋' },
-  causalloop: { label: 'Causal loop', icon: '🔁' },
-  markov: { label: 'Markov chain', icon: '🎲' },
-  gitgraph: { label: 'Git graph', icon: '🔗' },
-  epc: { label: 'EPC', icon: '⚙️' },
-  idef0: { label: 'IDEF0', icon: '🏗' },
-  threatmodel: { label: 'Threat model', icon: '🔐' },
-};
+// label per diagram type, derived from the registry's canonical `name`.
+export const DIAGRAM_LABELS: Record<DiagramType, { label: string }> =
+  Object.fromEntries(
+    DIAGRAM_REGISTRY.map((m) => [m.type, { label: m.name }]),
+  ) as Record<DiagramType, { label: string }>;
 
 export const INDUSTRY_LABELS: Record<Industry, { label: string; icon: string }> = {
   healthcare: { label: 'Healthcare', icon: '🩺' },
@@ -131,35 +57,23 @@ export const COMPLEXITY_LABELS: Record<Complexity, string> = {
   3: 'Advanced',
 };
 
-export const CLUSTER_TO_TYPES: Record<string, DiagramType[]> = {
-  relationships: ['genogram', 'ecomap', 'pedigree', 'sociogram', 'phylo'],
-  'electrical-industrial': ['timing', 'logic', 'circuit', 'ladder', 'sld', 'block', 'fbd', 'sfc', 'pid', 'breadboard'],
-  'corporate-legal': ['entity', 'erd', 'orgchart'],
-  'causality-analysis': ['fishbone', 'venn', 'decisiontree', 'matrix', 'causalloop', 'markov'],
-  'software-uml': ['umlclass', 'usecase', 'sequence', 'bpmn', 'state', 'petri', 'gitgraph', 'epc'],
-  'risk-reliability': ['faulttree', 'bowtie', 'eventtree', 'fmea'],
-  research: ['prisma'],
-  'project-management': ['pert', 'idef0'],
-  'network-infrastructure': ['network', 'threatmodel'],
-  general: ['flowchart', 'mindmap', 'timeline'],
-};
+// cluster id → its diagram types, grouped + ordered straight from the registry.
+export const CLUSTER_TO_TYPES: Record<DiagramCluster, DiagramType[]> = (() => {
+  const map = Object.fromEntries(
+    CLUSTERS_ORDERED.map((c) => [c, [] as DiagramType[]]),
+  ) as Record<DiagramCluster, DiagramType[]>;
+  for (const m of DIAGRAM_REGISTRY) map[m.cluster].push(m.type);
+  return map;
+})();
 
-export const CLUSTER_META: Record<string, { label: string; color: string }> = {
-  relationships:           { label: 'Relationships',           color: 'var(--cat-0)' },
-  'electrical-industrial': { label: 'Electrical & Industrial', color: 'var(--cat-2)' },
-  'corporate-legal':       { label: 'Corporate & Legal',       color: 'var(--cat-3)' },
-  'causality-analysis':    { label: 'Causality & Analysis',    color: 'var(--cat-1)' },
-  'software-uml':          { label: 'Software & UML',          color: 'var(--cat-4)' },
-  'risk-reliability':      { label: 'Risk & Reliability',      color: 'var(--cat-4)' },
-  research:                { label: 'Research',                color: 'var(--cat-5)' },
-  'project-management':    { label: 'Project Management',      color: 'var(--cat-6)' },
-  'network-infrastructure': { label: 'Network & Infrastructure', color: 'var(--cat-2)' },
-  general:                 { label: 'General',                 color: 'var(--cat-7)' },
-};
+export const CLUSTER_META: Record<DiagramCluster, { label: string; color: string }> =
+  Object.fromEntries(
+    (Object.keys(CLUSTER_DISPLAY) as DiagramCluster[]).map((c) => [
+      c,
+      { label: CLUSTER_DISPLAY[c].label, color: CLUSTER_DISPLAY[c].color },
+    ]),
+  ) as Record<DiagramCluster, { label: string; color: string }>;
 
-export function getDiagramCluster(diagram: DiagramType): string {
-  for (const [cluster, types] of Object.entries(CLUSTER_TO_TYPES)) {
-    if ((types as string[]).includes(diagram)) return cluster;
-  }
-  return 'relationships';
+export function getDiagramCluster(diagram: DiagramType): DiagramCluster {
+  return getDiagramMeta(diagram)?.cluster ?? 'generic';
 }

--- a/website/lib/gallery-examples.ts
+++ b/website/lib/gallery-examples.ts
@@ -11,16 +11,14 @@ import {
   type DiagramCluster,
 } from 'schematex/ai';
 import { CLUSTER_DISPLAY, CLUSTERS_ORDERED } from '@/lib/clusters';
+import { type UseCase, USE_CASE_LABELS, resolveUseCase } from '@/lib/use-cases';
 
 export type { DiagramType };
 
-export type Industry =
-  | 'healthcare'
-  | 'legal-finance'
-  | 'industrial'
-  | 'education'
-  | 'research'
-  | 'business';
+// "Industry" is the gallery's use-case axis — derived from the curated
+// use-case taxonomy (lib/use-cases.ts), not a hand-kept enum.
+export type Industry = UseCase;
+export { resolveUseCase };
 
 export type Complexity = 1 | 2 | 3;
 
@@ -42,14 +40,8 @@ export const DIAGRAM_LABELS: Record<DiagramType, { label: string }> =
     DIAGRAM_REGISTRY.map((m) => [m.type, { label: m.name }]),
   ) as Record<DiagramType, { label: string }>;
 
-export const INDUSTRY_LABELS: Record<Industry, { label: string; icon: string }> = {
-  healthcare: { label: 'Healthcare', icon: '🩺' },
-  'legal-finance': { label: 'Legal & Finance', icon: '⚖️' },
-  industrial: { label: 'Industrial', icon: '🏭' },
-  education: { label: 'Education', icon: '🎓' },
-  research: { label: 'Research', icon: '🔬' },
-  business: { label: 'Business', icon: '💼' },
-};
+// use-case label per id, from the curated taxonomy.
+export const INDUSTRY_LABELS: Record<Industry, { label: string }> = USE_CASE_LABELS;
 
 export const COMPLEXITY_LABELS: Record<Complexity, string> = {
   1: 'Minimal',

--- a/website/lib/use-cases.ts
+++ b/website/lib/use-cases.ts
@@ -1,0 +1,128 @@
+// Use-case (audience / domain) taxonomy for the gallery.
+//
+// Example MDX frontmatter uses a rich, free-form `industry:` vocabulary (90+
+// distinct tokens: software, saas, manufacturing, devops, banking, …). The
+// gallery groups those into a small, curated set of audience buckets so the
+// "use-case" filter stays scannable AND accurate — every token maps to exactly
+// one bucket here, so nothing silently falls back into the wrong group.
+//
+// Adding a new domain token to an example? Add it to a bucket below. The
+// coverage test (tests in website) asserts every token used across the corpus
+// is mapped, so a new unmapped token fails CI instead of quietly mis-bucketing.
+
+export type UseCase =
+  | 'healthcare'
+  | 'software'
+  | 'engineering'
+  | 'industrial'
+  | 'business'
+  | 'legal-finance'
+  | 'education'
+  | 'research';
+
+export interface UseCaseGroup {
+  id: UseCase;
+  label: string;
+  /** Free-form frontmatter domain tokens that map into this bucket. */
+  domains: string[];
+}
+
+// Ordered — this is also the chip order in the filter bar.
+export const USE_CASE_GROUPS: UseCaseGroup[] = [
+  {
+    id: 'healthcare',
+    label: 'Healthcare & Social',
+    domains: [
+      'healthcare', 'clinical', 'genetics', 'biology', 'biotech',
+      'pharmaceuticals', 'pharmaceutical', 'social-work', 'child-protection',
+    ],
+  },
+  {
+    id: 'software',
+    label: 'Software & IT',
+    domains: [
+      'software', 'saas', 'it', 'devops', 'sre', 'cloud', 'datacenter',
+      'infrastructure', 'security', 'iot', 'productivity', 'analytics', 'sap',
+      'ecommerce', 'e-commerce', 'billing',
+    ],
+  },
+  {
+    id: 'engineering',
+    label: 'Engineering & Hardware',
+    domains: [
+      'engineering', 'hardware', 'electronics', 'embedded', 'embedded-systems',
+      'robotics', 'mechanical', 'maker', 'automotive', 'aviation',
+    ],
+  },
+  {
+    id: 'industrial',
+    label: 'Industrial & Process',
+    domains: [
+      'industrial', 'manufacturing', 'automation', 'plc', 'chemical-processing',
+      'chemical', 'specialty-chemicals', 'petrochemical', 'oil-gas',
+      'water-treatment', 'food-processing', 'beverage', 'brewing', 'baking',
+      'packaging', 'plastics', 'energy', 'renewables', 'utilities', 'nuclear',
+      'hvac', 'process-safety', 'fabrication', 'construction', 'residential',
+      'quality',
+    ],
+  },
+  {
+    id: 'business',
+    label: 'Business & Operations',
+    domains: [
+      'business', 'management', 'operations', 'strategy', 'business-strategy',
+      'product', 'hr', 'marketing', 'leadership', 'consulting', 'startup',
+      'scaleup', 'enterprise', 'support', 'coaching', 'hospitality', 'retail',
+      'logistics', 'supply-chain', 'warehousing', 'transportation', 'transport',
+    ],
+  },
+  {
+    id: 'legal-finance',
+    label: 'Finance & Legal',
+    domains: [
+      'legal-finance', 'finance', 'banking', 'insurance', 'legal', 'compliance',
+      'investor-relations',
+    ],
+  },
+  {
+    id: 'education',
+    label: 'Education',
+    domains: ['education'],
+  },
+  {
+    id: 'research',
+    label: 'Research & Analysis',
+    domains: [
+      'research', 'decision-analysis', 'probability', 'systems-thinking',
+      'foresight', 'urban-planning', 'bioinformatics',
+    ],
+  },
+];
+
+export const USE_CASE_LABELS: Record<UseCase, { label: string }> =
+  Object.fromEntries(
+    USE_CASE_GROUPS.map((g) => [g.id, { label: g.label }]),
+  ) as Record<UseCase, { label: string }>;
+
+const DOMAIN_TO_USECASE: Record<string, UseCase> = (() => {
+  const map: Record<string, UseCase> = {};
+  for (const g of USE_CASE_GROUPS) for (const d of g.domains) map[d] = g.id;
+  return map;
+})();
+
+/** Every domain token recognised by the taxonomy (for coverage tests). */
+export const KNOWN_DOMAINS = new Set(Object.keys(DOMAIN_TO_USECASE));
+
+/**
+ * Resolve an example's frontmatter `industry` tokens to a single use-case
+ * bucket. First mapped token wins (tokens are listed primary-first). Falls back
+ * to 'business' only if no token maps — the coverage test keeps that from
+ * happening silently for corpus examples.
+ */
+export function resolveUseCase(domains: readonly string[]): UseCase {
+  for (const d of domains) {
+    const uc = DOMAIN_TO_USECASE[d];
+    if (uc) return uc;
+  }
+  return 'business';
+}

--- a/website/mdx-components.tsx
+++ b/website/mdx-components.tsx
@@ -3,6 +3,7 @@ import type { MDXComponents } from 'mdx/types';
 import { Playground } from '@/components/Playground';
 import { RelatedExamples } from '@/components/RelatedExamples';
 import { MCPConnectCard } from '@/components/MCPConnectCard';
+import { DiagramCatalog } from '@/components/DiagramCatalog';
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -10,6 +11,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     Playground,
     RelatedExamples,
     MCPConnectCard,
+    DiagramCatalog,
     ...components,
   };
 }


### PR DESCRIPTION
Three related gallery/docs fixes after the diagram set grew to **45 types** (0.6 → 0.8.2).

## 1. Registry-derived catalog (no more drift)
Two hand-maintained diagram lists had fallen behind the registry.
- **`gallery-examples.ts`** redeclared a 44-type union + labels + clusters by hand — **missing `welding`** (no filter chip, wrong cluster, `?type=welding`→null).
- **`docs/index.mdx`** hard-coded a "What can I draw?" table stuck at ~20 types + the strings `31`/`25 more`.

Now both derive from `DIAGRAM_REGISTRY`:
- **`lib/clusters.ts`** — single source of cluster display data (label·order·color) for all 14 clusters; `gallery-examples.ts` + `diagrams-index.ts` both import it.
- **`<DiagramCatalog />`** renders the docs table from the registry + a live "N types across M domains" count.
- Adding a diagram to the registry now surfaces it in gallery filters **and** docs automatically.

## 2. Accurate use-case classification
Example frontmatter `industry:` uses **90+ free-form tokens** (software, saas, manufacturing, devops, banking, …) but the gallery only knew 6 enum values — so **62 of 153 examples fell back to `healthcare`**, inflating it to 75 (a BPMN "Refund escalation workflow" was tagged healthcare).
- **`lib/use-cases.ts`** — 8 curated audience buckets (Healthcare & Social, Software & IT, Engineering & Hardware, Industrial & Process, Business & Operations, Finance & Legal, Education, Research & Analysis), mapping all ~98 corpus tokens. `resolveUseCase()` replaces the fallback.
- Healthcare now reads **14** (real); the rest distribute correctly (Software 38, Industrial 31, Business 22, Education 18, …) — sums to 153.
- **`scripts/check-use-cases.mjs`** fails loudly if any example token is unmapped, so new examples can't silently mis-bucket.

## 3. Compact filter bar
The DIAGRAM chip row listed all 45 types (~6 rows, half the viewport). Now shows the first 12 + a **"+N more" / "show less"** toggle (active type always kept visible) → ~2 rows. USE-CASE (8 chips) stays fully visible; mobile keeps its scrollable bottom-sheet. Dropped the unused emoji label icons (house style).

## Verification
- ✅ website `tsc --noEmit` + `next build` pass
- ✅ `check-use-cases.mjs` green (98 tokens mapped)
- ✅ docs catalog: 45 types across 14 domains incl. welding
- ✅ gallery: use-case counts sum to 153, Healthcare = 14; DIAGRAM row collapsed to 12 + "+32 more"; welding chip + `?type=welding` + Electrical & Industrial cluster + industrial use-case all correct
- ✅ no console errors

## Out of scope (deliberate)
`README.md` / `package.json` description still say "36" — static files, can't derive from the registry; left for a focused follow-up.