### PR TITLE
fix(faulttree): probability formatter no longer rounds P(top)≈1 to '1'

### DIFF
--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared numeric formatting helpers for diagram engines.
+ */
+
+/**
+ * Format a probability / reliability in [0, 1] for display.
+ *
+ * - `≤ 0` → `"0"`, `≥ 1` → `"1"` (exact endpoints).
+ * - `< 0.001` → scientific notation (`"1.2e-4"`), so very rare/likely events
+ *   stay legible instead of collapsing to `"0.00"`.
+ * - otherwise three significant figures — but the precision is *escalated* as
+ *   the value approaches 1 so a sub-1 number never rounds up to `"1"` and hides
+ *   its nines (e.g. `0.9999` stays `"0.9999"`, not `"1"`). The "number of nines"
+ *   is exactly what matters for high reliabilities, so it must survive.
+ */
+export function formatProbability(n: number): string {
+  if (!Number.isFinite(n)) return String(n);
+  if (n <= 0) return "0";
+  if (n >= 1) return "1";
+  if (n < 1e-3) return n.toExponential(2);
+  for (let p = 3; p <= 9; p++) {
+    const s = parseFloat(n.toPrecision(p));
+    if (s > 0 && s < 1) return String(s);
+  }
+  return String(parseFloat(n.toPrecision(9)));
+}

--- a/src/diagrams/faulttree/renderer.ts
+++ b/src/diagrams/faulttree/renderer.ts
@@ -31,6 +31,7 @@ import {
   STROKE_WIDTH,
   resolveReliabilityTheme,
 } from "../../core/theme";
+import { formatProbability } from "../../core/format";
 import { parseFaultTree } from "./parser";
 import { layoutFaultTree, eventBox, FAULTTREE_CONST as C } from "./layout";
 import type {
@@ -316,10 +317,11 @@ function summarise(layout: FaultTreeLayoutResult): string {
 
 // ─── Helpers ──────────────────────────────────────────────────
 
+// Shared formatter: 3 sig figs, scientific for tiny values, and — the fix over
+// the old inline version — precision escalates near 1 so P(top) ≈ 1 keeps its
+// nines instead of rounding to "1".
 function fmtProb(n: number): string {
-  if (n === 0) return "0";
-  if (n >= 0.001) return String(parseFloat(n.toPrecision(3)));
-  return n.toExponential(2);
+  return formatProbability(n);
 }
 
 function clip(s: string, n: number): string {

--- a/tests/core/format.test.ts
+++ b/tests/core/format.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatProbability } from "../../src/core/format";
+
+describe("formatProbability", () => {
+  it("clamps the endpoints", () => {
+    expect(formatProbability(0)).toBe("0");
+    expect(formatProbability(-0.1)).toBe("0");
+    expect(formatProbability(1)).toBe("1");
+    expect(formatProbability(1.2)).toBe("1");
+  });
+
+  it("uses scientific notation for tiny values", () => {
+    expect(formatProbability(1e-4)).toBe("1.00e-4");
+    expect(formatProbability(0.00012)).toBe("1.20e-4");
+  });
+
+  it("uses three significant figures mid-range", () => {
+    expect(formatProbability(0.0234)).toBe("0.0234");
+    expect(formatProbability(0.5)).toBe("0.5");
+  });
+
+  it("never rounds a sub-1 value up to 1 — the nines survive", () => {
+    expect(formatProbability(0.9999)).toBe("0.9999");
+    expect(formatProbability(0.999999)).toBe("0.999999");
+    expect(formatProbability(0.99987)).not.toBe("1");
+  });
+});


### PR DESCRIPTION
## What

Extracts a shared `core/format.ts` **`formatProbability()`** and uses it in the fault-tree renderer.

## The bug

Fault-tree's inline `fmtProb` used `n.toPrecision(3)`, so a high top-event probability like `0.9999` rounded to **`1`** — hiding the nines, which are exactly what matters. This is the same class of bug fixed in RBD's reliability formatter; this PR unifies the rule.

## The fix

- Shared helper preserves fault-tree behaviour (3 significant figures mid-range, scientific notation for `< 0.001`) but **escalates precision near 1** so a sub-1 value never renders as `1` (`0.9999` stays `0.9999`).
- `eventtree` was audited — it has no probability formatter, so nothing to change there. RBD keeps its own reliability formatter (it wants more digits near 1 by default).

## Verification

- 4 new unit tests for `formatProbability` (endpoints, scientific tail, mid-range, near-1 nines).
- Full suite **1722 passing**; lint clean; no gallery-SVG drift (fault-tree examples have tiny P(top), so no rendered change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)