### PR TITLE
fix(floorplan): emit SVG width/height; fit example preview to pane

### DIFF
--- a/src/diagrams/floorplan/renderer.ts
+++ b/src/diagrams/floorplan/renderer.ts
@@ -82,7 +82,7 @@ function renderErrorPanel(lay: FloorplanLayoutResult, t: Theme): string {
   const w = Math.max(560, ...lines.map((l) => l.length * 6.6 + 48));
   const h = 56 + lines.length * 19;
   return svgRoot(
-    { viewBox: `0 0 ${r2(w)} ${h}`, class: "sx-fp", role: "img" },
+    { viewBox: `0 0 ${r2(w)} ${h}`, width: r2(w), height: h, class: "sx-fp", role: "img" },
     [
       titleEl(lay.title),
       descEl(`Floor plan validation failed with ${lines.length} error${lines.length === 1 ? "" : "s"}.`),
@@ -502,7 +502,7 @@ export function renderFloorplanLayout(lay: FloorplanLayoutResult, config?: Rende
     (lay.warnings.length ? ` Warnings: ${lay.warnings.join("; ")}.` : "");
 
   return svgRoot(
-    { viewBox: `0 0 ${W} ${H}`, class: "sx-fp", role: "img" },
+    { viewBox: `0 0 ${W} ${H}`, width: W, height: H, class: "sx-fp", role: "img" },
     [
       titleEl(lay.title),
       descEl(descText),

--- a/website/app/(home)/examples/[slug]/page.tsx
+++ b/website/app/(home)/examples/[slug]/page.tsx
@@ -86,7 +86,7 @@ export default async function ExampleDetailPage({
   };
 
   return (
-    <main className="mx-auto max-w-6xl px-6 py-10">
+    <main className="mx-auto w-full max-w-6xl px-6 py-10">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/website/components/Playground.tsx
+++ b/website/components/Playground.tsx
@@ -366,7 +366,7 @@ export function Playground({ initial, height = 560, fill = false, syncHash = fal
             </pre>
           ) : svg ? (
             <div
-              className="[&_svg]:block [&_svg]:max-h-full [&_svg]:max-w-full"
+              className="flex h-full w-full items-center justify-center [&_svg]:block [&_svg]:max-h-full [&_svg]:max-w-full"
               style={{ transform: `scale(${zoom / 100})`, transformOrigin: 'center center' }}
               dangerouslySetInnerHTML={{ __html: svg }}
             />


### PR DESCRIPTION
## What

Three fixes — one root bug plus two layout issues surfaced while diagnosing the floorplan example preview not rendering.

### 1. Floorplan preview rendered blank (the reported bug)
Floorplan was the **only** diagram emitting a bare `viewBox` with no `width`/`height` on its SVG root. Without intrinsic dimensions, the inline SVG collapsed to **0×0** inside the content-sized playground preview wrapper — the DSL parsed and the SVG generated fine (footer showed `✓ parsed · 45.1 KB SVG`), but nothing was visible. Added `width`/`height` to both the main render and the error panel, matching every other diagram type.

> Affects all floorplan consumers (PNG export, OG images, integrations), not just the example page. Gallery thumbnails use live `render()` so they're covered too.

### 2. Example detail pages narrower than the site header
`<main>` used `mx-auto max-w-6xl` on a flex-column `body`, where `mx-auto` disables flex stretch and the element collapses to its max-content width (~816px) instead of the 1152px cap — visibly narrower than the 1152px site header. Added `w-full` so it fills to `max-w-6xl`. Affects every example detail page.

### 3. Preview image didn't fit the pane
The preview's `max-w/h-full` referenced the content-sized wrapper, not the `.dot-grid` viewport, so large diagrams overflowed (scroll) instead of fitting. Made the wrapper fill the viewport so the constraint applies. Floorplan (918×837) now scales to fit; small diagrams unaffected (max only shrinks).

## Verification
- 76 floorplan engine tests pass.
- Browser-verified on `/examples/floorplan-family-home`: SVG now `918.5×837.5`, renders at `503×396` inside `551×444` pane (`fits: true`); `main` now `1152px` aligned with header (was `816px`).
- No regression: `/playground` (fill mode) + genogram preview verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
