### PR TITLE
Release 0.9.16 — genogram relationship + attribute gaps (top prod failure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.16] — 2026-07-09
+
+### Fixed — `genogram` relationship + attribute gaps (top production failure)
+
+`genogram` was the #1 remaining source of invalid artifacts in ChatDiagram production. Pulling the real failing DSL surfaced four gaps, all "the grammar advertises it / the model reasonably writes it, but the parser rejects it":
+
+- **`~x~` divorced couple operator.** The grammar's keyword list and examples advertise `~x~` for divorce, but the parser only recognized the ASCII alias `-x-` — so `a ~x~ b` failed with `Unknown individual 'x~ b'`. This was the single most common genogram failure (Spanish, Hebrew, Chinese, English prompts alike). `~x~` is now accepted; `-x-` remains a valid alias.
+- **Non-ASCII condition labels.** The `conditions: name(fill)` label was matched with an ASCII-only regex, so `hipertensión(full)` or `右側半癱(half-right)` failed with `Invalid condition format` even though the fill was valid. Labels may now be any Unicode text.
+- **Status synonyms.** `stillbirth` → `stillborn`, plus `miscarried`/`aborted`/`died`/`dead` → their canonical tokens.
+- **Bare age vs year.** A bare 1–3 digit number in `[...]` (e.g. `[male, 28]`) is now read as an age; a 4-digit number remains a birth year.
+
+---
+
 ## [0.9.15] — 2026-07-08
 
 ### Fixed — the header line is optional when the diagram type is already known

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/genogram/parser.ts
+++ b/src/diagrams/genogram/parser.ts
@@ -29,6 +29,7 @@ export class ParseError extends Error {
 // Longer tokens MUST come first so e.g. `~/~` is not split as `~` + `/~`.
 const COUPLE_OPS: Array<{ token: string; type: RelationshipType }> = [
   { token: "~/~", type: "cohabiting-ended" },
+  { token: "~x~", type: "divorced" }, // the form the grammar advertises; `-x-` is the ASCII alias
   { token: "-//", type: "separated" }, // alias for -/-
   { token: "-x-", type: "divorced" },
   { token: "-/-", type: "separated" },
@@ -45,6 +46,17 @@ const VALID_STATUS = new Set([
   "miscarriage",
   "abortion",
 ]);
+// Everyday synonyms an LLM reaches for, mapped to the canonical status token.
+const STATUS_ALIASES: Record<string, string> = {
+  stillbirth: "stillborn",
+  stillbirths: "stillborn",
+  miscarried: "miscarriage",
+  miscarry: "miscarriage",
+  aborted: "abortion",
+  dead: "deceased",
+  died: "deceased",
+  decd: "deceased",
+};
 const SPECIAL_CHILD_PROPS = new Set([
   "adopted",
   "foster",
@@ -600,8 +612,8 @@ function buildIndividual(
 
     if (VALID_SEX.has(tokenLower)) {
       individual.sex = tokenLower as Individual["sex"];
-    } else if (VALID_STATUS.has(tokenLower)) {
-      individual.status = tokenLower as Individual["status"];
+    } else if (VALID_STATUS.has(tokenLower) || STATUS_ALIASES[tokenLower]) {
+      individual.status = (STATUS_ALIASES[tokenLower] ?? tokenLower) as Individual["status"];
     } else if (tokenLower === "index") {
       if (!individual.markers) individual.markers = [];
       individual.markers.push("index-person");
@@ -612,6 +624,10 @@ function buildIndividual(
     } else if (SPECIAL_CHILD_PROPS.has(tokenLower) || tokenLower === "guardian") {
       // Handled at caller level for relationships
       continue;
+    } else if (/^\d{1,3}$/.test(tokenLower)) {
+      // A bare 1–3 digit number is an age (a 4-digit number is a year); this is
+      // what a user means by `[male, 28]`.
+      individual.age = parseInt(token, 10);
     } else if (/^\d{4}$/.test(tokenLower)) {
       if (individual.birthYear !== undefined) {
         individual.deathYear = parseInt(token, 10);
@@ -704,7 +720,10 @@ function parseConditions(
   const conditions: Condition[] = [];
 
   for (const part of parts) {
-    const match = part.match(/^([a-zA-Z0-9_-]+)\(([^)]+)\)$/);
+    // Label is everything before the `(...)` — allow Unicode names (accented
+    // Spanish, CJK, etc.) instead of ASCII-only, which used to reject valid
+    // conditions like `hipertensión(full)` / `右側半癱(half-right)`.
+    const match = part.match(/^([^(]+)\(([^)]+)\)$/);
     if (!match) {
       throw new ParseError(
         `Invalid condition format '${part}'. Expected: name(fill) or name(fill, #color)`,
@@ -713,7 +732,8 @@ function parseConditions(
         lineText
       );
     }
-    const [, label, innerRaw] = match;
+    const label = match[1]!.trim();
+    const innerRaw = match[2]!;
     const innerParts = innerRaw.split(",").map((s) => s.trim());
     const fill = innerParts[0];
     const color = innerParts[1]; // optional

--- a/tests/genogram/parser.test.ts
+++ b/tests/genogram/parser.test.ts
@@ -309,3 +309,29 @@ genogram
     expect(ast.relationships).toHaveLength(1);
   });
 });
+
+describe("genogram — production-driven leniency (0.9.16)", () => {
+  test("`~x~` divorced operator (the grammar-advertised form) parses", () => {
+    const ast = parseGenogram(`genogram\na [male]\nb [female]\na ~x~ b "div. 2010"`);
+    expect(ast.relationships[0]!.type).toBe("divorced");
+    // `-x-` ASCII alias still works
+    expect(parseGenogram(`genogram\na [male]\nb [female]\na -x- b`).relationships[0]!.type).toBe("divorced");
+  });
+
+  test("condition labels may be non-ASCII (accented / CJK)", () => {
+    const es = parseGenogram(`genogram\np [female, conditions: hipertensión(full, #e74c3c)]`);
+    expect(es.individuals[0]!.conditions?.[0]).toMatchObject({ label: "hipertensión", fill: "full" });
+    const cjk = parseGenogram(`genogram\np [female, conditions: 右側半癱(half-right)]`);
+    expect(cjk.individuals[0]!.conditions?.[0]!.label).toBe("右側半癱");
+  });
+
+  test("status synonyms normalize (stillbirth → stillborn)", () => {
+    expect(parseGenogram(`genogram\np [male, stillbirth]`).individuals[0]!.status).toBe("stillborn");
+    expect(parseGenogram(`genogram\np [female, died]`).individuals[0]!.status).toBe("deceased");
+  });
+
+  test("a bare 1–3 digit number is an age; 4 digits is a year", () => {
+    expect(parseGenogram(`genogram\np [male, 28]`).individuals[0]!.age).toBe(28);
+    expect(parseGenogram(`genogram\np [male, 1955]`).individuals[0]!.birthYear).toBe(1955);
+  });
+});


### PR DESCRIPTION
## Problem

`genogram` was the #1 remaining source of invalid artifacts in ChatDiagram production. Pulling the real failing DSL (30 days, `serverValidateErrors`) surfaced four gaps — all the same class as prior releases: **the grammar advertises it / the model reasonably writes it, but the parser rejects it.**

| Gap | Real failing input | Old error |
|---|---|---|
| `~x~` divorced (the big one, ~5/12 samples across ES/HE/ZH/EN) | `a ~x~ b "div. 2010"` | `Unknown individual 'x~ b'` |
| Non-ASCII condition labels | `hipertensión(full)`, `右側半癱(half-right)` | `Invalid condition format` |
| Status synonyms | `[male, stillbirth]` | `Unknown property 'stillbirth'` |
| Bare age vs year | `[male, 28]` | `Unknown property '28'` |

## Fix (`src/diagrams/genogram/parser.ts`)

- **`~x~` divorced operator** — the grammar's keyword list and examples advertise `~x~`, but `COUPLE_OPS` only had the ASCII alias `-x-`. Added `~x~`; `-x-` remains valid.
- **Unicode condition labels** — the `conditions: name(fill)` label was matched with `[a-zA-Z0-9_-]+`. Now matches everything before `(...)`, so accented/CJK names parse. Fill values are still validated against `VALID_FILLS`.
- **Status synonyms** — `stillbirth`→`stillborn`, `miscarried`→`miscarriage`, `aborted`→`abortion`, `died`/`dead`→`deceased`.
- **Bare age vs year** — a bare 1–3 digit number in `[...]` is now an age (matching `age:N`); a 4-digit number stays a birth year.

## Tests

- `tests/genogram/parser.test.ts`: new block covering all four (incl. `-x-` alias + `1955`-is-a-year regressions). **20/20** in the parser file.
- Full suite: **205/205 bundled examples validate**, `typecheck` clean.
- ⚠️ Pre-existing, unrelated: `tests/sociogram/renderer.test.ts > render via the main render() API` times out (~10s) — it fails the same way on clean `main` with this branch stashed, and recent PRs (#59–61) merged green, so it's local SSR slowness, not touched here.

Bumps to **0.9.16**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
