### PR TITLE
feat(analytics): consent-gated GA4 (G-3H1N0Y0SJV)

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -3,6 +3,7 @@ import { RootProvider } from 'fumadocs-ui/provider';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import { PlausibleAnalytics } from '@/components/plausible-analytics';
+import { CookieConsentGA } from '@/components/CookieConsentGA';
 import { DIAGRAM_TYPE_COUNT } from '@/lib/diagram-stats';
 
 export const metadata: Metadata = {
@@ -62,6 +63,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         >
           {children}
         </RootProvider>
+        <CookieConsentGA />
       </body>
     </html>
   );

--- a/website/components/CookieConsentGA.tsx
+++ b/website/components/CookieConsentGA.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Script from 'next/script';
+
+/**
+ * Google Analytics 4 loader, gated behind cookie consent.
+ *
+ * Why gated: GA4 sets cookies and is subject to GDPR/ePrivacy, so it must NOT
+ * load until the visitor opts in. Plausible (cookieless) stays always-on in the
+ * layout <head> and is intentionally NOT gated here.
+ *
+ * Behaviour:
+ * - First visit (no stored choice) → render the consent banner, GA stays off.
+ * - "Accept"  → persist 'granted', mount gtag.js, set GA cookies from then on.
+ * - "Decline" → persist 'denied', GA never loads.
+ * - Returning visitor → read the stored choice, skip the banner, load GA only if granted.
+ *
+ * Dormant by default: with no NEXT_PUBLIC_GA_ID set, this renders the banner
+ * only when a choice is pending — but never loads gtag — so wiring it up
+ * before the env var is configured is a no-op on tracking.
+ *
+ * No Privacy Policy link: Schematex has no /privacy page, so linking one would
+ * 404. Add the link back here if a privacy page ships.
+ */
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const STORAGE_KEY = 'schematex_cookie_consent'; // 'granted' | 'denied'
+
+type Consent = 'granted' | 'denied' | null;
+
+export function CookieConsentGA() {
+  const [consent, setConsent] = useState<Consent>(null);
+  // `decided` starts true so the banner renders nothing on the server and the
+  // first client paint — avoids a hydration mismatch and a flash of the banner.
+  const [decided, setDecided] = useState(true);
+
+  useEffect(() => {
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(STORAGE_KEY);
+    } catch {
+      // localStorage blocked (privacy mode) — treat as undecided, never load GA.
+    }
+    if (stored === 'granted' || stored === 'denied') {
+      setConsent(stored);
+      setDecided(true);
+    } else {
+      setDecided(false);
+    }
+  }, []);
+
+  function choose(value: Exclude<Consent, null>) {
+    try {
+      localStorage.setItem(STORAGE_KEY, value);
+    } catch {
+      // ignore — choice still applies for this session via state below
+    }
+    setConsent(value);
+    setDecided(true);
+  }
+
+  return (
+    <>
+      {GA_ID && consent === 'granted' && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script id="google-analytics" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${GA_ID}');
+            `}
+          </Script>
+        </>
+      )}
+
+      {!decided && (
+        <div
+          role="dialog"
+          aria-label="Cookie consent"
+          className="fixed inset-x-4 bottom-4 z-[100] mx-auto flex max-w-md flex-col gap-3 rounded-xl border border-gray-200 bg-white p-4 text-sm text-gray-900 shadow-lg sm:left-auto sm:right-4 sm:mx-0 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+        >
+          <p className="text-gray-600 dark:text-gray-400">
+            We use cookies to analyze traffic and improve your experience.
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => choose('denied')}
+              className="rounded-lg border border-gray-200 px-3 py-1.5 font-medium text-gray-600 transition hover:text-gray-900 dark:border-gray-700 dark:text-gray-400 dark:hover:text-gray-100"
+            >
+              Decline
+            </button>
+            <button
+              type="button"
+              onClick={() => choose('granted')}
+              className="rounded-lg bg-gray-900 px-3 py-1.5 font-medium text-white transition hover:opacity-90 dark:bg-gray-100 dark:text-gray-900"
+            >
+              Accept
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## What

Adds Google Analytics 4 to schematex.js.org behind a cookie-consent gate, matching the pattern rolled out across the portfolio (MyMap / CD / CM / Free tools / UserSay / ai-docs).

- **New** `website/components/CookieConsentGA.tsx` — env-based loader (`NEXT_PUBLIC_GA_ID`). gtag.js mounts **only after** the visitor clicks Accept; Decline / no-choice → GA never loads. Returning visitors skip the banner. Dormant when the env var is unset.
- **`website/app/layout.tsx`** — banner mounted in `<body>` (role=dialog). Plausible stays in `<head>`, always-on, **not** gated (cookieless).
- GA4 property **Schematex** + web stream `schematex` created; Measurement ID **G-3H1N0Y0SJV** set as `NEXT_PUBLIC_GA_ID` on Vercel (production + development).

## Notes

- **No Privacy Policy link** in the banner — Schematex has no `/privacy` page, so linking one would 404. Add it back when a privacy page ships.
- Dark-mode variants included since the site has a theme toggle.

## Verification (local, port 3033)

- Banner renders fresh; `window.gtag` undefined before consent ✓
- After Accept → banner gone, consent persisted (`schematex_cookie_consent=granted`), gtag.js with `id=G-3H1N0Y0SJV` loaded, `dataLayer` config fired ✓
- No console errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)