### PR TITLE
fix(website): kill JSON-LD OG 404s, custom 404 page, i18n followups

### DIFF
--- a/website/app/(home)/examples/[slug]/page.tsx
+++ b/website/app/(home)/examples/[slug]/page.tsx
@@ -73,7 +73,6 @@ export default async function ExampleDetailPage({
     headline: ex.title,
     description: ex.description,
     url,
-    image: `${url}/opengraph-image`,
     inLanguage: 'en',
     keywords: [ex.diagram, ex.standard, ...ex.industry, ...ex.tags]
       .filter(Boolean)

--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_LOCALE,
   LIVE_LOCALES,
   isPrefixedLocale,
+  localeDir,
 } from '@/lib/i18n/locales';
 
 // Only emit the live, prefixed locales — never the default (`/en/*` would
@@ -36,14 +37,16 @@ export default async function LangLayout({
   return (
     <>
       <LangSync locale={lang} />
-      <SiteHeader
-        version={version}
-        stars={stars}
-        lang={lang}
-        nav={dict.nav}
-        switcherLabel={dict.localeSwitcher.label}
-      />
-      {children}
+      <div lang={lang} dir={localeDir(lang)} className="contents">
+        <SiteHeader
+          version={version}
+          stars={stars}
+          lang={lang}
+          nav={dict.nav}
+          switcherLabel={dict.localeSwitcher.label}
+        />
+        {children}
+      </div>
     </>
   );
 }

--- a/website/app/not-found.tsx
+++ b/website/app/not-found.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link';
+import { render } from 'schematex';
+import { CountdownRedirect } from '@/components/CountdownRedirect';
+
+export const metadata = {
+  title: '404 — lost node',
+  description: 'This page is not on the graph.',
+  robots: { index: false, follow: true },
+};
+
+// The 404 page is itself a Schematex diagram — every page is a diagram, even
+// the one that doesn't exist. Rendered server-side, so it ships as static SVG.
+const DSL = `flowchart LR
+  here([You are here]) --> q{Page exists?}
+  q -->|No| lost[404 · lost node]
+  lost --> home([Take me home])`;
+
+function renderBanner(): string {
+  const svg = render(DSL);
+  // Strip the fixed width/height from the root tag so the viewBox lets it
+  // scale fluidly to its container.
+  return svg.replace(/^<svg([^>]*?)>/, (_m, attrs) =>
+    `<svg${attrs.replace(/\s(?:width|height)="[\d.]+"/g, '')}>`,
+  );
+}
+
+export default function NotFound() {
+  const banner = renderBanner();
+
+  return (
+    <main className="mx-auto flex min-h-[70vh] max-w-3xl flex-col items-center justify-center px-6 py-16 text-center">
+      <p className="font-mono text-sm font-semibold uppercase tracking-[0.2em] text-fd-primary">
+        404
+      </p>
+      <h1 className="mt-3 text-balance text-3xl font-semibold tracking-tight text-fd-foreground md:text-4xl">
+        This node isn’t on the graph
+      </h1>
+      <p className="mt-3 max-w-xl text-pretty text-lg leading-relaxed text-fd-muted-foreground">
+        The page you’re looking for doesn’t exist — maybe the link was wrong, or
+        it moved. Here’s the path back:
+      </p>
+
+      <div
+        className="mt-10 w-full max-w-2xl [&_svg]:h-auto [&_svg]:w-full"
+        // Decorative diagram of the 404 → home path.
+        aria-hidden="true"
+        dangerouslySetInnerHTML={{ __html: banner }}
+      />
+      <p className="mt-3 text-xs text-fd-muted-foreground/80">
+        Every page on Schematex is a diagram — even this one.
+      </p>
+
+      <div className="mt-10 flex flex-wrap items-center justify-center gap-2">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 rounded-md bg-fd-foreground px-4 py-2 text-sm font-medium text-fd-background hover:opacity-90"
+        >
+          ← Back home
+        </Link>
+        <Link
+          href="/examples"
+          className="inline-flex items-center gap-1.5 rounded-md border border-fd-border px-4 py-2 text-sm font-medium text-fd-foreground hover:bg-fd-accent"
+        >
+          Browse examples
+        </Link>
+        <Link
+          href="/playground"
+          className="inline-flex items-center gap-1.5 rounded-md border border-fd-border px-4 py-2 text-sm font-medium text-fd-foreground hover:bg-fd-accent"
+        >
+          Open playground
+        </Link>
+      </div>
+
+      <div className="mt-8">
+        <CountdownRedirect seconds={12} to="/" />
+      </div>
+    </main>
+  );
+}

--- a/website/components/CountdownRedirect.tsx
+++ b/website/components/CountdownRedirect.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Human-only countdown back to the homepage. Lives entirely client-side, so
+ * the page still responds with a real HTTP 404 — crawlers see the 404 status
+ * and never run this redirect, which keeps us clear of "soft 404" penalties.
+ * Cancelable: a lost visitor who wants to read the URL or hit back can stay.
+ */
+export function CountdownRedirect({
+  seconds = 12,
+  to = '/',
+}: {
+  seconds?: number;
+  to?: string;
+}) {
+  const [remaining, setRemaining] = useState(seconds);
+  const [active, setActive] = useState(true);
+
+  useEffect(() => {
+    if (!active) return;
+    if (remaining <= 0) {
+      window.location.assign(to);
+      return;
+    }
+    const id = setTimeout(() => setRemaining((r) => r - 1), 1000);
+    return () => clearTimeout(id);
+  }, [remaining, active, to]);
+
+  if (!active) {
+    return (
+      <p className="text-sm text-fd-muted-foreground" role="status">
+        Staying put. Use the links above whenever you’re ready.
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm text-fd-muted-foreground"
+      role="status"
+      aria-live="polite"
+    >
+      <span>
+        Routing you home in{' '}
+        <span className="font-mono font-semibold text-fd-foreground tabular-nums">
+          {remaining}s
+        </span>
+      </span>
+      <button
+        type="button"
+        onClick={() => setActive(false)}
+        className="rounded-md border border-fd-border px-2.5 py-1 font-medium text-fd-foreground transition-colors hover:bg-fd-accent"
+      >
+        Stay on this page
+      </button>
+    </div>
+  );
+}

--- a/website/lib/i18n/LocaleSwitcher.tsx
+++ b/website/lib/i18n/LocaleSwitcher.tsx
@@ -69,7 +69,10 @@ export function LocaleSwitcher({
           <ul
             role="listbox"
             aria-label={label}
-            className="absolute bottom-full z-50 mb-2 max-h-72 min-w-[12rem] overflow-auto rounded-md border border-fd-border bg-fd-card py-1 shadow-lg"
+            className={
+              'absolute z-50 max-h-72 min-w-[12rem] overflow-auto rounded-md border border-fd-border bg-fd-card py-1 shadow-lg ' +
+              (variant === 'header' ? 'right-0 top-full mt-2' : 'bottom-full mb-2')
+            }
           >
             {LIVE_LOCALES.map((loc) => (
               <li key={loc}>

--- a/website/lib/i18n/get-dictionary.ts
+++ b/website/lib/i18n/get-dictionary.ts
@@ -1,6 +1,6 @@
 import type { Dictionary } from './dictionaries/en';
 import { en } from './dictionaries/en';
-import { DEFAULT_LOCALE, type SupportedLocale } from './locales';
+import type { SupportedLocale } from './locales';
 
 // Lazy per-locale loaders. Only locales with a shipped dictionary appear here;
 // anything else falls back to English (and such a locale should never reach a
@@ -26,6 +26,6 @@ const loaders: Partial<Record<SupportedLocale, () => Promise<Dictionary>>> = {
 };
 
 export async function getDictionary(locale: string): Promise<Dictionary> {
-  const load = loaders[locale as SupportedLocale] ?? loaders[DEFAULT_LOCALE]!;
+  const load = loaders[locale as SupportedLocale] ?? (() => Promise.resolve(en));
   return load();
 }


### PR DESCRIPTION
## Why

Google Search Console flagged **43 "Not found (404)"** URLs, almost all of the form `https://schematex.js.org/examples/{slug}/opengraph-image`, plus a couple of stray crawled paths (`/3`, `/N`).

**Root cause of the bulk 404s:** the example page's `TechArticle` JSON-LD hardcoded `image: ${url}/opengraph-image`. Next.js serves the dynamic `[slug]` OG image at a *hashed* segment (`/opengraph-image-133e0p?hash`), so the bare path 404s. Google crawls JSON-LD `image` URLs → 43 permanent 404s. The actual `og:image` / `twitter:image` **meta tags already carry the correct hashed URL (verified 200)**, so social sharing was never broken — the JSON-LD field was a redundant, 404-ing self-reference.

## Changes

**SEO fix** (`51ccc4a`)
- `examples/[slug]/page.tsx`: drop the bare `/opengraph-image` from JSON-LD. Verified locally: JSON-LD no longer references it; `og:image` meta still resolves to the hashed 200 image.

**Custom 404 page** (`923db2a`)
- New `app/not-found.tsx` + `components/CountdownRedirect.tsx`: replaces the bare framework 404 with an on-brand page that *is itself a rendered flowchart* (`You are here → Page exists? → No → 404 → home`), with links back to home/examples/playground and a **cancelable** countdown redirect.
- Keeps a real **HTTP 404 status** — the redirect is client-only, so crawlers see 404 and never follow it. This is a friendly custom 404, **not** a soft 404 (200 + error content). Verified: `GET /3 → 404`, diagram renders & scales, no console errors.

**i18n followups** (`7226967`) — uncommitted local work that didn't make it into #36:
- `[lang]/layout.tsx`: wrap header+content in `dir={localeDir(lang)}` + `lang` for RTL locales.
- `LocaleSwitcher.tsx`: position dropdown by variant (header opens down, footer opens up).
- `get-dictionary.ts`: fall back to the imported `en` dict directly instead of `loaders[DEFAULT_LOCALE]`.

## After merge / deploy
- The 43 `/opengraph-image` URLs will still return 404 (correct — never real pages); nothing references them anymore, so GSC resolves them on re-crawl. Click **Validate Fix** in the report.
- Stray paths like `/3`, `/N` now land on the friendly 404 instead of the framework default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)