### PR TITLE
fix: circuit ERC conventional-net false positives + flowchart auto label wrap (0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.1] — 2026-06-09
+
+### Added — flowchart auto label wrapping
+
+The long-standing layout TODO ("until line-wrapping lands") is in: node labels measuring wider than the new `FC_CONST.wrapLabelWidth` (260px ≈ 38 Latin / 20 full-width chars) are wrapped automatically instead of growing into a 420px single-line strip and overflowing the shape — the most-reported readability complaint from production flowcharts (truncated/overlapping labels on prose-style nodes).
+
+- **`wrapLabel()`** (`src/diagrams/flowchart/layout.ts`) — greedy line breaking that prefers spaces (consumed at the break), treats every full-width glyph as a valid break point (spaceless CJK prose wraps cleanly), and hard-breaks unbreakable over-wide tokens (URLs, ids) rather than letting them overflow. Applied once at `layoutFlowchart` entry, so sizing, the existing multi-line height growth, and the renderer's `<tspan>` output all see the same wrapped text.
+- **Deliberately conservative**: labels with explicit `<br/>`/`\n` breaks keep the author's line choices, and labels containing inline `<b>`/`<i>` markup pass through untouched (a styled span cannot be split across the per-line segment parser without breaking styling).
+- `FC_CONST.maxLabelWidth` (420) is retained as the final clamp, but now only bites on unbreakable single tokens that survive wrapping.
+
+### Fixed — circuit ERC: conventional rail/port names no longer flagged as floating
+
+`CIRCUIT_FLOATING_NET` was the single largest source of spurious `partial` statuses in production (~3,300 reports in 14 days): textbook schematics deliberately leave supply rails and labeled I/O terminals as single-pin nets — opamp supply wiring is conventionally omitted (`vcc`/`vee` declared only on their sources) and the output node is labeled `out` and left open as a port.
+
+- **`isConventionalOpenNet()`** (`src/diagrams/circuit/lint.ts`) — single-pin nets matching power-rail conventions (`vcc`/`vdd`/`vee`/`vss`/`vref`/… , voltage literals `+5V`/`3.3V`/`3V3`), I/O-port names (`in`/`out`/`vin`/`vout`, numbered variants, `_in`/`_out` compound suffixes like `pwm_in`), or header-broken-out serial/control pins (`sda1`, `tx`, `clk`, `rst`, …) now skip the floating-net and typo checks entirely. Such circuits validate `valid` instead of `partial`.
+- Everything else keeps the full ERC: non-conventional dangling names (`base1`, `gate`) are still flagged, and the one-edit-away `CIRCUIT_NET_TYPO` detection is unchanged.
+
+---
+
 ## [0.9.0] — 2026-06-05
 
 ### Added — LLM-emittable grammar cards: all 45 families hardened + single-shot context (PR #35)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/circuit/lint.ts
+++ b/src/diagrams/circuit/lint.ts
@@ -48,6 +48,33 @@ const GROUND_TYPES = new Set<CircuitComponentType>([
 /** Auto-synthesized floating no-connect nets from pin under-specification. */
 const NC_NET = /_nc\d+$/;
 
+/**
+ * Net names that are single-pin **by convention** — power-rail flags and
+ * labeled I/O ports. In hand-drawn and EDA schematics alike, supply rails
+ * (VCC/VEE on a source whose consumers are not drawn — opamp supply pins are
+ * conventionally omitted) and labeled open terminals (`out` on the load) are
+ * deliberate, not wiring mistakes. These were the dominant real-world false
+ * positives for CIRCUIT_FLOATING_NET, so they skip the floating/typo checks
+ * entirely; everything else still gets the full ERC.
+ */
+const CONVENTIONAL_OPEN_NET = [
+  // power rails: vcc vdd vee vss vbat vbus vref vcore avcc avdd dvdd dvss agnd dgnd
+  /^(vcc|vdd|vee|vss|vbat|vbus|vref|vcore|avcc|avdd|dvdd|dvss|agnd|dgnd)\d*$/i,
+  // voltage-literal rails: +5V, -12v, 3.3V, 3V3, 1V8
+  /^[+-]?\d+(\.\d+)?v$/i,
+  /^\d+v\d+$/i,
+  // I/O ports: in, out, input, output, vin, vout, io (optionally numbered)
+  /^(v?in|v?out|input|output|io)\d*$/i,
+  // compound port suffixes: pwm_in, sig_out, audio_in2
+  /(^|[_.])(in|out|input|output)\d*$/i,
+  // serial/control pins broken out to headers: sda1, tx, clk, rst …
+  /^(sda|scl|tx|rx|txd|rxd|clk|sck|xtal|mosi|miso|cs|ss|en|rst|reset|nrst|int|irq|pwm)\d*$/i,
+];
+
+function isConventionalOpenNet(id: string): boolean {
+  return CONVENTIONAL_OPEN_NET.some((re) => re.test(id));
+}
+
 function componentIdOfAnchor(anchor: string): string {
   const dot = anchor.lastIndexOf(".");
   return dot < 0 ? anchor : anchor.slice(0, dot);
@@ -149,6 +176,7 @@ export function lintCircuit(text: string): SchematexDiagnostic[] {
     if (net.id === "GND") continue;            // ground rail fans out by nature
     if (NC_NET.test(net.id)) continue;         // already covered by underspecified
     if (net.anchors.length !== 1) continue;
+    if (isConventionalOpenNet(net.id)) continue; // rails/ports are open by design
 
     const comp = compById.get(componentIdOfAnchor(net.anchors[0]));
     if (comp && INTENTIONAL_SINGLE_PIN.has(comp.componentType)) continue;

--- a/src/diagrams/flowchart/layout.ts
+++ b/src/diagrams/flowchart/layout.ts
@@ -42,12 +42,18 @@ export const FC_CONST = {
   labelHPad: 16,
   minNodeWidth: 72,
   /**
-   * Cap on per-line label width. Until line-wrapping lands, this clamp is
-   * a soft contract: nodes never grow past this, and any overflow becomes
-   * the caller's problem. Set generously so common CJK sentences (≤30
-   * full-width chars) still fit without truncation or text overflow.
+   * Cap on per-line label width. Labels wider than `wrapLabelWidth` are
+   * auto-wrapped first (see `wrapLabel`), so this clamp only bites on
+   * unbreakable single tokens that survive wrapping (URLs, ids).
    */
   maxLabelWidth: 420,
+  /**
+   * Auto-wrap target: a single-line label measuring wider than this is
+   * broken into multiple lines (preferring spaces, falling back to CJK
+   * char boundaries). ≈38 Latin chars / ≈20 full-width chars per line —
+   * keeps prose nodes near a readable 3:1 aspect instead of a 400px strip.
+   */
+  wrapLabelWidth: 260,
   crossingSweepIters: 24,
 } as const;
 
@@ -133,6 +139,68 @@ export function measureLabelWidth(label: string): number {
     if (w > max) max = w;
   }
   return max;
+}
+
+/**
+ * Auto-wrap a node label that renders wider than `FC_CONST.wrapLabelWidth`.
+ *
+ * Conservative on purpose — only single-line, markup-free labels are
+ * touched. Explicit `<br/>`/`\n` breaks mean the author already chose line
+ * boundaries, and inline `<b>`/`<i>` spans cannot be split across the
+ * per-line segment parser in core/svg.ts:multilineText without breaking
+ * styling, so both pass through unchanged.
+ *
+ * Break preference: after a space (the space is consumed) or after any
+ * full-width glyph (CJK prose has no spaces). A single token wider than the
+ * wrap target hard-breaks mid-token rather than overflowing its shape.
+ */
+export function wrapLabel(label: string): string {
+  const text = String(label);
+  if (/<br\s*\/?>|\n/i.test(text)) return label; // author-chosen breaks
+  if (/<\/?[bi]>/i.test(text)) return label; // inline markup — do not split
+  if (measureLineWidth(text) <= FC_CONST.wrapLabelWidth) return label;
+
+  const maxW = FC_CONST.wrapLabelWidth;
+  const lines: string[] = [];
+  let line = "";
+  let lineW = 0;
+  let breakAt = -1; // index into `line` AFTER which we may break
+  let breakIsSpace = false;
+
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+    const chW = isFullWidth(code) ? FC_CONST.cjkCharWidth : FC_CONST.charWidth;
+
+    if (ch === " " && line.length > 0) {
+      breakAt = line.length; // break before this space, consuming it
+      breakIsSpace = true;
+    }
+
+    if (lineW + chW > maxW && line.length > 0) {
+      if (breakAt > 0) {
+        const head = line.slice(0, breakAt);
+        const tail = line.slice(breakIsSpace ? breakAt + 1 : breakAt);
+        lines.push(head);
+        line = tail;
+      } else {
+        lines.push(line); // unbreakable token — hard break
+        line = "";
+      }
+      lineW = measureLineWidth(line);
+      breakAt = -1;
+      breakIsSpace = false;
+      if (ch === " " && line.length === 0) continue; // never lead with a space
+    }
+
+    line += ch;
+    lineW += chW;
+    if (isFullWidth(code)) {
+      breakAt = line.length; // CJK glyphs are valid break points
+      breakIsSpace = false;
+    }
+  }
+  if (line.length > 0) lines.push(line);
+  return lines.join("\n");
 }
 
 // ─── Internal working types ────────────────────────────────
@@ -921,6 +989,11 @@ function hasOverlappingTopLevelClusters(
 export function layoutFlowchart(ast: FlowchartAST): FlowchartLayoutResult {
   const dir: FlowchartDirection = ast.direction;
   const isHorizontalDir = dir === "LR" || dir === "RL";
+
+  // ── Auto-wrap over-wide labels ───────────────────────────
+  // In-place on the AST (which this function already mutates for implicit
+  // nodes) so sizing below and the renderer both see the wrapped text.
+  for (const n of ast.nodes) n.label = wrapLabel(n.label);
 
   // ── Measure node sizes ───────────────────────────────────
   // Returned w/h are in "abstract TB space" — flow direction is always Y.

--- a/tests/circuit/erc.test.ts
+++ b/tests/circuit/erc.test.ts
@@ -52,11 +52,13 @@ describe("circuit ERC — no ground reference", () => {
 
 describe("circuit ERC — floating net", () => {
   test("a net touched by only one pin is flagged", () => {
-    // R1.end -> `out` goes nowhere else.
-    const diags = lintCircuit('circuit "fl" netlist\nV1 vin 0 5V\nR1 vin out 1k');
+    // R1.end -> `n_load` goes nowhere else (and matches no port/rail convention).
+    const diags = lintCircuit(
+      'circuit "fl" netlist\nV1 vin 0 5V\nR1 vin n_load 1k'
+    );
     const fl = diags.find((d) => d.code === "CIRCUIT_FLOATING_NET");
     expect(fl).toBeDefined();
-    expect(fl!.message).toContain('"out"');
+    expect(fl!.message).toContain('"n_load"');
   });
 
   test("a fully wired divider has no floating nets", () => {
@@ -71,6 +73,56 @@ describe("circuit ERC — floating net", () => {
         'circuit "p" netlist\nV1 vin 0 5V\nR1 vin out 1k\nP1 out type=port'
       )
     ).not.toContain("CIRCUIT_FLOATING_NET");
+  });
+});
+
+describe("circuit ERC — conventional open nets (rails + ports)", () => {
+  // Textbook/EDA convention: power-rail flags and labeled I/O ports are
+  // single-pin nets *by design* (opamp supplies are routinely not drawn).
+  // These were the dominant production false positives: `vcc`/`vee` on the
+  // supply sources and `out` on the load.
+  test("supply rails declared only on their source are not floating", () => {
+    const dsl =
+      'circuit "amp" netlist\nV1 vcc 0 +12V\nV2 0 vee value=12V\nR1 sig amp_out 10k\nVin sig 0 type=ac value=1Vpp\nU1 0 sig amp_out type=opamp\nRload amp_out 0 1k';
+    const diags = lintCircuit(dsl);
+    expect(
+      diags.filter((d) => d.code === "CIRCUIT_FLOATING_NET")
+    ).toHaveLength(0);
+  });
+
+  test("an open output port named `out` is not floating", () => {
+    expect(
+      codes('circuit "o" netlist\nV1 vin 0 5V\nR1 vin out 1k')
+    ).not.toContain("CIRCUIT_FLOATING_NET");
+  });
+
+  test("voltage-literal rails (3V3, +5V) and numbered ports (out2, sda1) pass", () => {
+    const dsl =
+      'circuit "mcu" netlist\nV1 3V3 0 3.3V\nR1 a out2 1k\nR2 a sda1 4k7\nV2 a 0 5V';
+    expect(codes(dsl)).not.toContain("CIRCUIT_FLOATING_NET");
+  });
+
+  test("underscore port suffixes (pwm_in, sig_out) pass", () => {
+    const dsl =
+      'circuit "io" netlist\nV1 a 0 5V\nR1 a pwm_in 1k\nR2 a sig_out 1k';
+    expect(codes(dsl)).not.toContain("CIRCUIT_FLOATING_NET");
+  });
+
+  test("non-conventional dangling names (base1, gate) are still flagged", () => {
+    const diags = lintCircuit(
+      'circuit "q" netlist\nV1 a 0 5V\nR1 a base1 1k\nR2 a gate 1k'
+    );
+    const floats = diags.filter((d) => d.code === "CIRCUIT_FLOATING_NET");
+    expect(floats.map((d) => d.message).join(" ")).toContain('"base1"');
+    expect(floats.map((d) => d.message).join(" ")).toContain('"gate"');
+  });
+
+  test("conventional open nets keep render status `valid`", () => {
+    const r = renderResult(
+      'circuit "ok" netlist\nV1 vcc 0 5V\nR1 vcc out 1k\nR2 vcc 0 2k'
+    );
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe("valid");
   });
 });
 

--- a/tests/flowchart/layout.test.ts
+++ b/tests/flowchart/layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { parseFlowchart } from "../../src/diagrams/flowchart/parser";
 import {
+  FC_CONST,
   layoutFlowchart,
   measureLabelWidth,
 } from "../../src/diagrams/flowchart/layout";
@@ -183,6 +184,92 @@ A -->|no| C[Reject]`);
       // Two-line PRISMA-style label: bold header + count. Height must exceed
       // single-line baseline.
       expect(n.height).toBeGreaterThan(50);
+    });
+  });
+
+  describe("auto label wrapping", () => {
+    const LONG_LATIN =
+      "Customer submits the online return request form with order number and reason";
+    const LONG_DE =
+      "Kasse ohne Artikel weiterleiten und den Bestand im Warenwirtschaftssystem korrigieren";
+    const LONG_CJK =
+      "為降低不同資料來源及原始訊號品質差異對分析結果之影響本研究針對資料集進行前處理與特徵擷取";
+
+    const layoutSingle = (label: string) => {
+      const r = layoutFlowchart(parseFlowchart(`flowchart TD\nA["${label}"]`));
+      return r.nodes.find((n) => n.node.id === "A")!;
+    };
+
+    test("a long Latin sentence wraps into multiple lines within the wrap width", () => {
+      const n = layoutSingle(LONG_LATIN);
+      const lines = n.node.label.split("\n");
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) {
+        expect(measureLabelWidth(line)).toBeLessThanOrEqual(
+          FC_CONST.wrapLabelWidth
+        );
+      }
+      // No word is lost or split: rejoining restores the original sentence.
+      expect(lines.join(" ").replace(/\s+/g, " ")).toBe(LONG_LATIN);
+      // The node is no longer a 1-line monster strip.
+      expect(n.width).toBeLessThan(FC_CONST.wrapLabelWidth + 60);
+      expect(n.height).toBeGreaterThan(44);
+    });
+
+    test("German compound words wrap at spaces, never inside a word", () => {
+      const n = layoutSingle(LONG_DE);
+      const lines = n.node.label.split("\n");
+      expect(lines.length).toBeGreaterThan(1);
+      expect(lines.join(" ").replace(/\s+/g, " ")).toBe(LONG_DE);
+      expect(lines.some((l) => l.includes("Warenwirtschaftssystem"))).toBe(
+        true
+      );
+    });
+
+    test("spaceless CJK wraps at character boundaries", () => {
+      const n = layoutSingle(LONG_CJK);
+      const lines = n.node.label.split("\n");
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) {
+        expect(measureLabelWidth(line)).toBeLessThanOrEqual(
+          FC_CONST.wrapLabelWidth
+        );
+      }
+      expect(lines.join("")).toBe(LONG_CJK);
+    });
+
+    test("labels with explicit <br/> are left untouched", () => {
+      const n = layoutSingle(
+        "first part of a deliberately long line<br/>second"
+      );
+      expect(n.node.label).toContain("<br/>");
+      expect(n.node.label).not.toContain("\n");
+    });
+
+    test("labels with inline <b>/<i> markup are left untouched", () => {
+      const long =
+        "<b>Total records identified from databases and registers combined</b>";
+      const n = layoutSingle(long);
+      expect(n.node.label).toBe(long);
+    });
+
+    test("short labels are untouched", () => {
+      const n = layoutSingle("Done");
+      expect(n.node.label).toBe("Done");
+      expect(n.width).toBeGreaterThanOrEqual(72);
+    });
+
+    test("an unbreakable over-wide token hard-breaks rather than overflowing", () => {
+      const token = "a".repeat(80); // 80 × 6.8px ≈ 544px > wrap width
+      const n = layoutSingle(token);
+      const lines = n.node.label.split("\n");
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) {
+        expect(measureLabelWidth(line)).toBeLessThanOrEqual(
+          FC_CONST.wrapLabelWidth
+        );
+      }
+      expect(lines.join("")).toBe(token);
     });
   });
 


### PR DESCRIPTION
## What

Two production-driven quality fixes from ChatDiagram telemetry analysis (14-day window), released as **0.9.1**.

### 1. Circuit ERC — conventional rail/port names no longer flagged as floating

`CIRCUIT_FLOATING_NET` was the single largest source of spurious `partial` statuses in production (**~3,300 reports / 302 users in 14 days**). The dominant pattern is textbook-correct: supply rails declared only on their sources (`V1 vcc 0 +12V` — opamp supply wiring conventionally omitted) and the output node labeled `out`, left open as a port.

- New `isConventionalOpenNet()` in `src/diagrams/circuit/lint.ts`: single-pin nets matching power-rail names (`vcc`/`vdd`/`vee`/`vss`/`vref`/…, voltage literals `+5V`/`3V3`), IO-port names (`in`/`out`/`vin`/`vout`, numbered, `_in`/`_out` suffixes), or header-broken-out serial/control pins (`sda1`, `tx`, `clk`, `rst`, …) skip the floating/typo checks. These circuits now validate `valid`.
- Non-conventional dangling nets (`base1`, `gate`) are still flagged; `CIRCUIT_NET_TYPO` unchanged.

### 2. Flowchart — auto label wrapping (lands the "until line-wrapping lands" TODO)

Prose-style node labels grew into single-line 420px strips and overflowed their shapes — the most concrete readability complaint in production chats (truncated/overlapping German + CJK labels).

- New `wrapLabel()` in `src/diagrams/flowchart/layout.ts`: labels wider than `FC_CONST.wrapLabelWidth` (260px) wrap greedily — spaces preferred (consumed at the break), every full-width glyph is a break point (spaceless CJK wraps cleanly), unbreakable over-wide tokens hard-break instead of overflowing.
- Conservative by design: labels with explicit `<br/>`/`\n` or inline `<b>`/`<i>` markup pass through untouched.
- Applied once at `layoutFlowchart` entry, so sizing, multi-line height growth, and the renderer's `<tspan>` output all agree.

## Tests

13 new tests (6 circuit ERC conventional-net cases, 7 wrapping cases incl. German compound words, spaceless CJK, `<br/>`/markup passthrough, unbreakable-token hard break). One existing test updated: the generic floating-net case now uses a non-conventional net name (`n_load`) since `out` is exempt by design.

## Quality gate

- typecheck ✅ · vitest **1587/1587** ✅ · lint 0 errors ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
