### PR TITLE
ci(gallery): regenerate gallery SVGs + add drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,9 @@ jobs:
       - run: npm run lint
 
       - run: npm run build
+
+      # Every bundled example DSL must still render.
+      - run: node scripts/validate-examples.mjs
+
+      # Gallery SVGs must match current engine output (no silent drift).
+      - run: npm run gallery:check

--- a/examples/floorplan/family-home.svg
+++ b/examples/floorplan/family-home.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 918.5 837.5" class="sx-fp" role="img"><title>Four-Bedroom Family Home — 160 m²</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 918.5 837.5" width="918.5" height="837.5" class="sx-fp" role="img"><title>Four-Bedroom Family Home — 160 m²</title>
 <desc>11 rooms, 160.1 m² total. 49 furniture items.</desc>
 <style>.sx-fp { font-family: system-ui, -apple-system, sans-serif; }
 .sx-fp-title { font: 700 16px sans-serif; fill: #0f172a; }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,8 @@
     "lint": "eslint src/",
     "typecheck": "npm run build:ai && tsc --noEmit",
     "validate:examples": "npm run build && node scripts/validate-examples.mjs",
+    "gallery": "node scripts/generate-gallery-svgs.mjs",
+    "gallery:check": "node scripts/generate-gallery-svgs.mjs && git diff --exit-code -- examples/",
     "prepublishOnly": "npm run build && npm run typecheck"
   },
   "keywords": [


### PR DESCRIPTION
## What

Stops the **gallery SVGs from silently drifting** from engine output, and adds two missing CI gates.

The committed gallery SVGs (used in the README and website thumbnails) are generated by `scripts/generate-gallery-svgs.mjs`. When an engine changes but that script isn't re-run, the committed SVG goes stale with no signal — e.g. `examples/floorplan/family-home.svg` never got the `width`/`height` the floorplan engine started emitting in #42.

## Changes

- **Regenerate** `examples/floorplan/family-home.svg` to current output.
- **npm scripts**: `gallery` (generate) and `gallery:check` (generate + `git diff --exit-code -- examples/`).
- **CI** (`ci.yml`) now runs, after build:
  - `validate-examples` — every bundled example DSL still renders (wasn't in CI before).
  - `gallery:check` — fails the build if any gallery SVG drifts from current engine output.

## Follow-up (separate PR)

Audit of the probability formatters surfaced that `faulttree`'s `fmtProb` has the **same near-1 rounding bug** fixed in RBD (`n.toPrecision(3)` collapses 0.9999 → "1") and uses a coarse 3-sig-fig precision; `eventtree` should be checked too. A shared `formatProbability` helper (0/1 guards, exponential for tiny, nines-preserving near 1) is worth extracting — kept out of this PR to keep the gallery-gate change focused and because it touches computational-engine output.

## Verification

- ✅ `gallery:check` passes clean locally (exit 0)
- ✅ build · typecheck · full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
