### PR TITLE
feat(ga): first-party proxy via Next.js rewrites

### DIFF
--- a/website/components/CookieConsentGA.tsx
+++ b/website/components/CookieConsentGA.tsx
@@ -65,7 +65,7 @@ export function CookieConsentGA() {
       {GA_ID && consent === 'granted' && (
         <>
           <Script
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+            src="/js/gtag.js"
             strategy="afterInteractive"
           />
           <Script id="google-analytics" strategy="afterInteractive">
@@ -73,7 +73,7 @@ export function CookieConsentGA() {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', '${GA_ID}');
+              gtag('config', '${GA_ID}', { transport_url: location.origin });
             `}
           </Script>
         </>

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -16,9 +16,18 @@ const withPlausibleProxyWrapper = withPlausibleProxy({
   customDomain: 'https://plausible.ideamarketfit.com',
 });
 
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  async rewrites() {
+    if (!GA_ID) return [];
+    return [
+      { source: '/js/gtag.js', destination: `https://www.googletagmanager.com/gtag/js?id=${GA_ID}` },
+      { source: '/g/collect', destination: 'https://www.google-analytics.com/g/collect' },
+    ];
+  },
   transpilePackages: ['schematex'],
   serverExternalPackages: ['@resvg/resvg-js'],
   outputFileTracingIncludes: {


### PR DESCRIPTION
## Summary
- Adds \`rewrites()\` to \`next.config.mjs\`: \`/js/gtag.js\` → googletagmanager.com, \`/g/collect\` → google-analytics.com (guarded by \`NEXT_PUBLIC_GA_ID\`)
- Updates \`CookieConsentGA\`: script \`src\` uses \`/js/gtag.js\` (same-origin), adds \`transport_url: location.origin\` so event hits go through \`/g/collect\`
- Fixes ~40-60% GA miss rate from uBlock/Brave/Safari ITP blocking direct googletagmanager.com requests

## Test plan
- [ ] Deploy and curl `https://schematex.js.org/js/gtag.js` → 200 + JS
- [ ] curl `/g/collect` → 204
- [ ] Accept cookies in browser → Network tab shows `/js/gtag.js` loaded from same origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)