### PR TITLE
Release 0.9.14 — accept erd title: and floorplan furniture synonyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.14] — 2026-07-08
+
+### Fixed — accept forms the model reasonably writes (`erd` titles, floorplan furniture synonyms)
+
+Two more "advertised-but-rejected" gaps found via ChatDiagram production evals, in the same spirit as 0.9.13 — the parser rejected valid, standard-looking input a capable model naturally produces.
+
+- **`erd` — `title:`/`direction:`/`notation:` under the Mermaid `erDiagram` header.** The native `erd` header already accepted these attributes, but the Mermaid `erDiagram` paste-compat path hard-failed on them (`Unrecognized erDiagram line: title: "…"`) — and it didn't even carry a title. A model that writes `erDiagram` + `title: "…"` (mixing the two dialects' most natural forms) lost the whole diagram. The `erDiagram` path now accepts the same header attributes and maps `title:` to the diagram title. Genuinely malformed lines (e.g. a trailing over-closing `}`) still throw.
+- **`floorplan` — common furniture synonyms.** Added aliases for everyday words that map cleanly onto an existing type: `console-table`/`console`/`end-table` → `side-table`, `couch` → `sofa`, `settee` → `loveseat`, `tv-console`/`media-console`/`entertainment-center` → `tv-stand`, `refrigerator` → `fridge`, `cooktop`/`stovetop` → `stove`, `armoire` → `wardrobe`, `wc`/`water-closet` → `toilet`. A valid layout no longer fails on a vocabulary gap.
+
+---
+
 ## [0.9.13] — 2026-07-08
 
 ### Fixed — consistent comment handling across all diagram types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/erd/parser.ts
+++ b/src/diagrams/erd/parser.ts
@@ -242,6 +242,14 @@ function parseMermaidErd(lines: RawLine[]): ErdAst {
   const entityMap = new Map<string, ErdEntity>();
   const order: string[] = [];
   const refs: ErdRef[] = [];
+  // Header attributes (`title:`, `direction:`, `notation:`) are accepted here
+  // too — they are unambiguous `key: value` lines that can't be confused with
+  // an entity block or a relationship, and an LLM naturally reaches for
+  // `title: "..."` when it uses the Mermaid `erDiagram` header. Rejecting them
+  // used to fail an otherwise-valid diagram.
+  let title: string | undefined;
+  let direction: "LR" | "TB" = "LR";
+  let notation: ErdNotation = "crowsfoot";
 
   const ensure = (id: string): ErdEntity => {
     let e = entityMap.get(id);
@@ -257,6 +265,37 @@ function parseMermaidErd(lines: RawLine[]): ErdAst {
   while (i < lines.length) {
     const t = lines[i]!.text;
     const ln = lines[i]!.lineNumber;
+
+    // Header attributes — order-insensitive, same forms the native `erd`
+    // header accepts. `title:` maps to the diagram title; `direction:`/
+    // `notation:` are validated identically.
+    const lower = t.toLowerCase();
+    if (lower.startsWith("title:")) {
+      title = unquote(t.slice("title:".length).trim());
+      i++;
+      continue;
+    }
+    if (lower.startsWith("direction:")) {
+      const v = t.slice("direction:".length).trim().toUpperCase();
+      if (v !== "LR" && v !== "TB") {
+        throw new ErdParseError(`Unknown direction '${v}'. Use LR or TB.`, ln);
+      }
+      direction = v;
+      i++;
+      continue;
+    }
+    if (lower.startsWith("notation:")) {
+      const v = t.slice("notation:".length).trim().toLowerCase();
+      if (v !== "crowsfoot") {
+        throw new ErdParseError(
+          `notation '${v}' is documented but not yet implemented in v0.1; use 'crowsfoot'.`,
+          ln,
+        );
+      }
+      notation = v;
+      i++;
+      continue;
+    }
 
     // Entity block: `NAME {` (multi-line) or `NAME { ... }` (inline).
     const inlineBlock = new RegExp(`^(${MERMAID_NAME.source})\\s*\\{\\s*(.*?)\\s*\\}$`).exec(t);
@@ -309,8 +348,9 @@ function parseMermaidErd(lines: RawLine[]): ErdAst {
 
   return {
     type: "erd",
-    notation: "crowsfoot",
-    direction: "LR",
+    notation,
+    direction,
+    title,
     entities: order.map((id) => entityMap.get(id)!),
     refs,
   };

--- a/src/diagrams/floorplan/parser.ts
+++ b/src/diagrams/floorplan/parser.ts
@@ -125,6 +125,22 @@ const FURNITURE_ALIASES: Record<string, FurnitureType> = {
   "breaker-panel": "electrical-panel",
   db: "distribution-board",
   "consumer-unit": "distribution-board",
+  // Common everyday synonyms an LLM reaches for that map cleanly onto an
+  // existing type. Keeps a valid layout from failing on a vocabulary gap.
+  "console-table": "side-table",
+  console: "side-table",
+  "end-table": "side-table",
+  couch: "sofa",
+  settee: "loveseat",
+  "tv-console": "tv-stand",
+  "media-console": "tv-stand",
+  "entertainment-center": "tv-stand",
+  refrigerator: "fridge",
+  cooktop: "stove",
+  stovetop: "stove",
+  armoire: "wardrobe",
+  wc: "toilet",
+  "water-closet": "toilet",
 };
 
 function parseFurnitureType(t: Tok | undefined, ln: number): FurnitureType {

--- a/tests/erd/mermaid-compat.test.ts
+++ b/tests/erd/mermaid-compat.test.ts
@@ -38,4 +38,25 @@ table User { id int PK; email varchar }`);
     expect(ast.entities[0]!.attributes[0]!.name).toBe("id");
     expect(ast.entities[0]!.attributes[0]!.type).toBe("int");
   });
+
+  test("`title:`/`direction:` header attributes are accepted under erDiagram", () => {
+    const ast = parseErd(`erDiagram
+title: "Movie Rental Database"
+direction: TB
+CUSTOMER ||--o{ RENTAL : places`);
+    expect(ast.title).toBe("Movie Rental Database");
+    expect(ast.direction).toBe("TB");
+    expect(ast.entities.map((e) => e.id).sort()).toEqual(["CUSTOMER", "RENTAL"]);
+  });
+
+  test("a genuinely malformed line under erDiagram still throws", () => {
+    // `title:` is accepted, but a trailing stray `}` (over-closed) is not —
+    // we widened the header vocabulary, not brace balancing.
+    expect(() =>
+      parseErd(`erDiagram
+A { int id PK }
+A ||--o{ B : x
+}`),
+    ).toThrow();
+  });
 });

--- a/tests/floorplan/parser.test.ts
+++ b/tests/floorplan/parser.test.ts
@@ -157,6 +157,21 @@ furniture consumer-unit in kitchen at 3.2,0.1 size 0.5
     expect(ast.furniture[2]!.size).toEqual({ w: 0.5, h: 0.5 });
   });
 
+  it("normalizes common everyday furniture synonyms", () => {
+    const ast = parseFloorplan(`floorplan
+room living at 0,0 size 6x4
+furniture console-table "Console" in living at 0.2,0.2 size 1.2x0.4
+furniture couch in living at 1,2
+furniture refrigerator in living at 5,0.2
+furniture tv-console in living at 0.2,3`);
+    expect(ast.furniture.map((f) => f.type)).toEqual([
+      "side-table",
+      "sofa",
+      "fridge",
+      "tv-stand",
+    ]);
+  });
+
   it("parses grid array with rows/cols/count/area/itemsize", () => {
     const ast = parseFloorplan(`floorplan
 room class at 0,0 size 32x26


### PR DESCRIPTION
## Problem

Two more "advertised-but-rejected" gaps surfaced by ChatDiagram production evals — same class as #59 (0.9.13). The parser rejected valid, standard-looking input a capable model naturally produces, failing an otherwise-correct diagram:

1. **`erd` — mixed dialect titles.** The grammar advertises "Mermaid `erDiagram`", and a model writes `erDiagram` + `title: "Movie Rental Database"` (the most natural way to title it). But the `erDiagram` paste-compat path hard-failed: `Unrecognized erDiagram line: title: "…"` — it only accepted entity blocks and relationships, and didn't even carry a title. (The native `erd` header already accepted `title:`/`direction:`/`notation:`.)
2. **`floorplan` — furniture vocabulary gap.** A detailed, valid Arabic floor plan failed on `unknown furniture type "console-table"` — a real, everyday furniture word that simply wasn't in the enum.

## Fix

- **`erd`:** the `erDiagram` path now accepts the same header attributes as the native `erd` header (`title:`, `direction:`, `notation:`), maps `title:` to the diagram title, and validates `direction:`/`notation:` identically. Genuinely malformed input (e.g. a trailing over-closing `}`) still throws — we widened the header vocabulary, not brace balancing.
- **`floorplan`:** added common synonyms that map cleanly onto an existing type — `console-table`/`console`/`end-table` → `side-table`, `couch` → `sofa`, `settee` → `loveseat`, `tv-console`/`media-console`/`entertainment-center` → `tv-stand`, `refrigerator` → `fridge`, `cooktop`/`stovetop` → `stove`, `armoire` → `wardrobe`, `wc`/`water-closet` → `toilet`.

## Tests

- `tests/erd/mermaid-compat.test.ts`: `title:`/`direction:` accepted under `erDiagram`; a malformed over-closing `}` still throws.
- `tests/floorplan/parser.test.ts`: everyday synonyms normalize to canonical types.
- Full suite: **1855/1855 pass** · bundled examples: **205/205 validate** · `typecheck` clean.

Bumps to **0.9.14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
