### PR TITLE
Release 0.9.15 — optional header, usecase i18n ids, network device synonyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ When a caller passes `config.type` (always the case for an AI artifact whose `en
 - **Dialect-aware.** erd recovers with `erDiagram` (the Mermaid crow's-foot dialect), not bare `erd` (which selects the native `table`/`ref` parser). Other engines use the bare type name.
 - Headerless-by-design grammars (mindmap's `# Title`) already `detect()` true, so they short-circuit untouched. Applies uniformly to `parse`, `parseResult`, `render`, and `renderResult`.
 
+### Fixed — `usecase` non-ASCII actor names + `network` device-kind synonyms
+
+Two more gaps surfaced by ChatDiagram production evals across high-traffic engines.
+
+- **`usecase` — non-ASCII auto-generated ids.** When an actor/use-case had no explicit `as <id>`, the synthetic id stripped every non-`[A-Za-z0-9_]` character to `_`. Korean actors (`순원`, `순장`) all collapsed to `__` and collided (`identifier '__' already declared`) — a recurring production failure for CJK use-case diagrams. Ids now preserve Unicode letters/digits, so non-ASCII names stay distinct.
+- **`network` — device-kind synonyms.** Added common everyday aliases so a valid topology doesn't fail on a vocabulary gap: `webserver`/`mailserver`/`dns`/`dhcp`/`ntp`/`database`/`db`/`dbserver`/`vm`/`host`/`hypervisor`/`activedirectory`/`domaincontroller` → `server`, `desktop` → `pc`, `smartphone`/`tablet` → `mobile`, `accesspoint`/`wap` → `ap`, `hub`/`bridge`/`l2switch` → `switch`, `ngfw`/`utm` → `firewall`, `mfp` → `printer`.
+
 ---
 
 ## [0.9.14] — 2026-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.15] — 2026-07-08
+
+### Fixed — the header line is optional when the diagram type is already known
+
+When a caller passes `config.type` (always the case for an AI artifact whose `engine="…"` tag names the type), the leading header line is redundant — the type is already known. But every per-diagram parser still *required* it and hard-failed when it was missing. LLMs, having just declared the engine in the artifact tag, routinely omit the header and emit pure content (`CEO\n  VP Sales…`, `Customer ||--o{ Order…`), losing the whole diagram.
+
+- **Header recovery.** When the type is forced and the body does not `detect()` as that type, the canonical header is prepended and kept **only if the result parses cleanly**. A genuinely malformed body (a real syntax error, an unsupported node form) still fails with its true error — recovery never masks it.
+- **Dialect-aware.** erd recovers with `erDiagram` (the Mermaid crow's-foot dialect), not bare `erd` (which selects the native `table`/`ref` parser). Other engines use the bare type name.
+- Headerless-by-design grammars (mindmap's `# Title`) already `detect()` true, so they short-circuit untouched. Applies uniformly to `parse`, `parseResult`, `render`, and `renderResult`.
+
+---
+
 ## [0.9.14] — 2026-07-08
 
 ### Fixed — accept forms the model reasonably writes (`erd` titles, floorplan furniture synonyms)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -237,6 +237,48 @@ function normalizeHeader(text: string, type: string): string {
   return text;
 }
 
+/**
+ * Header keyword(s) to try when a type-forced body only parses once a header is
+ * prepended. Most engines use the bare type name as a valid header; erd's
+ * Mermaid dialect needs `erDiagram` (bare `erd` selects the native table/ref
+ * parser, which rejects crow's-foot relationship lines).
+ */
+function headerCandidates(type: string): string[] {
+  if (type === "erd") return ["erDiagram", "erd"];
+  return [type];
+}
+
+/**
+ * When the diagram type is explicitly known (forced via `config.type`) the
+ * header line is redundant — the caller already told us the type. LLMs, having
+ * declared the engine in the artifact tag, routinely omit it and emit pure
+ * content (`CEO\n  VP…`, `Customer ||--o{ Order…`). If the body does not
+ * detect as this type, prepend the canonical header and keep it **only if the
+ * result parses cleanly** — so a genuine syntax error is never masked (a body
+ * that is malformed for other reasons still fails with its real error).
+ *
+ * Headerless grammars (mindmap's `# Title`) already `detect()` true, so they
+ * short-circuit and are never touched.
+ */
+function recoverHeader(
+  plugin: DiagramPlugin,
+  prepared: string,
+  forced: boolean
+): string {
+  if (!forced || !plugin.parse || plugin.detect(prepared)) return prepared;
+  for (const hdr of headerCandidates(plugin.type)) {
+    const candidate = `${hdr}\n${prepared}`;
+    if (!plugin.detect(candidate)) continue;
+    try {
+      plugin.parse(candidate);
+      return candidate;
+    } catch {
+      // this header candidate doesn't resolve the body — try the next
+    }
+  }
+  return prepared;
+}
+
 function preprocess(text: string): string {
   const { data, body: rawBody } = parseFrontmatter(stripCodeFences(text));
   // Universal comment pass: `%%` (Mermaid-style) is stripped for EVERY diagram
@@ -276,11 +318,14 @@ function preprocess(text: string): string {
 export function parse(text: string, config?: SchematexConfig): unknown {
   const prepared0 = preprocess(text);
   const plugin = detectPlugin(prepared0, config);
-  const prepared = normalizeHeader(prepared0, plugin.type);
-  if (plugin.parse) return plugin.parse(prepared);
-  throw new Error(
-    `Diagram type '${plugin.type}' does not yet expose a parse() method.`
-  );
+  if (!plugin.parse) {
+    throw new Error(
+      `Diagram type '${plugin.type}' does not yet expose a parse() method.`
+    );
+  }
+  const forced = config?.type != null && plugin.type === config.type;
+  const prepared = recoverHeader(plugin, normalizeHeader(prepared0, plugin.type), forced);
+  return plugin.parse(prepared);
 }
 
 export function parseResult(
@@ -296,7 +341,8 @@ export function parseResult(
         `Diagram type '${plugin.type}' does not yet expose a parse() method.`
       );
     }
-    const prepared = normalizeHeader(prepared0, plugin.type);
+    const forced = config?.type != null && plugin.type === config.type;
+    const prepared = recoverHeader(plugin, normalizeHeader(prepared0, plugin.type), forced);
     const ast = plugin.parse(prepared);
     const diagnostics = runLint(plugin, prepared);
     return {
@@ -334,7 +380,8 @@ export function render(text: string, config?: SchematexConfig): string {
 
   const prepared0 = preprocess(text);
   const plugin = detectPlugin(prepared0, config);
-  const prepared = normalizeHeader(prepared0, plugin.type);
+  const forced = config?.type != null && plugin.type === config.type;
+  const prepared = recoverHeader(plugin, normalizeHeader(prepared0, plugin.type), forced);
   return renderWithPlugin(prepared, plugin, config);
 }
 
@@ -346,7 +393,8 @@ export function renderResult(
   try {
     const prepared0 = preprocess(text);
     plugin = detectPlugin(prepared0, config);
-    const prepared = normalizeHeader(prepared0, plugin.type);
+    const forced = config?.type != null && plugin.type === config.type;
+    const prepared = recoverHeader(plugin, normalizeHeader(prepared0, plugin.type), forced);
     const svg = renderWithPlugin(prepared, plugin, config);
     const diagnostics = runLint(plugin, prepared);
     return {

--- a/src/diagrams/network/parser.ts
+++ b/src/diagrams/network/parser.ts
@@ -45,6 +45,32 @@ const KIND_ALIASES: Record<string, DeviceKind> = {
   decoder: "encoder",
   videowall: "monitor",
   segment: "lan",
+  // Common everyday synonyms a model reaches for. A specific server role still
+  // renders as a generic `server` (with its label) instead of hard-failing.
+  webserver: "server",
+  mailserver: "server",
+  dns: "server",
+  dhcp: "server",
+  ntp: "server",
+  database: "server",
+  dbserver: "server",
+  db: "server",
+  vm: "server",
+  host: "server",
+  hypervisor: "server",
+  activedirectory: "server",
+  domaincontroller: "server",
+  desktop: "pc",
+  smartphone: "mobile",
+  tablet: "mobile",
+  accesspoint: "ap",
+  wap: "ap",
+  hub: "switch",
+  bridge: "switch",
+  l2switch: "switch",
+  ngfw: "firewall",
+  utm: "firewall",
+  mfp: "printer",
 };
 
 const GROUP_KINDS = new Set<string>(["site", "building", "campus", "rack", "subnet", "vlan", "zone", "dmz"]);

--- a/src/diagrams/usecase/parser.ts
+++ b/src/diagrams/usecase/parser.ts
@@ -439,10 +439,13 @@ function parseNote(ln: RawLine, state: ParserState): boolean {
 }
 
 function defaultIdFor(name: string): string {
-  // Convert quoted name with spaces into a synthetic id by stripping non-word chars.
-  // Used when the user omits `as <id>`.
-  const safe = name.replace(/[^A-Za-z0-9_]/g, "_");
-  return /^[A-Za-z_]/.test(safe) ? safe : "_" + safe;
+  // Convert a quoted name into a synthetic id when the user omits `as <id>`.
+  // Preserve Unicode letters/digits so non-ASCII names stay distinct — Korean
+  // actors like `순원` / `순장` used to collapse to `__` and collide with
+  // "identifier '__' already declared". Only characters that can't appear in an
+  // identifier are replaced with `_`.
+  const safe = name.replace(/[^\p{L}\p{N}_]/gu, "_");
+  return /^[\p{L}_]/u.test(safe) ? safe : "_" + safe;
 }
 
 function parseRelation(ln: RawLine, state: ParserState): boolean {

--- a/tests/core/header-recovery.test.ts
+++ b/tests/core/header-recovery.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "vitest";
+import { validateDsl } from "../../src/ai";
+
+// When the diagram type is known (forced via config.type — always the case in an
+// AI artifact whose `engine="…"` tag names the type), the header line is
+// redundant. Bodies that omit it should still parse; genuinely malformed bodies
+// must still fail (recovery must never mask a real error).
+describe("optional header when the type is known", () => {
+  test("erd — headerless Mermaid body recovers (prepends erDiagram, not native erd)", () => {
+    const body = `Customer ||--o{ Rental : places
+Rental ||--|{ Movie : includes
+Customer {
+  int id PK
+}`;
+    expect(validateDsl("erd", body).ok).toBe(true);
+  });
+
+  test("a headered body is unaffected", () => {
+    expect(validateDsl("erd", `erDiagram\nA ||--o{ B : x`).ok).toBe(true);
+    expect(validateDsl("genogram", `genogram\nalice [female]`).ok).toBe(true);
+  });
+
+  test("recovery never masks a genuine syntax error", () => {
+    // orgchart body is missing the header AND uses bare labels instead of the
+    // `id : "Name"` form — prepending `orgchart` does not make it parse, so it
+    // must still report invalid rather than being silently "recovered".
+    expect(validateDsl("orgchart", `CEO\n  VP Sales\n    Director`).ok).toBe(false);
+    // erd headerless with an invalid cardinality glyph — recovery prepends
+    // `erDiagram`, but the bad glyph still fails, so it is not masked.
+    expect(validateDsl("erd", `A ||XX{ B : rel`).ok).toBe(false);
+  });
+});

--- a/tests/network/parser.test.ts
+++ b/tests/network/parser.test.ts
@@ -132,4 +132,19 @@ describe("network parser — validation", () => {
   it("throws on an unclosed group block", () => {
     expect(() => parseNetwork('network\n  site hq "HQ" {\n  router r1')).toThrow(/unclosed group/);
   });
+
+  it("normalizes common device-kind synonyms to canonical kinds", () => {
+    const ast = parseNetwork(`network
+  webserver web1 "Web"
+  dns dns1
+  desktop d1
+  ngfw fw1
+  smartphone m1`);
+    const kind = (id: string) => ast.devices.find((d) => d.id === id)!.kind;
+    expect(kind("web1")).toBe("server");
+    expect(kind("dns1")).toBe("server");
+    expect(kind("d1")).toBe("pc");
+    expect(kind("fw1")).toBe("firewall");
+    expect(kind("m1")).toBe("mobile");
+  });
 });

--- a/tests/usecase/parser.test.ts
+++ b/tests/usecase/parser.test.ts
@@ -207,4 +207,11 @@ A -- U3
 `);
     expect(ast.warnings.some((w) => /system.*omitted/i.test(w))).toBe(true);
   });
+
+  it("gives non-ASCII actor names distinct ids (no `__` collision)", () => {
+    // Korean actors used to sanitize to `__` and collide with
+    // "identifier '__' already declared".
+    const ast = parseUsecase(`usecase\nactor: 순원\nactor: 순장`);
+    expect(ast.actors.map((a) => a.id)).toEqual(["순원", "순장"]);
+  });
 });


### PR DESCRIPTION
## Problem

When a caller passes `config.type` — **always** the case for an AI-generated artifact, whose `engine="…"` tag already names the diagram type — the leading header line inside the DSL body is redundant. The type is known. Yet every per-diagram parser still *required* the header and hard-failed when it was missing.

LLMs, having just declared the engine in the artifact tag, treat the in-body header as duplicated and routinely omit it, emitting pure content:

```
CEO
  VP Sales
    Director
```
```
Customer ||--o{ Rental : places
Rental ||--|{ Movie : includes
```

Both lost the entire diagram (`Orgchart has no parseable nodes`, `Expected 'erd' or Mermaid 'erDiagram' header`). Production evals surfaced this as a recurring, cross-engine failure.

## Fix

`recoverHeader(plugin, prepared, forced)` — when the type is **forced** and the body does not `detect()` as that type, prepend the canonical header and **keep it only if the result parses cleanly**:

- **Never masks a real error.** A body that is malformed for other reasons (bad glyph, unsupported node form like orgchart's bare labels) still fails with its true error — recovery is accepted solely when the header was the *only* thing missing.
- **Dialect-aware.** `erd` recovers with `erDiagram` (the Mermaid crow's-foot dialect), not bare `erd` (which selects the native `table`/`ref` parser and would reject relationship lines). Other engines use the bare type name.
- **Cheap + safe.** Headerless-by-design grammars (mindmap's `# Title`) already `detect()` true, so they short-circuit untouched; the common headered path pays only one `detect()`. Wired uniformly into `parse`, `parseResult`, `render`, `renderResult`.

## Tests

- `tests/core/header-recovery.test.ts`: headerless `erd` recovers; headered bodies unaffected; orgchart bare-labels and an invalid erd glyph still fail (recovery doesn't mask real errors).
- Full suite: **1858/1858 pass** · bundled examples: **205/205 validate** · `typecheck` clean.

Bumps to **0.9.15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
