### PR TITLE
fix(circuit): surface unknown-type lines as errors + accept semicolon comments (0.9.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.18] — 2026-07-09
+
+### Fixed — `circuit` silently dropped unknown-type lines + rejected `;` comments (production failure)
+
+Pulling a real failing MyMap production map (a home-wiring circuit edited over several turns) surfaced two `circuit` gaps that together turned a good first diagram into a near-empty one, while every validator reported success:
+
+- **Positional mode silently dropped unrecognized component lines.** A model that wrote SPICE-style connectivity *without* the `netlist` header — e.g. `breaker CB1 (L L1) 16A`, `rcd RCD1 …`, `switch SW1 …` — had each unknown-type line silently discarded, rendering a schematic with almost nothing on it. Crucially `validateDsl` and `renderDsl` still returned `ok: true` with zero warnings, so no downstream check (in-loop `validateDsl`, or a caller's post-generation gate) could catch it. An identifier-led line whose head is not a known component type now raises `Unknown component type: "<x>"` with a hint to add the `netlist` header — matching the `id: type` colon form and every other diagram's unknown-kind handling. Known types and the netlist path are unchanged.
+- **`;` comments hard-failed in netlist mode.** The grammar advertises "SPICE-style netlist", and `;` is SPICE's in-line comment marker, so models routinely write `; note` lines. These failed with `Invalid component id: ";"`. `;` is now stripped as a comment (full-line and trailing) in both netlist and positional circuit modes, alongside the existing `*`, `#`, and `%%` markers. `;` stays circuit-local — it is **not** promoted to a universal marker, because other diagram types (e.g. `network`) use `;` as a statement separator.
+
+---
+
 ## [0.9.16] — 2026-07-09
 
 ### Fixed — `genogram` relationship + attribute gaps (top production failure)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 36 industry-standard diagrams (genogram, pedigree, ladder logic, SLD, FBD, SFC, P&ID, UML class, UML use case, UML sequence, fault tree, bowtie, PRISMA, phylo, fishbone, entity structure, ...) from a text DSL. Free, fully open source, made for AI. Pure SVG, zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/circuit/netlist.ts
+++ b/src/diagrams/circuit/netlist.ts
@@ -173,11 +173,14 @@ export function parseNetlist(
     // SPICE full-line comment: a line whose first non-blank char is `*`. The
     // grammar advertises "SPICE-style netlist", and `*` is SPICE's canonical
     // full-line comment marker; it can never begin a valid component id, so
-    // skipping these lines is unambiguous. (`#` inline comments — a schematex
-    // extension — are stripped just below; `%%` is handled in the shared
-    // preprocess pass.)
+    // skipping these lines is unambiguous. (`#` and `;` inline comments are
+    // stripped just below; `%%` is handled in the shared preprocess pass.)
     if (/^\s*\*/.test(raw)) continue;
-    const stripped = raw.replace(/#.*$/, "").trim();
+    // Strip inline comments. `#` is the schematex extension; `;` is SPICE's
+    // in-line comment marker (netlist mode has no `;` statement syntax, so it is
+    // unambiguous here) — models with a strong SPICE prior write `; note` lines,
+    // which used to hard-fail as `Invalid component id: ";"`.
+    const stripped = raw.replace(/[#;].*$/, "").trim();
     if (!stripped) continue;
 
     const tokens = tokenize(stripped);

--- a/src/diagrams/circuit/parser.ts
+++ b/src/diagrams/circuit/parser.ts
@@ -191,14 +191,14 @@ function parseAttrs(rest: string): { direction?: CircuitDirection; attrs: Record
 export function parseCircuit(text: string): CircuitAST {
   const rawLines = text.split("\n");
   const firstMeaningful = rawLines
-    .map((l) => l.replace(/#.*$/, "").trim())
+    .map((l) => l.replace(/[#;].*$/, "").trim())
     .find((l) => l.length > 0) ?? "";
 
   if (/^circuit\b.*\bnetlist\s*$/i.test(firstMeaningful)) {
     const netlistTitle = matchQuotedTitle(firstMeaningful);
     let headerIdx = -1;
     for (let i = 0; i < rawLines.length; i++) {
-      const s = rawLines[i].replace(/#.*$/, "").trim();
+      const s = rawLines[i].replace(/[#;].*$/, "").trim();
       if (s.length > 0) {
         headerIdx = i;
         break;
@@ -219,7 +219,7 @@ export function parseCircuit(text: string): CircuitAST {
   const mkId = (prefix: string) => `${prefix}_${autoId++}`;
 
   for (const rawLine of lines) {
-    const stripped = rawLine.replace(/#.*$/, "").trim();
+    const stripped = rawLine.replace(/[#;].*$/, "").trim();
     if (!stripped) continue;
 
     // header
@@ -335,8 +335,20 @@ export function parseCircuit(text: string): CircuitAST {
       const typeStr = bareMatch[1];
       const norm = normalizeType(typeStr);
       if (!norm) {
-        // ignore unknown bare tokens rather than throwing — keeps DSL forgiving
-        continue;
+        // An identifier-led line whose head is not a known component type is
+        // almost always a botched declaration — a typo'd type, or (the common
+        // one) netlist-style connectivity written WITHOUT the `netlist` header,
+        // e.g. `breaker CB1 (L L1) 16A`. Silently dropping such lines used to
+        // render a misleadingly near-empty schematic that still reported
+        // success, so nothing downstream (validateDsl / the caller's post-gen
+        // check) could catch it. Surface it as a real error instead — matching
+        // the `id: type` colon form above and every other diagram's unknown-kind
+        // handling.
+        throw new CircuitParseError(
+          `Unknown component type: "${typeStr}". ` +
+            `For SPICE-style connectivity (Id net1 net2 [value]), start the diagram with the ` +
+            `\`netlist\` header: circuit "..." netlist.`
+        );
       }
       const rest = bareMatch[2] ?? "";
       const parsed = parseAttrs(rest);

--- a/tests/circuit/positional-strict.test.ts
+++ b/tests/circuit/positional-strict.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "vitest";
+import { parseCircuit, CircuitParseError } from "../../src/diagrams/circuit/parser";
+import { validateDsl } from "../../src/ai";
+
+// Regression: positional-mode circuit used to SILENTLY DROP any identifier-led
+// line whose head was not a known component type. A model that wrote
+// netlist-style connectivity without the `netlist` header (e.g. `breaker CB1
+// (L L1) 16A`, `rcd RCD1 ...`, `switch SW1 ...`) got a misleadingly near-empty
+// schematic that still reported `validate ok / render ok`. Those lines must now
+// surface as a real error so downstream validation can catch it.
+describe("circuit positional mode rejects unknown component types", () => {
+  test("an unknown bare-form type throws instead of being dropped", () => {
+    const dsl = `circuit "home switch"\nbreaker CB1 (L L1) 16A`;
+    expect(() => parseCircuit(dsl)).toThrow(CircuitParseError);
+    expect(() => parseCircuit(dsl)).toThrow(/Unknown component type: "breaker"/);
+  });
+
+  test("the error hints at the missing `netlist` header", () => {
+    const dsl = `circuit "home switch"\nrcd RCD1 (L1 N L2 N2) 30mA`;
+    expect(() => parseCircuit(dsl)).toThrow(/netlist/);
+  });
+
+  test("validateDsl reports the real failing DSL as invalid, not ok", () => {
+    // The exact shape that slipped through in production: a header without
+    // `netlist`, then several unknown-type lines.
+    const dsl = [
+      'circuit "家庭开关电路图"',
+      "  vsource V1 (L N) 220V~",
+      "  breaker CB1 (L L1) 16A",
+      "  switch SW1 (L2 Lsw)",
+      "  lamp LAMP1 (Lsw N2) 60W",
+    ].join("\n");
+    const result = validateDsl("circuit", dsl);
+    expect(result.ok).toBe(false);
+  });
+
+  test("known bare-form types and the netlist path are unaffected", () => {
+    // Positional bare form with a KNOWN type still parses.
+    expect(() => parseCircuit(`circuit "t"\nground`)).not.toThrow();
+    // The same circuit written correctly (netlist header + SPICE ids) is valid.
+    const netlist = `circuit "home switch" netlist\nV1 L N 220VAC\nF1 L L1 16A\nS1 L1 Lout\nR_lamp Lout N 60W`;
+    expect(validateDsl("circuit", netlist).ok).toBe(true);
+  });
+});

--- a/tests/core/comment-handling.test.ts
+++ b/tests/core/comment-handling.test.ts
@@ -65,4 +65,21 @@ describe("circuit honors SPICE-style comments", () => {
     const dsl = `circuit "T" netlist\n%% power section\nV1 vcc 0 12V\nR1 vcc 0 10k`;
     expect(validateDsl("circuit", dsl).ok).toBe(true);
   });
+
+  test("`;` full-line comment is ignored (SPICE in-line marker)", () => {
+    // A model with a SPICE prior writes `; note` lines; these used to hard-fail
+    // as `Invalid component id: ";"`.
+    const dsl = `circuit "T" netlist\n; power section\nV1 vcc 0 12V\n; the load\nR1 vcc 0 10k`;
+    expect(validateDsl("circuit", dsl).ok).toBe(true);
+  });
+
+  test("`;` inline (trailing) comment is stripped", () => {
+    const dsl = `circuit "T" netlist\nV1 vcc 0 12V ; supply\nR1 vcc 0 10k ; load`;
+    expect(validateDsl("circuit", dsl).ok).toBe(true);
+  });
+
+  test("`;` comment works in positional mode too", () => {
+    const dsl = `circuit "control"\n; disconnect + fuse\nQ1: disconnect_switch right\nF1: fuse right`;
+    expect(validateDsl("circuit", dsl).ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## What & why

A real MyMap production map — a home-wiring **circuit** edited over several turns — degraded from a good first diagram into a near-empty one, while `validateDsl` and `renderDsl` both reported success the whole time. Root cause was two `circuit` gaps:

1. **Positional mode silently dropped unknown-type lines.** When a model wrote SPICE-style connectivity *without* the `netlist` header — `breaker CB1 (L L1) 16A`, `rcd RCD1 …`, `switch SW1 …` — each unknown-type line was silently discarded (the `parser.ts` bare-form path). The schematic rendered almost empty, yet `validateDsl`/`renderDsl` returned `ok: true` with **zero warnings** — so neither an in-loop `validateDsl` nor a caller's post-generation gate could catch it.
2. **`;` comments hard-failed netlist mode.** `;` is SPICE's in-line comment marker and the grammar advertises "SPICE-style netlist", so models write `; note` lines — which failed with `Invalid component id: ";"`.

## Changes

- **Unknown positional component type → real error.** An identifier-led line whose head is not a known component type now raises `Unknown component type: "<x>"` with a hint to add the `netlist` header — matching the existing `id: type` colon form and every other diagram's unknown-kind handling. Known types and the whole netlist path are unchanged.
- **`;` accepted as a circuit comment** (full-line and trailing) in both netlist and positional modes, alongside `*`, `#`, `%%`. Kept **circuit-local** — deliberately *not* promoted to a universal marker, because other diagram types (e.g. `network`) use `;` as a statement separator.

## Before / after (the exact production DSLs)

| DSL | before | after |
|---|---|---|
| netlist with `; …` comment lines | ❌ `Invalid component id: ";"` | ✅ valid |
| `circuit "…"` (no `netlist`) + `breaker/rcd/switch …` | ⚠️ `ok:true`, renders ~empty | ❌ `invalid` — `Unknown component type: "breaker". …start with the netlist header` |

## Tests

- New `tests/circuit/positional-strict.test.ts` (unknown-type throws; the real production DSL is now `invalid`; known types + netlist path unaffected).
- Extended `tests/core/comment-handling.test.ts` with `;` full-line / inline / positional cases.
- **Full suite: 1872/1872 green.** typecheck clean.

Ships as **0.9.18** (CHANGELOG updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
