### PR TITLE
Release 0.9.13 — consistent comment handling across all diagram types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.13] — 2026-07-08
+
+### Fixed — consistent comment handling across all diagram types
+
+Comment stripping was implemented ad-hoc inside each diagram's parser, so which marker counted as a comment was an accident of that diagram's lexer rather than a designed contract. A probe across all 50 types found no marker worked everywhere: `#` was accepted by 47/50 but is *content* in `mindmap`/`flowchart`/`gitgraph`; `%%` by only 29/50; `*` by 22/50. Driven by ChatDiagram production data — a model that faithfully wrote SPICE-style `*` comments to organize a `circuit` netlist had its entire diagram rejected with `Invalid component id: "*"`, because `circuit` advertises "SPICE-style netlist" but its parser only stripped `#`.
+
+- **Universal `%%` comments.** Mermaid-style `%%` line and inline comments are now stripped once in the shared preprocess pass, so **every** diagram type accepts them regardless of its own lexer. `%%` never begins valid content in any schematex grammar, so this is collision-free; comment-only lines are blanked (not removed) so diagnostic line numbers stay stable.
+- **`circuit` honors SPICE `*` comments.** A line whose first non-blank character is `*` is now treated as a full-line comment, matching the SPICE-style syntax the grammar advertises. `*` can never begin a valid component id, so this is unambiguous. (`#` inline comments continue to work.)
+- **`stripLineComment(line, markers?)`** now takes an optional marker set (default `%%`/`//`/`#`, unchanged for existing callers); the shared pass narrows it to `%%` only, so `#`/`//` stay content where diagrams use them (e.g. `#` headings in `mindmap`).
+
+Scope: this establishes the one universal marker and fixes the confirmed `circuit` advertised-vs-accepted bug. Folding each diagram's remaining native markers into a declared per-diagram policy is a follow-up. Added a conformance test that injects a `%%` comment into every diagram's bundled example and asserts it still validates.
+
+---
+
 ## [0.9.12] — 2026-06-30
 
 ### Added — `siteplan`: parcel, road, driveway, and property-layout diagrams

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,5 +1,9 @@
 import type { DiagramPlugin, RenderConfig } from "./types";
-import { parseFrontmatter } from "./dsl-preprocess";
+import {
+  parseFrontmatter,
+  stripComments,
+  UNIVERSAL_COMMENT_MARKERS,
+} from "./dsl-preprocess";
 import {
   diagnosticFromError,
   renderDiagnosticSvg,
@@ -234,7 +238,14 @@ function normalizeHeader(text: string, type: string): string {
 }
 
 function preprocess(text: string): string {
-  const { data, body } = parseFrontmatter(stripCodeFences(text));
+  const { data, body: rawBody } = parseFrontmatter(stripCodeFences(text));
+  // Universal comment pass: `%%` (Mermaid-style) is stripped for EVERY diagram
+  // here, so it works consistently no matter what each parser's own lexer
+  // supports. `%%` never begins valid content in any schematex grammar, so this
+  // is collision-free; line positions are preserved to keep diagnostic line
+  // numbers stable. Diagram-native markers (`#` shell, `*` SPICE, …) are still
+  // handled inside each parser.
+  const body = stripComments(rawBody, UNIVERSAL_COMMENT_MARKERS);
   if (!data.title) return body;
   // Strip the title here — `data.title` was already unquoted by parseFrontmatter.
   const safeTitle = data.title.replace(/"/g, '\\"');

--- a/src/core/dsl-preprocess.ts
+++ b/src/core/dsl-preprocess.ts
@@ -97,13 +97,32 @@ export function parseFrontmatter(text: string): DslFrontmatter {
   return { data, body };
 }
 
+/** A line-comment marker. Each begins a "rest of line is a comment" region. */
+export type CommentMarker = "%%" | "//" | "#";
+
+/**
+ * The historical default marker set. Kept as the default so existing callers
+ * (`isBlankOrComment`, `firstContentLine`, and the handful of per-diagram
+ * parsers that import `stripLineComment` directly) are unchanged.
+ */
+export const DEFAULT_COMMENT_MARKERS: readonly CommentMarker[] = ["%%", "//", "#"];
+
+/**
+ * `%%` is the one marker that never begins valid content in ANY schematex
+ * grammar (it is Mermaid's comment style). It is stripped for every diagram in
+ * the shared preprocess pass, giving one universal, learnable comment syntax
+ * regardless of a diagram's own lexer. Per-diagram native markers (`#` shell,
+ * `*` SPICE, …) are still honored by each parser on top of this.
+ */
+export const UNIVERSAL_COMMENT_MARKERS: readonly CommentMarker[] = ["%%"];
+
 /**
  * Strip an inline comment from a line.
  *
- * Recognized markers (in order of precedence):
- *   - `%%` — Mermaid's comment style
- *   - `//` — C-style line comment
- *   - `#`  — shell/python style
+ * Recognized markers default to {@link DEFAULT_COMMENT_MARKERS} (`%%`, `//`,
+ * `#`) but can be narrowed by the caller — the shared preprocess pass passes
+ * {@link UNIVERSAL_COMMENT_MARKERS} so it only removes `%%`, leaving `#`/`//`
+ * to diagrams where they are content (e.g. `#` headings in mindmap).
  *
  * Markers inside ASCII double-quoted regions are preserved verbatim so URLs
  * (`"https://..."`) and CSS-color values (`"#ff0"`) survive. Smart-quoted
@@ -111,7 +130,10 @@ export function parseFrontmatter(text: string): DslFrontmatter {
  * and the cost of full Unicode quote tracking for every line isn't worth
  * the protection.
  */
-export function stripLineComment(line: string): string {
+export function stripLineComment(
+  line: string,
+  markers: readonly CommentMarker[] = DEFAULT_COMMENT_MARKERS,
+): string {
   let inQuote = false;
   for (let i = 0; i < line.length; i++) {
     const ch = line[i]!;
@@ -122,11 +144,27 @@ export function stripLineComment(line: string): string {
       continue;
     }
     if (inQuote) continue;
-    if (ch === "%" && line[i + 1] === "%") return line.slice(0, i);
-    if (ch === "/" && line[i + 1] === "/") return line.slice(0, i);
-    if (ch === "#") return line.slice(0, i);
+    for (const marker of markers) {
+      if (line.startsWith(marker, i)) return line.slice(0, i);
+    }
   }
   return line;
+}
+
+/**
+ * Strip comments from every line of a block, preserving line positions:
+ * comment-only lines become blank rather than being removed, so downstream
+ * parser diagnostics keep stable line numbers. Used by the shared preprocess
+ * pass with {@link UNIVERSAL_COMMENT_MARKERS}.
+ */
+export function stripComments(
+  text: string,
+  markers: readonly CommentMarker[] = DEFAULT_COMMENT_MARKERS,
+): string {
+  return text
+    .split("\n")
+    .map((line) => stripLineComment(line, markers))
+    .join("\n");
 }
 
 /** Returns true if the trimmed line is blank or a pure comment. */

--- a/src/diagrams/circuit/netlist.ts
+++ b/src/diagrams/circuit/netlist.ts
@@ -170,6 +170,13 @@ export function parseNetlist(
 
   for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
     const raw = lines[lineIdx];
+    // SPICE full-line comment: a line whose first non-blank char is `*`. The
+    // grammar advertises "SPICE-style netlist", and `*` is SPICE's canonical
+    // full-line comment marker; it can never begin a valid component id, so
+    // skipping these lines is unambiguous. (`#` inline comments — a schematex
+    // extension — are stripped just below; `%%` is handled in the shared
+    // preprocess pass.)
+    if (/^\s*\*/.test(raw)) continue;
     const stripped = raw.replace(/#.*$/, "").trim();
     if (!stripped) continue;
 

--- a/tests/core/comment-handling.test.ts
+++ b/tests/core/comment-handling.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+import {
+  stripLineComment,
+  stripComments,
+  UNIVERSAL_COMMENT_MARKERS,
+} from "../../src/core/dsl-preprocess";
+import { listDiagrams, getExamples, validateDsl } from "../../src/ai";
+
+describe("stripLineComment marker set", () => {
+  test("default set strips %%, //, and #", () => {
+    expect(stripLineComment("a %% c").trimEnd()).toBe("a");
+    expect(stripLineComment("a // c").trimEnd()).toBe("a");
+    expect(stripLineComment("a # c").trimEnd()).toBe("a");
+  });
+
+  test("narrowing to %% leaves # and // untouched", () => {
+    expect(stripLineComment("a # c", UNIVERSAL_COMMENT_MARKERS)).toBe("a # c");
+    expect(stripLineComment("a // c", UNIVERSAL_COMMENT_MARKERS)).toBe("a // c");
+    expect(stripLineComment("a %% c", UNIVERSAL_COMMENT_MARKERS).trimEnd()).toBe("a");
+  });
+
+  test("markers inside double-quoted regions are preserved", () => {
+    expect(stripLineComment('label "50%% done"', UNIVERSAL_COMMENT_MARKERS)).toBe(
+      'label "50%% done"',
+    );
+    expect(stripLineComment('n "https://x" %% note', UNIVERSAL_COMMENT_MARKERS).trimEnd()).toBe(
+      'n "https://x"',
+    );
+  });
+});
+
+describe("stripComments preserves line positions", () => {
+  test("a comment-only line becomes blank, not removed", () => {
+    const out = stripComments("a\n%% gone\nb", UNIVERSAL_COMMENT_MARKERS);
+    expect(out.split("\n")).toEqual(["a", "", "b"]);
+  });
+});
+
+// Contract: `%%` is a universal comment marker — injecting a `%%` line into any
+// diagram's own valid example must not break validation. Locks the shared
+// preprocess pass against per-diagram lexer drift.
+describe("%% is a universal comment across every diagram type", () => {
+  for (const d of listDiagrams()) {
+    const ex = getExamples(d.type, { limit: 1 }).examples[0];
+    if (!ex?.dsl) continue; // no bundled example for this type — nothing to assert
+    test(`${d.type}: baseline valid, and valid with an injected %% comment`, () => {
+      const lines = ex.dsl.split("\n");
+      const base = validateDsl(d.type, ex.dsl);
+      expect(base.ok, `baseline example should validate: ${JSON.stringify(base)}`).toBe(true);
+
+      const withComment = [lines[0], "%% injected comment line", ...lines.slice(1)].join("\n");
+      const after = validateDsl(d.type, withComment);
+      expect(after.ok, `%% comment should be ignored: ${JSON.stringify(after)}`).toBe(true);
+    });
+  }
+});
+
+describe("circuit honors SPICE-style comments", () => {
+  test("`*` full-line comment is ignored (matches advertised SPICE-style)", () => {
+    const dsl = `circuit "T" netlist\n* power section\nV1 vcc 0 12V\nR1 vcc 0 10k`;
+    expect(validateDsl("circuit", dsl).ok).toBe(true);
+  });
+
+  test("`%%` comment also works via the universal pass", () => {
+    const dsl = `circuit "T" netlist\n%% power section\nV1 vcc 0 12V\nR1 vcc 0 10k`;
+    expect(validateDsl("circuit", dsl).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Comment stripping is implemented ad-hoc inside each per-diagram parser, so which marker counts as a comment is an accident of that diagram's lexer — not a designed contract. A probe across all 50 diagram types (inject a `<marker> <garbage>` line into each type's own valid example, check it still validates) shows **no comment marker works everywhere**:

| marker | accepted by | notable conflict |
|---|---|---|
| `#` | 47/50 | **content** in mindmap / flowchart / gitgraph (headings/nodes) |
| `//` | 39/50 | — |
| `%%` | 29/50 | rejected by circuit and ~20 others |
| `*` | 22/50 | circuit advertises SPICE-style but **rejects** it |
| `;` | 22/50 | — |

The sharpest case: `circuit`'s grammar says **"SPICE-style netlist (recommended)"**, but the parser rejected SPICE's own canonical full-line comment `*` (`Invalid component id: "*"`) while accepting the non-SPICE `#`. A model that faithfully wrote SPICE comments to organize a complex netlist got its whole diagram rejected.

## Fix — one contract

1. **Universal `%%`** — strip Mermaid-style `%%` comments once in the shared `preprocess()` pass (`core/api.ts`), the single choke point every diagram's parse/validate/render already flows through. `%%` never begins valid content in any schematex grammar, so it is collision-free. Line positions are preserved (comment-only lines become blank) so diagnostic line numbers stay stable.
2. **Honor native markers** — `circuit` now skips `*` full-line comments, matching the SPICE-style syntax it advertises. `*` can never begin a valid component id, so it is unambiguous.
3. **`stripLineComment(line, markers?)`** — takes an optional marker set (default `%%`/`//`/`#`, unchanged for existing callers); the shared pass narrows it to `%%` only, so `#`/`//` remain **content** where diagrams use them (e.g. mindmap headings).

This deliberately does **not** rewrite all 50 parsers' comment lexing — that's a natural follow-up (fold each diagram's native markers into a declared per-diagram policy). This PR establishes the universal contract + fixes the confirmed advertised-vs-accepted bug.

## Tests

- New `tests/core/comment-handling.test.ts`: injects a `%%` comment into **every** diagram's bundled example and asserts it still validates (locks the contract against per-lexer drift), plus circuit `*`/`%%` cases and quote-preservation.
- Full suite: **1852/1852 pass** · bundled examples: **205/205 validate** · `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
