### PR TITLE
Make mindmap backgrounds transparent by default

### DIFF
--- a/examples/mindmap/driver-readmissions.svg
+++ b/examples/mindmap/driver-readmissions.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 946.3 244.0" width="946.3" height="244.0" role="graphics-document" aria-label="Mindmap: Reduce 30-day readmissions"><title>Reduce 30-day readmissions</title>
 <desc>logic-right mindmap with 7 nodes</desc>
-<rect x="0" y="0" width="946.3" height="244" fill="#ffffff"/>
 <g class="schematex-mindmap-rings" aria-hidden="true"></g>
 <g class="schematex-mindmap-edges" aria-hidden="true"><path d="M 341.6 134.0 C 391.1 134.0, 382.1 79.5, 431.6 79.5" fill="none" stroke="#2563eb" stroke-width="2.2" stroke-linecap="round"/>
 <path d="M 657.8 79.5 C 690.8 79.5, 684.8 59.0, 717.8 59.0" fill="none" stroke="#2563eb" stroke-width="1.6" stroke-linecap="round"/>

--- a/examples/mindmap/futureswheel-remote-work.svg
+++ b/examples/mindmap/futureswheel-remote-work.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 857.2 620.6" width="857.2" height="620.6" role="graphics-document" aria-label="Mindmap: Remote work becomes default"><title>Remote work becomes default</title>
 <desc>futures-wheel mindmap with 10 nodes</desc>
-<rect x="0" y="0" width="857.19" height="620.6152422706632" fill="#ffffff"/>
 <g class="schematex-mindmap-rings" aria-hidden="true"><circle cx="445.6" cy="310.3" r="150.0" fill="none" stroke="#0f172a" stroke-width="1" stroke-dasharray="3 5" opacity="0.25" class="mm-ring mm-ring-1"/>
 <circle cx="445.6" cy="310.3" r="300.0" fill="none" stroke="#0f172a" stroke-width="1" stroke-dasharray="3 5" opacity="0.25" class="mm-ring mm-ring-2"/></g>
 <g class="schematex-mindmap-edges" aria-hidden="true"><path d="M 445.6 310.3 L 575.5 235.3" fill="none" stroke="#2563eb" stroke-width="2.2" stroke-linecap="round"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "schematex",
-  "version": "0.9.12",
+  "version": "0.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schematex",
-      "version": "0.9.12",
+      "version": "0.9.17",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/mindmap/renderer.ts
+++ b/src/diagrams/mindmap/renderer.ts
@@ -338,7 +338,6 @@ export function renderMindmapAST(
     [
       svgTitle(title),
       svgDesc(descLabel),
-      rect({ x: 0, y: 0, width: layout.width, height: layout.height, fill: theme.bg }),
       group({ class: "schematex-mindmap-rings", "aria-hidden": "true" }, ringSvgs),
       group({ class: "schematex-mindmap-edges", "aria-hidden": "true" }, edgeSvgs),
       group({ class: "schematex-mindmap-nodes" }, nodeSvgs),

--- a/tests/mindmap/futureswheel.test.ts
+++ b/tests/mindmap/futureswheel.test.ts
@@ -158,6 +158,10 @@ describe("futureswheel angular containment", () => {
 describe("futureswheel rendered SVG", () => {
   const svg = renderMindmap(THREE_RING);
 
+  test("does not bake in a full-canvas background", () => {
+    expect(svg).not.toMatch(/<rect x="0" y="0" width="[^"]+" height="[^"]+" fill="#ffffff"\/>/);
+  });
+
   test("nodes carry semantic mm-order-N classes by consequence order", () => {
     expect(svg).toContain("mm-order-0"); // central event
     expect(svg).toContain("mm-order-1"); // first-order consequences


### PR DESCRIPTION
## What changed

- Removed the full-canvas white `<rect>` from the mindmap SVG renderer.
- Regenerated the committed mindmap example SVGs so they no longer bake in a white background.
- Added a renderer test that prevents mindmap from reintroducing a default full-canvas white background.
- Bumped the package patch version to `0.9.17`.

## Why

The README says Schematex SVGs are background-agnostic by default, with opaque backgrounds handled by the host container or explicit PNG export options. Mindmap was violating that by writing `fill="#ffffff"` directly into the SVG output.

## Impact

Mindmap SVGs now inherit the surface behind them by default. Existing PNG export paths that explicitly pass `background: "white"` continue to produce white-background PNGs.

## Validation

- `npm test -- tests/mindmap`
- `npm run typecheck`
- Verified `examples/mindmap` and `src/diagrams/mindmap` no longer contain the full-canvas white rect pattern.
