### PR TITLE
fix(ai): surface shipped capabilities in generation context (floorplan/matrix/timing) → 0.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.10] — 2026-06-26
+
+### Fixed — AI generation context surfaced shipped capabilities (`floorplan`, `matrix`, `timing`)
+
+No engine changes — this release fixes the **AI-facing prompt context** (`buildPromptContext` / generation-tier grammar cards + featured examples) so that already-shipped capabilities are actually discoverable by an LLM on the default path. Audit driven by ChatDiagram production data (wedding "plan de table" requests that fell back to comment-stuffing because the model never saw the feature).
+
+- **`floorplan` — named seating charts.** The `seats "Alice" "Bob" …` clause (write occupant names onto auto-seated chairs — the difference between a venue plan and a seating chart) shipped in 0.9.x but was absent from the generation-tier grammar card and from every featured example, so the model couldn't emit it. Added `seats` to the `furniture` clause + a `prefer` bullet (with `plan de table` / 席次表 phrasing), and promoted **"Wedding seating chart — named guests"** to a featured example.
+- **`matrix` — QFD / SIPOC / Punnett body grammar.** The three computational modes (`matrix qfd` House-of-Quality, `matrix sipoc`, `matrix punnett`) were named as headers but their **body syntax was missing** from the grammar card, and no QFD/SIPOC/Punnett example was featured — the model knew the modes existed but couldn't write a valid document. Added the `what:`/`how:`/`rel`/`roof`, `suppliers:/inputs:/process:/outputs:/customers:`, and `cross:`/`trait` grammar + inline forms + `prefer` guidance, and featured the **House of Quality**, **monohybrid Punnett**, and **SIPOC** examples.
+- **`timing` — removed a phantom keyword.** The grammar card advertised `phase: FLOAT (0.0–1.0)`, which the timing engine never implemented — the model would emit it and the parse would fail. Removed.
+
+---
+
 ## [0.9.8] — 2026-06-15
 
 ### Added — Comparison & decision-matrix engine (`comparison`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/ai/_generated.ts
+++ b/src/ai/_generated.ts
@@ -1239,7 +1239,7 @@ export const EXAMPLES: readonly GeneratedExample[] = [
       "seating-chart"
     ],
     "complexity": 3,
-    "featured": false,
+    "featured": true,
     "dsl": "floorplan \"Wedding Seating Chart\" unit m\nroom hall \"Grand Ballroom\" at 0,0 size 17x13 nolabel\ndoor hall south at 50% width 1.8\nfurniture head-table \"Head Table\" in hall at 5.5,0.6 size 6x0.9 seats \"Bride\" \"Groom\" \"Mom\" \"Dad\" \"MOH\" \"Best Man\"\nfurniture round-table-8 \"Table 1\" in hall at 1,3.6 seats \"Alice\" \"Bob\" \"Carol\" \"Dave\" \"Eve\" \"Frank\" \"Grace\" \"Heidi\"\nfurniture round-table-8 \"Table 2\" in hall at 7,3.6 seats \"Ivan\" \"Judy\" \"Mallory\" \"Niaj\" \"Olivia\" \"Peggy\"\nfurniture round-table-8 \"Table 3\" in hall at 13,3.6 seats \"张伟\" \"李娜\" \"王芳\" \"刘洋\"\nfurniture round-table-8 \"Table 4\" in hall at 1,8.4 seats \"Quinn\" \"Rupert\" \"Sybil\" \"Trent\" \"Uma\" \"Vera\"\nfurniture round-table-8 \"Table 5\" in hall at 7,8.4 seats \"Walt\" \"Xena\" \"Yuki\" \"Zane\"\nfurniture dance-floor \"Dance Floor\" in hall at 12,8 size 4.5x4.5",
     "notes": "## What this shows\n\nEach table is an individual `furniture` statement with a `seats \"…\"` clause, so the engine writes guest names onto the chairs in seating order — round tables clockwise from the top, the head table along its single facing edge. That is the difference between a *venue plan* (where the tables go) and a *seating chart* (who sits where), which is the deliverable guests actually read off the easel.\n\nNames map to chairs one-for-one: **Table 3** lists four guests on an eight-chair round, so four chairs are named and four stay empty — no error. CJK names (`张伟`, `李娜`) are quoted like any label. Because names render horizontally, the tables are left unrotated."
   },
@@ -1850,7 +1850,7 @@ export const EXAMPLES: readonly GeneratedExample[] = [
       "biology"
     ],
     "complexity": 1,
-    "featured": false,
+    "featured": true,
     "dsl": "matrix punnett \"Eye color  (Bb × Bb)\"\ncross: Bb x Bb\ntrait B: \"Brown eyes\" / \"Blue eyes\"",
     "notes": "## What this shows\n\nThe **monohybrid cross** is where every genetics course starts: one gene, two heterozygous parents. Here both parents are `Bb` for eye colour — `B` (brown) is dominant, `b` (blue) recessive. You write only the cross; the engine does the Mendelian bookkeeping.\n\nEach `Bb` parent makes two gametes, `B` and `b`, so the grid is 2×2. The engine fills it — `BB`, `Bb`, `Bb`, `bb` — and computes the two ratios every student memorises: a **3:1 phenotype ratio** (3 brown-eyed : 1 blue-eyed) and a **1:2:1 genotype ratio** (1 `BB` : 2 `Bb` : 1 `bb`). The single recessive `bb` box is tinted apart from the three dominant boxes, and the `trait` line names the phenotypes so the legend reads in plain English. Allele case sets dominance — uppercase is dominant — so the notation is exactly what a textbook uses."
   },
@@ -1887,7 +1887,7 @@ export const EXAMPLES: readonly GeneratedExample[] = [
       "voice-of-customer"
     ],
     "complexity": 3,
-    "featured": false,
+    "featured": true,
     "dsl": "matrix qfd \"Coffee maker\"\nwhat: \"Quiet operation\" weight: 5\nwhat: \"Brews fast\" weight: 3\nwhat: \"Energy efficient\" weight: 4\nhow: \"Fan RPM\" dir: down\nhow: \"Heater watts\" dir: up\nhow: \"Insulation\" dir: up\nrel (0,0): 9\nrel (0,2): 3\nrel (1,1): 9\nrel (2,1): 3\nrel (2,2): 9\nroof (0,1): --\nroof (1,2): +",
     "notes": "## What this shows\n\nThe **House of Quality** — the core matrix of Akao's Quality Function Deployment — translates what customers want into the engineering characteristics that deliver it. Customer requirements (**WHATs**) are the rows, each with an importance weight; engineering characteristics (**HOWs**) are the columns; the body cells record how strongly each HOW serves each WHAT on the 9 / 3 / 1 strong-medium-weak scale.\n\nThe differentiator is the computed row at the foot of the house: each column's **technical importance** is the sum of `weight × strength` down that column, here **45 / 39 / 51** — so Insulation (51) is the highest-leverage characteristic to invest in and Heater watts (39) the lowest. (Add `normalize: true` to read these as 33% / 29% / 38% instead.) Above the columns, the **roof** is a half-matrix of diamond cells recording HOW-to-HOW correlations: `roof (0,1): --` flags that lowering Fan RPM while raising Heater watts is a trade-off, while `roof (1,2): +` flags that Heater watts and Insulation reinforce each other."
   },
@@ -1905,7 +1905,7 @@ export const EXAMPLES: readonly GeneratedExample[] = [
       "process-scoping"
     ],
     "complexity": 2,
-    "featured": false,
+    "featured": true,
     "dsl": "matrix sipoc \"Order fulfilment\"\nsuppliers: \"Vendor\", \"Warehouse\"\ninputs: \"PO\", \"Stock levels\"\nprocess: \"Receive order\", \"Pick\", \"Pack\", \"Ship\"\noutputs: \"Shipped package\", \"Invoice\"\ncustomers: \"End customer\", \"Finance\"",
     "notes": "## What this shows\n\nA **SIPOC** is the first artifact a Six Sigma team builds in the *Define* phase of DMAIC. It names — in five columns read left to right — everyone and everything the process touches: **S**uppliers hand in **I**nputs, the **P**rocess turns them into **O**utputs, and **C**ustomers receive them. Here the order-fulfilment process runs `Receive order → Pick → Pack → Ship`, fed by purchase orders and stock levels from the vendor and warehouse, and producing a shipped package for the end customer and an invoice for finance.\n\nThe point of a SIPOC is boundary-setting before measurement: it forces the team to agree where the process starts, where it ends, and who hands work in and out of it. The five columns always render in canonical S-I-P-O-C order, so the diagram reads correctly even when the blocks are authored out of sequence."
   },

--- a/src/ai/profiles.ts
+++ b/src/ai/profiles.ts
@@ -199,7 +199,7 @@ const PROFILES: Record<DiagramType, GenerationProfile> = {
     header: 'timing "Title"',
     mode: "WaveDrom signals, with clock/run-length shorthands",
     keywords:
-      'timing "title" [hscale: N] · SIGNAME: wave_spec · wave chars 0 1 x z = . u d p P n N h H l L 2-9 · clock N [neg] · rle <state>*<count> … · data: ["a","b"] for = and digit segments · [GroupName] or group "name" { … } · --- spacer · phase: FLOAT (0.0–1.0)',
+      'timing "title" [hscale: N] · SIGNAME: wave_spec · wave chars 0 1 x z = . u d p P n N h H l L 2-9 · clock N [neg] · rle <state>*<count> … · data: ["a","b"] for = and digit segments · [GroupName] or group "name" { … } · --- spacer',
     forms: [
       'timing "Synchronous Bus Read"',
       "CLK:  clock 8",
@@ -562,7 +562,7 @@ const PROFILES: Record<DiagramType, GenerationProfile> = {
     header: 'matrix "Title"',
     mode: "quadrant scatter (default) | named templates | heatmap | sipoc | qfd | punnett",
     keywords:
-      'header variants: matrix "Title" | matrix <template> "Title" | matrix heatmap NxM | matrix correlation | matrix sipoc | matrix qfd | matrix punnett · templates: eisenhower impact-effort rice bcg ansoff johari 9-box risk-matrix · quadrant: x-axis: Low -> High · y-axis: Low -> High · "Label" at (x,y) [size:N category:C shape:circle|square|triangle|diamond] · quadrant Q1..Q4 "name" · Q1:/"Q1: text" cell shortcuts · style: table · config: offChartPolicy=clamp-badge|drop bubbleScale=area|radius',
+      'header variants: matrix "Title" | matrix <template> "Title" | matrix heatmap NxM | matrix correlation | matrix sipoc | matrix qfd | matrix punnett · templates: eisenhower impact-effort rice bcg ansoff johari 9-box risk-matrix · quadrant: x-axis: Low -> High · y-axis: Low -> High · "Label" at (x,y) [size:N category:C shape:circle|square|triangle|diamond] · quadrant Q1..Q4 "name" · Q1:/"Q1: text" cell shortcuts · style: table · config: offChartPolicy=clamp-badge|drop bubbleScale=area|radius · QFD body (under `matrix qfd`): what: "Need" [weight: N] · how: "Spec" [dir: up|down|target] · rel (whatIdx, howIdx): 9|3|1 · roof (i, j): ++|+|-|-- · [normalize: percent] — engine computes the technical-importance row · SIPOC body (under `matrix sipoc`): suppliers:/inputs:/process:/outputs:/customers: "A", "B", … (each column one line) · Punnett body (under `matrix punnett`): cross: Bb x Bb (genotype pairs, separator x/×/*) · trait B: "Brown" / "Blue" (dominant / recessive phenotype names) — engine computes the genotype + phenotype ratios',
     forms: [
       'matrix eisenhower "This Week"',
       "style: table",
@@ -573,11 +573,23 @@ const PROFILES: Record<DiagramType, GenerationProfile> = {
       'matrix bcg "Product Portfolio"',
       '"Platform SDK" at (0.8, 0.8) size: 5 category: star',
       '"Legacy API" at (0.85, 0.15) size: 4 category: cashcow',
+      "",
+      'matrix qfd "House of Quality"',
+      'what: "Quiet operation" weight: 5',
+      'how: "Fan RPM" dir: down',
+      "rel (1, 1): 9",
+      "",
+      'matrix punnett "Monohybrid Cross"',
+      "cross: Bb x Bb",
+      'trait B: "Brown" / "Blue"',
     ],
     prefer: [
       "Use a named template (`eisenhower`, `impact-effort`, `bcg`, `ansoff`, `johari`, `9-box`, `risk-matrix`, `rice`) for first-shot generation — it pre-fills axes and quadrant labels.",
       "Add `style: table` with `Q1:`/`Q2:`/`Q3:`/`Q4:` item lines for the four-cell list layout instead of a scatter.",
       "Quadrant scatter coordinates are normalized `[0,1]` fractions; add `size: N` for a bubble chart and `category:` to drive legend color.",
+      'For QFD / House of Quality, lead with the header `matrix qfd "…"`, then list customer needs as `what: "…" weight: N` and engineering specs as `how: "…" dir: up|down`, then weight the cells with `rel (whatIdx, howIdx): 9|3|1` (1-based, in declaration order) — the engine computes the technical-importance row, so never type it yourself.',
+      'For SIPOC, header `matrix sipoc "…"`, then one line per column: `suppliers:`, `inputs:`, `process:`, `outputs:`, `customers:`, each a comma-separated quoted list.',
+      'For a Punnett square, header `matrix punnett "…"`, then `cross: <genotype> x <genotype>` (even-length allele pairs like `Bb` or `RrYy`) and optional `trait <Letter>: "Dominant" / "Recessive"` — the engine fills the grid and computes the genotype/phenotype ratios.',
     ],
     avoid: [
       "Don't mix `sipoc:`/`qfd:`/`punnett:` sub-keywords in plain quadrant mode — they activate only under the matching header mode (`matrix sipoc`).",
@@ -1641,7 +1653,7 @@ const PROFILES: Record<DiagramType, GenerationProfile> = {
     header: 'floorplan "Title" [unit m|ft]',
     mode: "explicit dimensions + relative room placement; furniture room-relative from each room's top-left",
     keywords:
-      'room id "Label" at x,y | right-of/left-of/above/below ref [offset n] [align start|center|end] size WxH [fill #hex] [nolabel] · extend <room> at x,y | right-of ref size WxH (L/T/U rooms) · north [deg] · door <room> north|south|east|west | between A B at N% [width n] [hinge left|right] [swing in|out] [type single|double|sliding|pocket|bifold] · window <wallref> at N% [width n] [type fixed|sliding|casement|bay] · opening <wallref|between A B> at N% [width n] · furniture <type> in room at x,y [size WxH] [rotate deg] ["label"] · grid|row <type> in room rows R cols C [count N] area x1,y1 x2,y2 [itemsize WxH] · arc <type> in room count N center x,y radius r from deg to deg · types: bed-double/single/queen/king bunk-bed crib sofa loveseat sectional armchair ottoman coffee-table side-table tv tv-stand fireplace floor-lamp rug wardrobe dresser nightstand bookshelf plant piano piano-upright pool-table ceiling-fan dining-table counter wall-cabinet island kitchen-sink stove range-hood fridge dishwasher bar-stool toilet sink vanity bidet urinal bathtub shower washer dryer stairs stairs-l stairs-u spiral-stairs elevator column desk-chair desk desk-l chair whiteboard smartboard bookcase cubbies filing-cabinet lockers kidney-table round-table-4/6/8/10 conference-table banquet-table head-table stage dance-floor bar dj-booth cocktail-table podium row-chairs shelving checkout clothing-rack fitting-room pallet-rack loading-dock forklift salon-chair shampoo-bowl manicure-table treadmill weight-bench power-rack yoga-mat tree car',
+      'room id "Label" at x,y | right-of/left-of/above/below ref [offset n] [align start|center|end] size WxH [fill #hex] [nolabel] · extend <room> at x,y | right-of ref size WxH (L/T/U rooms) · north [deg] · door <room> north|south|east|west | between A B at N% [width n] [hinge left|right] [swing in|out] [type single|double|sliding|pocket|bifold] · window <wallref> at N% [width n] [type fixed|sliding|casement|bay] · opening <wallref|between A B> at N% [width n] · furniture <type> in room at x,y [size WxH] [rotate deg] ["label"] [seats "Name" "Name" …] · grid|row <type> in room rows R cols C [count N] area x1,y1 x2,y2 [itemsize WxH] · arc <type> in room count N center x,y radius r from deg to deg · types: bed-double/single/queen/king bunk-bed crib sofa loveseat sectional armchair ottoman coffee-table side-table tv tv-stand fireplace floor-lamp rug wardrobe dresser nightstand bookshelf plant piano piano-upright pool-table ceiling-fan dining-table counter wall-cabinet island kitchen-sink stove range-hood fridge dishwasher bar-stool toilet sink vanity bidet urinal bathtub shower washer dryer stairs stairs-l stairs-u spiral-stairs elevator column desk-chair desk desk-l chair whiteboard smartboard bookcase cubbies filing-cabinet lockers kidney-table round-table-4/6/8/10 conference-table banquet-table head-table stage dance-floor bar dj-booth cocktail-table podium row-chairs shelving checkout clothing-rack fitting-room pallet-rack loading-dock forklift salon-chair shampoo-bowl manicure-table treadmill weight-bench power-rack yoga-mat tree car',
     forms: [
       'floorplan "Two-Bedroom Apartment" unit m',
       'room living "Living Room" at 0,0 size 5.2x4.2',
@@ -1657,6 +1669,7 @@ const PROFILES: Record<DiagramType, GenerationProfile> = {
       "Furniture `at x,y` is relative to its room's interior top-left corner, in the plan unit.",
       "Use `grid`/`row`/`arc` for repeated items (desks, banquet tables, ceremony chairs) instead of many `furniture` lines; `count` truncates row-major.",
       "Round tables auto-seat their chairs (round-table-8 = 8 chairs); dining/banquet/conference tables auto-seat both long edges; leave chair clearance ≥ 0.5 m around tables.",
+      'For a seating chart / plan de table / 席次表 — who sits where, not just where the tables go — add `seats "Alice" "Bob" …` to each table: the names are written onto the chairs in seating order (round tables clockwise from top, head/long tables along the seated edge). Fewer names than chairs is fine (extras stay empty); CJK names quote like any label.',
       "For L/T/U-shaped rooms, declare the main rectangle then `extend <room> at x,y size WxH` — the extension must share an edge; the engine merges walls and sums the area.",
       "Stairs are furniture: `furniture stairs in hall at x,y` (also stairs-l, stairs-u, spiral-stairs) — they draw treads, the UP arrow, and the cut-plane break line automatically; label \"DN\" for a descending run.",
       "Commercial & site symbols: retail uses shelving/checkout/clothing-rack/fitting-room; warehouse uses pallet-rack/loading-dock/forklift; salon uses salon-chair/shampoo-bowl/manicure-table; gym uses treadmill/weight-bench/power-rack/yoga-mat; `tree` and `car` are sized for site plans, landscaping, and parking stalls.",

--- a/website/content/examples/floorplan-seating-chart.mdx
+++ b/website/content/examples/floorplan-seating-chart.mdx
@@ -7,7 +7,7 @@ industry: [hospitality, business]
 persona: For the wedding planner who needs the chart guests read, not just a room layout
 complexity: 3
 tags: [floorplan, wedding, event, seating, seating-chart]
-featured: false
+featured: true
 relatedLink:
   label: Floor plan syntax
   href: /docs/floorplan

--- a/website/content/examples/matrix-punnett-monohybrid.mdx
+++ b/website/content/examples/matrix-punnett-monohybrid.mdx
@@ -7,7 +7,7 @@ industry: [education, genetics, biology]
 persona: For the biology teacher or student learning Mendelian inheritance
 complexity: 1
 tags: [matrix, punnett, genetics, mendel, monohybrid, biology]
-featured: false
+featured: true
 relatedLink:
   label: Matrix syntax
   href: /docs/matrix

--- a/website/content/examples/matrix-qfd-coffee-maker.mdx
+++ b/website/content/examples/matrix-qfd-coffee-maker.mdx
@@ -7,7 +7,7 @@ industry: [quality, manufacturing]
 persona: For the product engineer translating customer needs into specs
 complexity: 3
 tags: [matrix, qfd, house-of-quality, akao, voice-of-customer]
-featured: false
+featured: true
 relatedLink:
   label: Matrix syntax
   href: /docs/matrix

--- a/website/content/examples/matrix-sipoc-order-fulfilment.mdx
+++ b/website/content/examples/matrix-sipoc-order-fulfilment.mdx
@@ -7,7 +7,7 @@ industry: [quality, manufacturing]
 persona: For the Six Sigma process-improvement lead
 complexity: 2
 tags: [matrix, sipoc, six-sigma, dmaic, process-scoping]
-featured: false
+featured: true
 relatedLink:
   label: Matrix syntax
   href: /docs/matrix


### PR DESCRIPTION
## Why

Audit triggered by **ChatDiagram production data**: French wedding users pasting ~150-guest lists with social constraints asked for a *plan de table* (named seating chart), but the model fell back to stuffing names into DSL comments — invisible on the rendered image. Root cause was **not** a missing engine feature (the `seats "Name" …` clause has shipped since 0.9.x and is fully tested) but the **AI-facing prompt context**: the capability was absent from the generation-tier grammar card *and* from every featured example, so an LLM on the default path never learned it exists.

A full sweep of all 48 diagram types found this same "shipped-but-invisible" pattern in exactly one other type (`matrix`), plus one reverse drift (`timing` advertised a keyword the engine never had).

## What changed (no engine code — `src/ai/` data + example frontmatter only)

- **`floorplan` — named seating charts.** Added `seats "Name" …` to the generation grammar card + a `prefer` bullet (with *plan de table* / 席次表 phrasing); promoted **"Wedding seating chart — named guests"** to `featured`.
- **`matrix` — QFD / SIPOC / Punnett body grammar.** The three computational modes were named as headers but their body syntax was missing. Added `what:`/`how:`/`rel`/`roof` (QFD), `suppliers:/inputs:/process:/outputs:/customers:` (SIPOC), and `cross:`/`trait` (Punnett) grammar + inline forms + `prefer` guidance; featured the **House of Quality**, **monohybrid Punnett**, and **SIPOC** examples.
- **`timing` — removed phantom `phase:`** keyword the engine never implemented (parse would fail if a model emitted it).

## Verification

- `buildPromptContext` now embeds the seating / Punnett / SIPOC examples and the new grammar (probed directly against `dist/ai`).
- `typecheck` clean; `lint` 0 errors; all 199 examples render; affected suites (floorplan/matrix/timing) green.
- One failing test (`sociogram` render-via-api) is **pre-existing on `main`** and unrelated to this change.

Version bumped 0.9.9 → 0.9.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)