### PR TITLE
docs: complete evacuation translations

### DIFF
--- a/website/content/docs/evacuation.de.mdx
+++ b/website/content/docs/evacuation.de.mdx
@@ -4,82 +4,174 @@ title: Flucht- und Rettungsplan
 
 ## Über Flucht- und Rettungspläne
 
-Ein **Flucht- und Rettungsplan** zeigt den **Standort**, die Fluchtwege zu den Notausgängen sowie Feuerlöscher, Handfeuermelder, Erste Hilfe und Sammelstelle. Schematex legt diese Angaben auf einen maßhaltigen Grundriss und prüft die für **DIN ISO 23601** wichtigen Punkte: Standortmarkierung, durchgängige Wege, unabhängige Ausgänge, Druckmaßstab, Sicherheitszeichen und Pflichtlegende.
+Ein **Flucht- und Rettungsplan** ist der ausgehängte Plan für den Personenschutz. Er zeigt einer Person ihren Standort, die Fluchtwege zu den Endausgängen sowie Alarmierungseinrichtungen, Feuerlöscheinrichtungen, Erste-Hilfe-Einrichtungen und die Sammelstelle. Schematex baut ihn auf maßhaltiger `floorplan`-Geometrie auf und prüft Regeln, die ein reines Zeichenprogramm nicht erkennen kann: fehlende Standortmarkierungen, unterbrochene Wegabschnitte, nicht unabhängige Ausgänge, Druckmaßstab, Größe der Sicherheitszeichen und die Pflichtlegende.
+
+Die Engine unterstützt drei wählbare Regelwerke: DIN ISO 23601 / ISO 7010 / ISO 3864, NFPA 170 Kapitel 11 in Verbindung mit NFPA 101 sowie zweisprachige Pläne nach UAE Civil Defence. Die Ausgabe ist eine editierbare SVG-Arbeitshilfe für die Prüfung durch Fachkundige; sie ersetzt nicht die Freigabe durch die zuständige Behörde.
 
 <Playground initial={`evacuation "Bürogeschoss — Flucht- und Rettungsplan" unit m
 compliance iso
 sheet a3 landscape
-room buero "Büro" at 0,0 size 6x5
-room flur "Flur" below buero size 6x2.4
-room treppeA "Treppe A" left-of flur size 3x2.4
-room treppeB "Treppe B" right-of flur size 3x2.4
-opening between buero flur at 50% width 1.6
-door between flur treppeA at 50% width 1.1
-door between flur treppeB at 50% width 1.1
-here in buero at 3,2.5
-exit-final xA in treppeA at 0,1.2 side west "AUSGANG"
-exit-final xB in treppeB at 3,1.2 side east "AUSGANG"
-extinguisher f1 in flur at 2,1.8 class "ABC"
-route primary here -> flur -> treppeB -> xB
-route secondary here -> flur -> treppeA -> xA`} height={620} />
+room office "Großraumbüro" at 0,0 size 6x5
+room lobby "Aufzugsvorraum" below office size 6x2.4
+room stairA "Treppe A" left-of lobby size 3x2.4
+room stairB "Treppe B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "AUSGANG"
+exit-final xB in stairB at 3,1.2 side east "AUSGANG"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. Standort und Blattformat
+## 1. Mit dem Standort beginnen
 
-Jedes ausgehängte Blatt braucht genau eine Standortmarkierung:
+Ändern Sie den Header in `evacuation` (Alias `escapeplan`), geben Sie das Ziel-`sheet` an und setzen Sie genau eine `here`-Markierung an die Stelle, an der dieses Exemplar ausgehängt wird:
 
 ```
 evacuation "2. Obergeschoss — Flucht- und Rettungsplan" unit m
 compliance iso
 sheet a3 landscape
-here in buero at 3,2.5
+room office "Büro" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "AUSGANG"
+route primary here -> x1
 ```
 
-Für fünf Montageorte werden fünf Varianten gerendert; nur die `here`-Zeile ändert sich.
+Für ein Gebäude können viele ausgehängte Exemplare erforderlich sein. Behalten Sie Geometrie und Fluchtwege unverändert bei und rendern Sie für jeden Montageort ein eigenes Exemplar, in dem nur die `here`-Zeile geändert wird.
 
 ## 2. Sicherheitszeichen
 
-Die Zeichen werden in einem festen 24×24-Raster gezeichnet und auf dem Blatt standardmäßig 8 mm groß ausgegeben. Grün kennzeichnet sichere Zustände und Flucht, Rot die Brandschutzeinrichtungen. Die Piktogramme sind eigenständig neu gezeichnet; amtliche ISO-Vektordateien werden weder kopiert noch nachgezeichnet.
+Sicherheitszeichen verwenden ein festes 24×24-Zeichenraster und eine feste Druckgröße von standardmäßig 8 mm, unabhängig vom Maßstab des Grundrisses. Rettungszeichen haben eine vollflächig grüne plate, Brandschutzzeichen eine vollflächig rote plate; die Piktogramme sind jeweils weiße Aussparungen. Schematex zeichnet eigenständige Geometrie und bettet weder ISO- noch NFPA-Grafiken ein oder zeichnet sie nach.
 
-Wichtige Schlüsselwörter sind `exit`, `exit-final`, `assembly`, `here`, `extinguisher`, `call-point`, `first-aid`, `aed`, `no-elevator`, `fire-door` und `smoke-door`. Die vollständige Liste entspricht der englischen Referenzseite.
+Das koordinatenbasierte Vokabular umfasst:
+
+- Ausgänge und Rettung: `exit`, `exit-final`, `assembly`, `refuge`, `shelter`, `escape-ladder`, `rescue-window`, `emergency-door-push`, `emergency-door-slide`
+- Medizinische und sonstige Nothilfe: `first-aid`, `aed`, `stretcher`, `doctor`, `eyewash`, `safety-shower`, `emergency-phone`, `break-glass`
+- Feuerlöscheinrichtungen: `extinguisher`, `hose-reel`, `fire-ladder`, `fire-equipment`, `call-point`, `fire-phone`, `riser`
+- Plan- und Verbotszeichen: `here`, `not-an-exit`, `no-elevator`, `alarm-sounder`
+- Tür-Overlays: `fire-door` und `smoke-door` werden an einer vorhandenen Tür statt an einer Koordinate angebracht
+
+Verwenden Sie entweder die Kurzform oder das ausdrückliche `safety`:
+
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "Sammelstelle A"
+fire-door between corridor stairA rating "EI30"
+```
+
+Raumkoordinaten beziehen sich auf den jeweiligen Raum. `outside at x,y` ist eine absolute Plankoordinate. Mit `side north|south|east|west` rastet ein Zeichen an der Wand ein; `hand left|right` überschreibt die automatisch gewählte Richtungsvariante.
 
 ## 3. Fluchtwege
 
+Ein Fluchtweg ist eine bewusst festgelegte Folge und kein automatisch ermittelter Pfad:
+
 ```
-route primary here -> flur -> treppeB -> xB
-route secondary here -> flur -> treppeA -> xA
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
 ```
 
-Jeder Raumwechsel muss über eine deklarierte Tür oder Öffnung führen. Zwischenräume müssen ausdrücklich genannt werden. Pfeilspitzen zeigen immer vom Standort zum Ausgang; der alternative Weg ist gestrichelt.
+Jeder Übergang zwischen verschiedenen Räumen muss durch eine deklarierte `door` oder `opening` führen. Geben Sie Zwischenräume ausdrücklich an. Schematex zeichnet deterministische orthogonale Segmente durch jede Öffnung, rundet die Knicke ab und setzt alle 2 m chevrons, die vom Standort weg weisen. `secondary` wird gestrichelt dargestellt, `accessible` trägt ein Rollstuhlsymbol und `rescue` ist blau.
 
-## 4. Normprofile
+Fluchtwege müssen an `exit`, `exit-final` oder `assembly` enden. Zwei Wege sind nur dann unabhängig, wenn sie an verschiedenen Endausgängen enden und sich ihre Raumfolgen strukturell unterscheiden.
 
-- `compliance iso`: DIN ISO 23601 / ISO 7010 / ISO 3864, Maßstab höchstens 1:250.
-- `compliance nfpa`: NFPA 170 Kapitel 11, zwei unabhängige Wege sind ein Fehler.
-- `compliance uae`: UAE Civil Defence, englisch-arabische Beschriftung ist Pflicht.
+## 4. Compliance profiles
 
-## 5. Druckmaßstab
+| Profile | Einsatzbereich | Wichtige Unterschiede |
+| --- | --- | --- |
+| `iso` (Standard) | Pläne nach DIN/BS/internationaler ISO 23601 | ISO-7010-Zeichen, Maßstab höchstens 1:250, Zeichen ≥7 mm |
+| `nfpa` | US-amerikanische Emergency Evacuation Diagrams | NFPA-170-Varianten, zwei Wege sind Pflicht, automatisches `no-elevator` |
+| `uae` | Einreichungen bei UAE Civil Defence | gelbe Standortmarkierung, englisch-arabische Beschriftung, von ISO abgeleitete Maßstabsgrenze |
 
-`sheet a4|a3|a2|letter|tabloid landscape|portrait` legt das Ausgabeformat fest. Der größte Geschossrahmen bestimmt den gemeinsamen Maßstab. Sicherheitszeichen bleiben physisch 8 mm groß und werden nicht zusammen mit dem Gebäude verkleinert.
+Wählen Sie das profile am Anfang:
 
-## 6. Geschosse
+```
+compliance nfpa
+```
 
-Mit `floor N "Bezeichnung"` entstehen getrennte Geschossrahmen. Gleich benannte Treppen-IDs wie `S1` registrieren ein durchgehendes Treppenhaus; mehr als 0,1 m Versatz erzeugt eine Warnung. Jedes Geschoss muss Standort, Ausgänge und Wege selbst erfüllen.
+Die Auswahl des profiles ändert Zeichenvarianten und Validierung, niemals die Raumgeometrie.
 
-## 7. Pflichtlegende und Ebenen
+## 5. Druckmaßstab und sheet-Größe
 
-Die Tier-M-Legende ist immer aktiv; `legend: off` ist unzulässig. Möbel, Flächenangaben und Maßketten werden automatisch ausgeblendet. Treppen, Aufzüge, Stützen, Nordpfeil, Wege, Zeichen und Maßstabshinweis bleiben sichtbar.
+Deklarieren Sie `sheet a4|a3|a2|letter|tabloid` zusammen mit `landscape` oder `portrait`. Schematex zieht einen Rand von 15 mm ab, passt die größte floor plate an beide druckbaren Achsen an und rundet den Nenner auf einen üblichen Wert auf (`1:50`, `1:100`, `1:200`, `1:250` und so weiter).
 
-## 8. Prüfung
+Sicherheitszeichen bleiben auf dem Papier 8 mm groß. Der Maßstab rechnet diese feste Papiergröße für die Kollisionsprüfung vorübergehend in eine Grundrissfläche zurück; die Zeichen schrumpfen nicht mit dem Gebäude. Bei ISO- und UAE-Plänen ist ein gröberer Maßstab als 1:250 ein Fehler.
 
-Schematex meldet unter anderem fehlenden Standort, fehlenden Ausgang, nicht benachbarte Wegsprünge, nicht unabhängige Wege, unerschlossene Räume, ein falsches Wegende, überlappende Zeichen, fehlende Zweisprachigkeit, deaktivierte Legende, Monochrom-Ausgabe, zu kleinen Druckmaßstab und unbekannte Zeichen. Jede Meldung nennt DIN ISO 23601, NFPA oder UAE Civil Defence als Grundlage.
+Jedes gerenderte sheet enthält einen Hinweis wie:
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Ebenen und mehrgeschossige Pläne
+
+Der Evacuation mode behält Räume, Wände, Öffnungen, Türschwenkbögen, Treppen, Aufzüge, Stützen, Raumnamen, Nordpfeil, Fluchtwege, Sicherheitszeichen, Legende und Maßstabshinweis bei. Normales Mobiliar, Flächentext und Maßlinien werden automatisch ausgeblendet. Fügen Sie `show furniture` nur hinzu, wenn ein bestimmtes Objekt für die Orientierung erforderlich ist.
+
+Die Syntax für mehrere Geschosse wird vom floorplan übernommen:
+
+```
+evacuation "Flucht- und Rettungspläne des Gebäudes" unit m stack horizontal
+floor 0 "Erdgeschoss"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "1. Obergeschoss"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+Alle plates verwenden denselben Maßstab. Die Wiederverwendung von `S1` registriert ein gemeinsames Treppenhaus: Das untere Vorkommen wird mit UP beschriftet, die oberen mit DN; ein Koordinatenversatz von mehr als 0,1 m erzeugt eine Warnung. Jedes Geschoss wird dennoch als eigener ausgehängter Plan validiert.
+
+## 7. Pflichtlegende
+
+Die Legende gehört zu Tier M: Sie ist immer vorhanden und führt jede verwendete Darstellung auf, gruppiert nach Fluchtwegen, Ausgängen, Feuerlöscheinrichtungen, Erste Hilfe und Bauteilen. ISO profiles enthalten den Kenncode des Sicherheitszeichens in der Beschriftung; bei NFPA werden ISO-Codes weggelassen.
+
+Mit den gemeinsamen legend-Direktiven können Sie Beschriftungen oder Abschnitte umbenennen. `legend: off` ist jedoch ein Parse-Fehler, weil DIN ISO 23601 und NFPA 170 eine Legende verlangen.
+
+## 8. Validierungsmeldungen
+
+Die Engine prüft vor der Veröffentlichung alle folgenden Regeln:
+
+1. Jedes Geschoss hat eine `here`-Markierung.
+2. Jedes Geschoss hat einen Ausgang.
+3. Jeder Wegabschnitt zwischen Räumen führt durch eine deklarierte Öffnung.
+4. Zwei Fluchtwege sind strukturell unabhängig (NFPA: Fehler; ISO/UAE: Warnung).
+5. Verbundene Räume sind auf einem Fluchtweg vertreten oder haben einen eigenen Ausgang.
+6. Fluchtwege enden an einem Ausgang oder einer Sammelstelle.
+7. Sicherheitszeichen fester Größe bleiben lesbar und überlappen sich nicht.
+8. UAE-Beschriftungen enthalten nicht leere englische und arabische Hälften, getrennt durch ` / `.
+9. NFPA-/UAE-Pläne mit Aufzügen erhalten automatisch eine `no-elevator`-Markierung.
+10. Die Legende kann nicht deaktiviert werden.
+11. `monochrome` meldet einen Fehler und rendert zur Diagnose trotzdem in den semantischen Sicherheitsfarben.
+12. Der Druckmaßstab von ISO-/UAE-Plänen ist nicht gröber als 1:250.
+13. Bei unbekannten Zeichentypen werden gültige Namen aufgeführt und der ähnlichste vorgeschlagen.
+
+Jede Diagnose nennt die maßgebliche Quelle. So erkennen Verfassende, ob sich die Korrektur aus DIN ISO 23601, NFPA 170/NFPA 101 oder den Richtlinien von UAE Civil Defence ergibt.
 
 ## 9. Grammatik
 
-Die DSL-Formen sind identisch mit der englischen Seite; Titel und sichtbare Beschriftungen dürfen deutsch sein. Die Schlüsselwörter bleiben englisch, damit Quellen zwischen Sprachversionen austauschbar sind.
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
 
 ## Verwandte Beispiele
 
 - [Bürogeschoss mit zwei Fluchtwegen](/examples#evacuation)
-- [Zweistöckiges Wohnhaus](/examples#evacuation)
+- [US-Lagerhalle nach NFPA](/examples#evacuation)
+- [Englisch-arabischer Klinikplan](/examples#evacuation)

--- a/website/content/docs/evacuation.es.mdx
+++ b/website/content/docs/evacuation.es.mdx
@@ -4,46 +4,174 @@ title: Plano de evacuación
 
 ## Acerca de los planos de evacuación
 
-Un **plano de evacuación** publicado muestra «usted está aquí», las rutas hacia las salidas finales y la ubicación de alarmas, equipos contra incendios y primeros auxilios. Schematex lo construye sobre geometría medible y valida ISO 23601, NFPA 170 o el perfil bilingüe de UAE Civil Defence.
+Un **plano de evacuación** es el diagrama de seguridad que se coloca en un lugar visible para indicar a cada persona dónde se encuentra, qué rutas conducen a cada salida de emergencia y dónde están las alarmas, los equipos contra incendios, los primeros auxilios y el punto de reunión. Schematex lo construye sobre geometría `floorplan` medible y comprueba reglas que una herramienta de dibujo no puede detectar: marcadores de ubicación ausentes, tramos de ruta interrumpidos, salidas no independientes, escala de impresión, tamaño de las señales de seguridad y leyenda obligatoria.
 
-<Playground initial={`evacuation "Plano de evacuación" unit m
+El motor admite tres normativas seleccionables: ISO 23601 / ISO 7010 / ISO 3864, el capítulo 11 de NFPA 170 junto con NFPA 101 y los planos bilingües de UAE Civil Defence. El resultado es un SVG editable que sirve de apoyo para la revisión de profesionales competentes; no sustituye la aprobación de la autoridad con jurisdicción.
+
+<Playground initial={`evacuation "Planta de oficinas — Plano de evacuación" unit m
 compliance iso
 sheet a3 landscape
-room sala "Sala" at 0,0 size 6x4
-here in sala at 2,2
-exit-final salida in sala at 6,2 side east "SALIDA"
-route primary here -> salida`} height={460} />
+room office "Oficina diáfana" at 0,0 size 6x5
+room lobby "Vestíbulo de ascensores" below office size 6x2.4
+room stairA "Escalera A" left-of lobby size 3x2.4
+room stairB "Escalera B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "SALIDA"
+exit-final xB in stairB at 3,1.2 side east "SALIDA"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. Ubicación publicada
+## 1. Empiece por la ubicación del plano
 
-Cada copia necesita un único `here`. Para varios puntos de montaje, renderiza una copia por ubicación y cambia solo esa línea.
+Cambie el header a `evacuation` (alias `escapeplan`), declare el `sheet` de destino y añada exactamente un marcador `here` en el lugar donde se instalará esta copia:
 
-## 2. Señales
+```
+evacuation "Planta 2 — Plano de evacuación" unit m
+compliance iso
+sheet a3 landscape
+room office "Oficina" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "SALIDA"
+route primary here -> x1
+```
 
-Las señales usan un lienzo fijo de 24×24 y 8 mm impresos. Verde significa condición segura; rojo, equipo contra incendios. Usa `exit`, `exit-final`, `assembly`, `extinguisher`, `call-point`, `first-aid`, `aed`, `no-elevator` y el resto del catálogo documentado.
+Un edificio puede necesitar muchas copias colocadas en puntos distintos. Mantenga idénticas la geometría y las rutas, y renderice una copia por cada lugar de instalación cambiando únicamente la línea `here`.
 
-## 3. Rutas
+## 2. Señales de seguridad
 
-`route primary here -> corredor -> escalera -> salida` conecta anclas mediante puertas u `opening` declarados. Las habitaciones intermedias son obligatorias; el motor no inventa caminos.
+Las señales utilizan una cuadrícula fija de 24×24 unidades de dibujo y un tamaño impreso fijo de 8 mm por defecto, independiente de la escala del plano. Las señales de condición segura llevan una plate verde maciza y las señales contra incendios, una plate roja maciza; los pictogramas se forman mediante reservas blancas. Schematex dibuja geometría original, sin incrustar ni calcar material gráfico de ISO o NFPA.
 
-## 4. Perfiles
+El vocabulario basado en coordenadas es:
 
-`compliance iso` aplica ISO 23601/7010/3864; `nfpa` aplica NFPA 170 y NFPA 101; `uae` exige etiquetas inglesas/árabes separadas por ` / `.
+- Salidas y rescate: `exit`, `exit-final`, `assembly`, `refuge`, `shelter`, `escape-ladder`, `rescue-window`, `emergency-door-push`, `emergency-door-slide`
+- Asistencia médica y de emergencia: `first-aid`, `aed`, `stretcher`, `doctor`, `eyewash`, `safety-shower`, `emergency-phone`, `break-glass`
+- Equipos contra incendios: `extinguisher`, `hose-reel`, `fire-ladder`, `fire-equipment`, `call-point`, `fire-phone`, `riser`
+- Plano y prohibición: `here`, `not-an-exit`, `no-elevator`, `alarm-sounder`
+- Overlays de puertas: `fire-door` y `smoke-door` se vinculan a una puerta existente en vez de a una coordenada
 
-## 5. Escala
+Puede usar la forma abreviada o indicar `safety` de manera explícita:
 
-Declara `sheet a4|a3|a2|letter|tabloid landscape|portrait`. El plano calcula una escala convencional compartida y mantiene las señales a 8 mm. ISO/UAE rechaza escalas más gruesas que 1:250.
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "Punto de reunión A"
+fire-door between corridor stairA rating "EI30"
+```
 
-## 6. Capas y pisos
+Las coordenadas de una sala son relativas a esa sala. `outside at x,y` es una coordenada absoluta del plano. `side north|south|east|west` ajusta una señal a la pared; `hand left|right` sustituye la variante direccional seleccionada automáticamente.
 
-El modo oculta muebles ordinarios, áreas y cotas; conserva escaleras, ascensores, norte, rutas y símbolos. `floor N "Etiqueta"` crea placas con escala común e IDs de escalera compartidos.
+## 3. Rutas de evacuación
+
+Una ruta es una secuencia definida por el autor, no un recorrido inferido:
+
+```
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
+```
+
+Cada salto entre salas distintas debe atravesar una `door` o `opening` declarada. Indique explícitamente las salas intermedias. Schematex dibuja segmentos ortogonales deterministas que pasan por cada abertura, redondea los giros y coloca chevrons cada 2 m orientados en sentido contrario a `here`. `secondary` se dibuja con trazo discontinuo, `accessible` incorpora un símbolo de silla de ruedas y `rescue` aparece en azul.
+
+Las rutas deben terminar en `exit`, `exit-final` o `assembly`. Dos rutas solo son independientes cuando terminan en salidas finales distintas y sus secuencias de salas presentan diferencias estructurales.
+
+## 4. Compliance profiles
+
+| Profile | Para qué se usa | Diferencias importantes |
+| --- | --- | --- |
+| `iso` (predeterminado) | Planos DIN/BS/internacionales según ISO 23601 | señales ISO 7010, límite de escala 1:250, señales ≥7 mm |
+| `nfpa` | Diagramas estadounidenses de evacuación de emergencia | variantes NFPA 170, no disponer de dos rutas es un error, `no-elevator` automático |
+| `uae` | Presentaciones ante UAE Civil Defence | marcador de ubicación amarillo, rótulos en inglés y árabe, límite de escala derivado de ISO |
+
+Seleccione el profile cerca del comienzo:
+
+```
+compliance nfpa
+```
+
+El profile elegido cambia las variantes de los glyphs y la validación, nunca la geometría de las salas.
+
+## 5. Escala de impresión y tamaño del sheet
+
+Declare `sheet a4|a3|a2|letter|tabloid` con `landscape` o `portrait`. Schematex descuenta un margen de 15 mm, ajusta la floor plate más grande a los dos ejes imprimibles y redondea el denominador al siguiente valor convencional (`1:50`, `1:100`, `1:200`, `1:250`, etc.).
+
+Las señales de seguridad conservan 8 mm en el papel. La escala convierte temporalmente ese tamaño físico fijo en una huella dentro del plano para comprobar colisiones; las señales no se reducen al aumentar el edificio. En los planos ISO y UAE, una escala menos detallada que 1:250 se considera un error.
+
+Cada sheet renderizado incluye una nota como:
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Layers y planos de varias plantas
+
+El evacuation mode conserva salas, paredes, aberturas, giros de puertas, escaleras, ascensores, pilares, nombres de salas, norte, rutas, señales de seguridad, leyenda y nota de escala. Oculta automáticamente el mobiliario ordinario, el texto de superficie y las cotas. Añada `show furniture` solo cuando un elemento concreto sea necesario para orientarse.
+
+La sintaxis de varias plantas se hereda de floorplan:
+
+```
+evacuation "Planos de evacuación del edificio" unit m stack horizontal
+floor 0 "Planta baja"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "Primera planta"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+Todas las plates comparten una única escala. Al reutilizar `S1` se registra la misma caja de escalera: la aparición inferior se etiqueta UP, las superiores DN y un desplazamiento de coordenadas superior a 0,1 m genera una advertencia. Aun así, cada planta se valida como un plano colocado independiente.
 
 ## 7. Leyenda obligatoria
 
-La leyenda Tier M siempre está activa. `legend: off` es un error porque ISO 23601 y NFPA 170 exigen explicar los símbolos usados.
+La leyenda es Tier M: siempre está presente y enumera todas las codificaciones utilizadas, agrupadas en Rutas de evacuación, Salidas, Equipos contra incendios, Primeros auxilios y Elementos estructurales. Los profiles ISO incluyen en los rótulos el código de identidad de la señal; NFPA omite los códigos ISO.
 
-## 8. Validación
+Puede cambiar el nombre de los rótulos o las secciones mediante las directivas de legend compartidas, pero `legend: off` produce un error de parseo porque ISO 23601 y NFPA 170 exigen la leyenda.
 
-Se comprueban ubicación, salida, continuidad, independencia, habitaciones sin ruta, destino, legibilidad, bilingüismo, ascensor, leyenda, color, escala y vocabulario. Cada mensaje cita la norma aplicable.
+## 8. Mensajes de validación
+
+El motor comprueba todo lo siguiente antes de publicar:
+
+1. Cada planta tiene un marcador `here`.
+2. Cada planta tiene una salida.
+3. Los saltos de una ruta cruzan una abertura declarada.
+4. Dos rutas de evacuación son estructuralmente independientes (error en NFPA; advertencia en ISO/UAE).
+5. Las salas conectadas están representadas en una ruta o disponen de salida.
+6. Las rutas terminan en una salida o un punto de reunión.
+7. Las señales de seguridad de tamaño fijo siguen siendo legibles y no se solapan.
+8. Los rótulos UAE contienen mitades no vacías en inglés y árabe, separadas por ` / `.
+9. Los planos NFPA/UAE con ascensores reciben automáticamente un marcador `no-elevator`.
+10. No se puede desactivar la leyenda.
+11. `monochrome` informa de un error y aun así renderiza con colores semánticos de seguridad para facilitar el diagnóstico.
+12. La escala impresa de los planos ISO/UAE no es menos detallada que 1:250.
+13. Un tipo de señal desconocido muestra los nombres válidos y sugiere la coincidencia más cercana.
+
+Cada diagnóstico cita la fuente normativa aplicable para que el autor sepa si la corrección procede de ISO 23601, NFPA 170/NFPA 101 o las directrices de UAE Civil Defence.
+
+## 9. Gramática
+
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
+
+## Ejemplos relacionados
+
+- [Planta de oficinas con dos rutas de evacuación](/examples#evacuation)
+- [Almacén estadounidense según NFPA](/examples#evacuation)
+- [Plano de clínica en inglés y árabe](/examples#evacuation)

--- a/website/content/docs/evacuation.fr.mdx
+++ b/website/content/docs/evacuation.fr.mdx
@@ -4,46 +4,174 @@ title: Plan d’évacuation
 
 ## À propos des plans d’évacuation
 
-Un **plan d’évacuation** affiché indique votre position, les cheminements vers les sorties définitives et l’emplacement des alarmes, moyens de lutte contre l’incendie et premiers secours. Schematex s’appuie sur une géométrie mesurable et contrôle ISO 23601, NFPA 170 ou le profil bilingue UAE Civil Defence.
+Un **plan d’évacuation** est le document de sécurité affiché qui indique à une personne où elle se trouve, quels cheminements mènent à chaque issue de secours et où trouver les dispositifs d’alarme, les moyens de lutte contre l’incendie, les premiers secours et le point de rassemblement. Schematex le construit sur une géométrie `floorplan` mesurable et contrôle des règles qu’un simple outil de dessin ne peut pas détecter : position actuelle manquante, tronçons de route interrompus, sorties non indépendantes, échelle d’impression, taille des signaux de sécurité et légende obligatoire.
 
-<Playground initial={`evacuation "Plan d’évacuation" unit m
+Le moteur prend en charge trois référentiels au choix : ISO 23601 / ISO 7010 / ISO 3864, NFPA 170 chapitre 11 avec NFPA 101 et les plans bilingues de l’UAE Civil Defence. Le résultat est une aide SVG modifiable destinée à la vérification par une personne compétente ; il ne remplace pas l’approbation de l’autorité compétente.
+
+<Playground initial={`evacuation "Étage de bureaux — Plan d’évacuation" unit m
 compliance iso
 sheet a3 landscape
-room salle "Salle" at 0,0 size 6x4
-here in salle at 2,2
-exit-final sortie in salle at 6,2 side east "SORTIE"
-route primary here -> sortie`} height={460} />
+room office "Bureau ouvert" at 0,0 size 6x5
+room lobby "Hall des ascenseurs" below office size 6x2.4
+room stairA "Escalier A" left-of lobby size 3x2.4
+room stairB "Escalier B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "SORTIE"
+exit-final xB in stairB at 3,1.2 side east "SORTIE"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. Position du lecteur
+## 1. Commencer par l’emplacement d’affichage
 
-Chaque exemplaire comporte un seul `here`. Pour plusieurs emplacements d’affichage, rendez plusieurs copies en ne modifiant que cette ligne.
+Remplacez le header par `evacuation` (alias `escapeplan`), déclarez le `sheet` cible et ajoutez exactement un repère `here` à l’endroit où cet exemplaire sera affiché :
 
-## 2. Signalétique
+```
+evacuation "Étage 2 — Plan d’évacuation" unit m
+compliance iso
+sheet a3 landscape
+room office "Bureau" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "SORTIE"
+route primary here -> x1
+```
 
-Les pictogrammes sont dessinés dans un repère fixe 24×24 et imprimés à 8 mm. Le vert désigne l’évacuation et le rouge les équipements incendie. Le vocabulaire comprend sorties, point de rassemblement, extincteur, déclencheur, premiers secours, AED et interdictions.
+Un bâtiment peut nécessiter de nombreux exemplaires affichés. Conservez la même géométrie et les mêmes routes, puis générez un exemplaire par point de pose en ne modifiant que la ligne `here`.
 
-## 3. Itinéraires
+## 2. Signaux de sécurité
 
-`route primary here -> couloir -> escalier -> sortie` traverse uniquement des portes ou ouvertures déclarées. Les locaux intermédiaires doivent être nommés; aucun chemin n’est inventé.
+Les signaux utilisent une grille de dessin fixe de 24×24 unités et une taille imprimée fixe de 8 mm par défaut, indépendante de l’échelle du plan. Les signaux d’évacuation ont une plate verte pleine et les signaux de lutte contre l’incendie une plate rouge pleine ; leurs pictogrammes sont formés en réserve blanche. Schematex dessine une géométrie originale, sans incorporer ni décalquer les graphismes ISO ou NFPA.
 
-## 4. Profils
+Le vocabulaire positionné par coordonnées comprend :
 
-`iso` applique ISO 23601/7010/3864, `nfpa` NFPA 170/NFPA 101 et `uae` l’étiquetage anglais/arabe obligatoire.
+- Sorties et secours : `exit`, `exit-final`, `assembly`, `refuge`, `shelter`, `escape-ladder`, `rescue-window`, `emergency-door-push`, `emergency-door-slide`
+- Aide médicale et d’urgence : `first-aid`, `aed`, `stretcher`, `doctor`, `eyewash`, `safety-shower`, `emergency-phone`, `break-glass`
+- Équipements de lutte contre l’incendie : `extinguisher`, `hose-reel`, `fire-ladder`, `fire-equipment`, `call-point`, `fire-phone`, `riser`
+- Plan et interdiction : `here`, `not-an-exit`, `no-elevator`, `alarm-sounder`
+- Overlays de porte : `fire-door` et `smoke-door` se fixent à une porte existante plutôt qu’à une coordonnée
 
-## 5. Échelle d’impression
+Utilisez soit la forme courte, soit le mot-clé explicite `safety` :
 
-Déclarez la feuille et son orientation. Toutes les plaques d’étage partagent l’échelle calculée, tandis que les symboles restent physiquement à 8 mm. ISO/UAE limite l’échelle à 1:250.
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "Point de rassemblement A"
+fire-door between corridor stairA rating "EI30"
+```
 
-## 6. Calques et étages
+Les coordonnées d’une pièce sont relatives à cette pièce. `outside at x,y` désigne une coordonnée absolue du plan. `side north|south|east|west` plaque un signal contre le mur ; `hand left|right` remplace la variante directionnelle choisie automatiquement.
 
-Le mobilier courant, les surfaces et les cotes sont masqués; escaliers, ascenseurs, nord, itinéraires et symboles restent visibles. `floor N "Libellé"` crée plusieurs plaques et les mêmes identifiants d’escalier contrôlent l’alignement vertical.
+## 3. Cheminements d’évacuation
+
+Une route est une séquence définie par l’auteur, pas un chemin calculé :
+
+```
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
+```
+
+Chaque passage entre deux pièces différentes doit franchir une `door` ou une `opening` déclarée. Nommez explicitement les pièces intermédiaires. Schematex trace des segments orthogonaux déterministes à travers chaque ouverture, arrondit les changements de direction et place tous les 2 m des chevrons orientés en s’éloignant de `here`. `secondary` est en pointillés, `accessible` porte un symbole de fauteuil roulant et `rescue` est bleu.
+
+Les routes doivent aboutir à `exit`, `exit-final` ou `assembly`. Deux routes ne sont indépendantes que si elles se terminent à des issues finales différentes et si leurs séquences de pièces diffèrent structurellement.
+
+## 4. Compliance profiles
+
+| Profile | Usage | Différences importantes |
+| --- | --- | --- |
+| `iso` (par défaut) | Plans DIN/BS/internationaux selon ISO 23601 | signaux ISO 7010, limite d’échelle 1:250, signaux ≥7 mm |
+| `nfpa` | Diagrammes d’évacuation d’urgence aux États-Unis | variantes NFPA 170, l’absence de deux routes est une erreur, `no-elevator` automatique |
+| `uae` | Dossiers soumis à l’UAE Civil Defence | repère de position jaune, libellés anglais/arabe, limite d’échelle dérivée d’ISO |
+
+Sélectionnez le profile près du début :
+
+```
+compliance nfpa
+```
+
+Le choix du profile modifie les variantes de glyphs et la validation, jamais la géométrie des pièces.
+
+## 5. Échelle d’impression et format du sheet
+
+Déclarez `sheet a4|a3|a2|letter|tabloid` avec `landscape` ou `portrait`. Schematex retranche une marge de 15 mm, ajuste la plus grande floor plate aux deux axes imprimables et arrondit le dénominateur à la valeur conventionnelle supérieure (`1:50`, `1:100`, `1:200`, `1:250`, etc.).
+
+Les signaux de sécurité restent imprimés à 8 mm. L’échelle reconvertit temporairement cette taille physique fixe en emprise sur le plan pour vérifier les collisions ; les signaux ne rétrécissent pas avec le bâtiment. Une échelle moins détaillée que 1:250 constitue une erreur pour les plans ISO et UAE.
+
+Chaque sheet généré comporte une note telle que :
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Layers et plans multi-étages
+
+L’evacuation mode conserve les pièces, murs, ouvertures, débattements de portes, escaliers, ascenseurs, poteaux, noms des pièces, nord, routes, signaux de sécurité, légende et note d’échelle. Il masque automatiquement le mobilier courant, les surfaces et les lignes de cote. Ajoutez `show furniture` uniquement lorsqu’un objet précis est nécessaire à l’orientation.
+
+La syntaxe multi-étages est héritée de floorplan :
+
+```
+evacuation "Plans d’évacuation du bâtiment" unit m stack horizontal
+floor 0 "Rez-de-chaussée"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "Premier étage"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+Toutes les plates partagent la même échelle. La réutilisation de `S1` enregistre une seule cage d’escalier : l’occurrence inférieure porte la mention UP, les occurrences supérieures DN et un décalage de coordonnées supérieur à 0,1 m déclenche un avertissement. Chaque étage reste validé comme un plan affiché distinct.
 
 ## 7. Légende obligatoire
 
-La légende Tier M ne peut pas être désactivée. Elle regroupe itinéraires, sorties, incendie, secours et éléments structurels.
+La légende est Tier M : elle est toujours présente et recense chaque représentation utilisée, regroupée en Cheminements d’évacuation, Sorties, Équipements de lutte contre l’incendie, Premiers secours et Structure. Les profiles ISO incluent le code d’identification du signal dans les libellés ; NFPA omet les codes ISO.
 
-## 8. Contrôles
+Vous pouvez renommer les libellés ou les sections à l’aide des directives legend communes, mais `legend: off` provoque une erreur de parsing, car ISO 23601 et NFPA 170 imposent une légende.
 
-Le moteur vérifie position, sortie, continuité, indépendance, locaux sans chemin, destination, lisibilité, bilinguisme, ascenseur, légende, couleurs, échelle et noms de symboles, avec la référence normative dans chaque message.
+## 8. Messages de validation
+
+Le moteur effectue tous les contrôles suivants avant publication :
+
+1. Chaque étage possède un repère `here`.
+2. Chaque étage possède une sortie.
+3. Les passages d’une route franchissent une ouverture déclarée.
+4. Deux routes d’évacuation sont structurellement indépendantes (erreur NFPA ; avertissement ISO/UAE).
+5. Les pièces reliées figurent sur une route ou possèdent leur propre sortie.
+6. Les routes se terminent à une sortie ou à un point de rassemblement.
+7. Les signaux de sécurité de taille fixe restent lisibles et ne se chevauchent pas.
+8. Les libellés UAE comportent des parties anglaise et arabe non vides, séparées par ` / `.
+9. Les plans NFPA/UAE comportant des ascenseurs reçoivent automatiquement un repère `no-elevator`.
+10. La légende ne peut pas être désactivée.
+11. `monochrome` signale une erreur, mais effectue tout de même le rendu dans les couleurs sémantiques de sécurité pour permettre le diagnostic.
+12. L’échelle imprimée des plans ISO/UAE n’est pas moins détaillée que 1:250.
+13. Un type de signal inconnu affiche les noms valides et suggère le plus proche.
+
+Chaque diagnostic cite la source normative applicable afin que l’auteur sache si la correction relève d’ISO 23601, de NFPA 170/NFPA 101 ou des directives de l’UAE Civil Defence.
+
+## 9. Grammaire
+
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
+
+## Exemples associés
+
+- [Étage de bureaux avec deux routes d’évacuation](/examples#evacuation)
+- [Entrepôt américain conforme à NFPA](/examples#evacuation)
+- [Plan de clinique en anglais et en arabe](/examples#evacuation)

--- a/website/content/docs/evacuation.ja.mdx
+++ b/website/content/docs/evacuation.ja.mdx
@@ -4,46 +4,174 @@ title: 避難経路図
 
 ## 避難経路図について
 
-**避難経路図**は、現在地、最終出口までの経路、火災報知器、消火設備、応急手当の位置を掲示する図です。Schematex は実寸の floorplan 上に表示し、ISO 23601、NFPA 170、UAE Civil Defence の各 profile を検証します。
+**避難経路図**は、現在地、最終出口へ至る避難経路、火災報知設備、消火器などの消防設備、救急設備、集合場所を示す掲示用の安全図です。Schematex は、実測可能な `floorplan` geometry を基に図面を作成し、通常の作図ツールでは判断できない項目を検証します。たとえば、現在地マーカーの欠落、route 区間の断絶、独立していない出口、印刷 scale、安全標識の大きさ、必須 legend などです。
 
-<Playground initial={`evacuation "避難経路図" unit m
+Engine では、ISO 23601 / ISO 7010 / ISO 3864、NFPA 101 と併用する NFPA 170 Chapter 11、UAE Civil Defence の二言語図面という 3 つの制度を選択できます。出力される編集可能な SVG は、有資格者による確認を補助するためのものであり、所轄官庁の承認に代わるものではありません。
+
+<Playground initial={`evacuation "オフィス階 — 避難経路図" unit m
 compliance iso
 sheet a3 landscape
-room room "Room" at 0,0 size 6x4
-here in room at 2,2
-exit-final exit1 in room at 6,2 side east "EXIT"
-route primary here -> exit1`} height={460} />
+room office "オープンオフィス" at 0,0 size 6x5
+room lobby "エレベーターホール" below office size 6x2.4
+room stairA "階段 A" left-of lobby size 3x2.4
+room stairB "階段 B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "非常口"
+exit-final xB in stairB at 3,1.2 side east "非常口"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. 現在地
+## 1. 掲示位置から始める
 
-掲示する一枚ごとに `here` は一つ必要です。掲示場所が複数なら、平面と経路を共有し、`here` の行だけ変えて別々に render します。
+Header を `evacuation`（alias は `escapeplan`）に変更し、出力先の `sheet` を宣言します。さらに、その図面を掲示する位置に `here` マーカーを 1 つだけ追加します。
 
-## 2. 安全記号
+```
+evacuation "2階 — 避難経路図" unit m
+compliance iso
+sheet a3 landscape
+room office "事務室" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "非常口"
+route primary here -> x1
+```
 
-記号は固定 24×24 grid に描かれ、印刷時は標準 8 mm です。緑は安全・避難、赤は消防設備を意味します。`exit`、`exit-final`、`assembly`、`extinguisher`、`call-point`、`first-aid`、`aed` などを使用できます。
+1 棟の建物でも、複数の掲示図が必要になることがあります。Geometry と routes は同一のまま、掲示位置ごとに `here` の行だけを変えて 1 枚ずつ render してください。
 
-## 3. 経路
+## 2. 安全標識
 
-`route primary here -> corridor -> stair -> exit1` の各部屋間には、宣言済みの `door` または `opening` が必要です。engine は経路探索を行わないため、中間室を明示します。
+安全標識は、floorplan の scale と切り離された固定 24×24 drawing grid と、既定で 8 mm の固定印刷サイズを使用します。避難誘導標識は緑の塗りつぶし plate、消防標識は赤の塗りつぶし plate とし、pictogram は白抜きで描画します。Schematex は独自の geometry を描画し、ISO や NFPA の図版を埋め込んだりトレースしたりしません。
 
-## 4. Compliance profile
+座標で配置できる語彙は次のとおりです。
 
-`iso` は ISO 23601/7010/3864、`nfpa` は NFPA 170/NFPA 101、`uae` は英語・アラビア語の二言語表示を適用します。
+- 出口・救助：`exit`、`exit-final`、`assembly`、`refuge`、`shelter`、`escape-ladder`、`rescue-window`、`emergency-door-push`、`emergency-door-slide`
+- 医療・緊急支援：`first-aid`、`aed`、`stretcher`、`doctor`、`eyewash`、`safety-shower`、`emergency-phone`、`break-glass`
+- 消防設備：`extinguisher`、`hose-reel`、`fire-ladder`、`fire-equipment`、`call-point`、`fire-phone`、`riser`
+- 図面・禁止：`here`、`not-an-exit`、`no-elevator`、`alarm-sounder`
+- Door overlay：`fire-door` と `smoke-door` は座標ではなく、既存の door に付与します
 
-## 5. 印刷 scale
+短縮形と、`safety` を明示する形のどちらも使用できます。
 
-sheet と orientation を宣言すると、全 floor plate で共通の scale を計算します。記号は 8 mm のままで、ISO/UAE は 1:250 より粗い scale を error にします。
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "集合場所 A"
+fire-door between corridor stairA rating "EI30"
+```
 
-## 6. Layer と複数階
+Room 座標は、その room を基準とする相対座標です。`outside at x,y` は plan 全体の絶対座標です。`side north|south|east|west` で標識を壁に吸着し、`hand left|right` で自動選択された方向 variant を上書きできます。
 
-通常家具、面積、寸法線は自動的に非表示です。階段、elevator、north、route、安全記号は残ります。`floor N "Label"` と共通 stair ID で階を登録します。
+## 3. 避難経路
+
+Route は作成者が指定する sequence であり、自動推定される path ではありません。
+
+```
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
+```
+
+異なる room 間の各 hop は、宣言済みの `door` または `opening` を通過する必要があります。途中の room も明示してください。Schematex は各 opening を通る決定的な直交 segment を描き、曲がり角を丸め、`here` から離れる向きの chevron を 2 m ごとに配置します。`secondary` は破線、`accessible` は車いすマーカー付き、`rescue` は青で表示されます。
+
+Routes の終点には `exit`、`exit-final`、`assembly` のいずれかが必要です。2 本の routes が独立していると判定されるのは、最終出口が異なり、かつ room sequence の構造も異なる場合だけです。
+
+## 4. Compliance profiles
+
+| Profile | 用途 | 主な違い |
+| --- | --- | --- |
+| `iso`（既定） | DIN、BS、その他の国際的な ISO 23601 図面 | ISO 7010 標識、scale 上限 1:250、標識 7 mm 以上 |
+| `nfpa` | 米国の緊急避難図 | NFPA 170 variants、2 routes がない場合は error、`no-elevator` を自動追加 |
+| `uae` | UAE Civil Defence への申請 | 黄色の現在地マーカー、英語・アラビア語 labels、ISO 由来の scale 上限 |
+
+冒頭付近で profile を選択します。
+
+```
+compliance nfpa
+```
+
+Profile を変更すると glyph variants と validation が変わりますが、room geometry は変わりません。
+
+## 5. 印刷 scale と sheet サイズ
+
+`sheet a4|a3|a2|letter|tabloid` に `landscape` または `portrait` を指定します。Schematex は 15 mm の margin を差し引き、最大の floor plate が印刷可能な縦横両方に収まるよう調整し、分母を一般的な値（`1:50`、`1:100`、`1:200`、`1:250` など）へ切り上げます。
+
+安全標識の紙面上の大きさは常に 8 mm です。Scale は、collision check のために、この固定された紙面寸法を一時的な plan-space footprint へ逆算します。建物が大きくなっても標識は縮小しません。ISO および UAE の図面では、1:250 より粗い scale は error です。
+
+Render された各 sheet には、次のような注記が入ります。
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Layers と複数階の図面
+
+Evacuation mode では、rooms、walls、openings、door swings、stairs、elevators、columns、room names、north、routes、安全標識、legend、scale note を残します。通常の家具、面積表示、寸法線は自動的に非表示になります。方向を把握するために特定の家具が必要な場合だけ `show furniture` を追加してください。
+
+複数階の syntax は floorplan から継承されます。
+
+```
+evacuation "建物避難経路図" unit m stack horizontal
+floor 0 "1階"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "2階"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+すべての plates は同じ scale を共有します。`S1` を再利用すると同じ階段室として登録され、下階の表示は UP、上階の表示は DN になります。座標のずれが 0.1 m を超えると warning が出ます。各階は、それぞれ独立した掲示図として引き続き validation されます。
 
 ## 7. 必須 legend
 
-Tier M legend は常に表示され、`legend: off` は parse error です。
+Legend は Tier M です。常に表示され、使用されているすべての表現を、避難経路、出口、消防設備、応急手当、構造の各 group に分けて一覧化します。ISO profiles では label に安全標識の識別 code が含まれ、NFPA では ISO code を表示しません。
 
-## 8. Validation
+共通の legend directives を使って labels や sections の名前を変更できます。ただし、ISO 23601 と NFPA 170 は legend を必須としているため、`legend: off` は parse error になります。
 
-現在地、出口、開口の連続性、独立経路、未接続室、終点、記号の重なり、二言語、elevator 禁止、legend、色、scale、未知記号を検査し、各 message に根拠規格を示します。
+## 8. Validation messages
+
+Engine は公開前に次の項目をすべて検証します。
+
+1. 各階に `here` マーカーがあること。
+2. 各階に非常口があること。
+3. Route の hop が宣言済みの opening を通ること。
+4. 2 本の避難 routes が構造的に独立していること（NFPA は error、ISO/UAE は warning）。
+5. 接続された rooms が route 上に含まれるか、その room 自体に出口があること。
+6. Routes が出口または集合場所で終わること。
+7. 固定サイズの安全標識が判読でき、互いに重ならないこと。
+8. UAE labels に、` / ` で区切られた空でない英語部分とアラビア語部分があること。
+9. Elevator がある NFPA/UAE 図面には、`no-elevator` マーカーが 1 つ自動追加されること。
+10. Legend を無効にできないこと。
+11. `monochrome` は error を報告し、診断のために semantic safety colors のまま render すること。
+12. ISO/UAE の印刷 scale が 1:250 より粗くないこと。
+13. 不明な sign kind に対して、有効な名前の一覧と最も近い候補が示されること。
+
+各 diagnostic には根拠となる規格が明記されるため、作成者は ISO 23601、NFPA 170/NFPA 101、UAE Civil Defence guidance のどれに基づく修正なのか判断できます。
+
+## 9. 文法
+
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
+
+## 関連例
+
+- [2 本の避難経路を持つオフィス階](/examples#evacuation)
+- [NFPA を使用した米国の倉庫](/examples#evacuation)
+- [英語・アラビア語併記の診療所図面](/examples#evacuation)

--- a/website/content/docs/evacuation.ko.mdx
+++ b/website/content/docs/evacuation.ko.mdx
@@ -1,49 +1,177 @@
 ---
-title: 대피 안내도
+title: 피난안내도
 ---
 
-## 대피 안내도 소개
+## 피난안내도 소개
 
-**대피 안내도**는 현재 위치, 최종 출구까지의 경로, 화재 경보·소화 장비·응급 처치 위치를 게시하는 도면입니다. Schematex는 실측 floorplan 위에 표시하고 ISO 23601, NFPA 170 또는 UAE Civil Defence profile을 검사합니다.
+**피난안내도**는 현재 위치, 최종 비상구로 이어지는 피난 경로, 화재 경보 설비, 소화 설비, 응급 처치 시설과 집결지를 안내하는 게시용 안전 도면입니다. Schematex는 실측 가능한 `floorplan` geometry 위에 도면을 구성하고, 일반적인 그리기 도구로는 확인할 수 없는 항목을 검사합니다. 현재 위치 표시 누락, 끊어진 route 구간, 독립적이지 않은 출구, 인쇄 scale, 안전 표지 크기, 필수 legend가 여기에 포함됩니다.
 
-<Playground initial={`evacuation "대피 안내도" unit m
+Engine은 ISO 23601 / ISO 7010 / ISO 3864, NFPA 101과 함께 적용하는 NFPA 170 Chapter 11, UAE Civil Defence의 영문·아랍어 병기 도면이라는 세 가지 기준을 선택할 수 있습니다. 출력물은 자격을 갖춘 담당자의 검토를 돕는 편집 가능한 SVG이며, 관할 기관의 승인을 대신하지 않습니다.
+
+<Playground initial={`evacuation "사무실 층 — 피난안내도" unit m
 compliance iso
 sheet a3 landscape
-room room "Room" at 0,0 size 6x4
-here in room at 2,2
-exit-final exit1 in room at 6,2 side east "EXIT"
-route primary here -> exit1`} height={460} />
+room office "개방형 사무실" at 0,0 size 6x5
+room lobby "엘리베이터 홀" below office size 6x2.4
+room stairA "계단 A" left-of lobby size 3x2.4
+room stairB "계단 B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "비상구"
+exit-final xB in stairB at 3,1.2 side east "비상구"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. 현재 위치
+## 1. 게시 위치부터 지정하기
 
-게시물 한 장마다 `here`가 하나 필요합니다. 게시 위치가 여러 곳이면 평면과 route는 유지하고 `here` 줄만 바꿔 각각 render합니다.
+Header를 `evacuation`으로 바꾸고(alias는 `escapeplan`), 대상 `sheet`를 선언한 다음 이 안내도가 설치될 위치에 `here` 마커를 정확히 하나 추가합니다.
+
+```
+evacuation "2층 — 피난안내도" unit m
+compliance iso
+sheet a3 landscape
+room office "사무실" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "비상구"
+route primary here -> x1
+```
+
+건물 하나에도 여러 장의 게시용 안내도가 필요할 수 있습니다. Geometry와 routes는 그대로 유지하고, 설치 지점마다 `here` 줄만 바꾸어 한 장씩 render합니다.
 
 ## 2. 안전 표지
 
-표지는 고정 24×24 grid에 그려지고 인쇄 크기는 기본 8 mm입니다. 녹색은 안전·대피, 빨간색은 소방 장비를 뜻합니다. 출구, 집결지, 소화기, 발신기, 응급 처치, AED와 금지 표지를 지원합니다.
+안전 표지는 floorplan scale과 무관한 고정 24×24 drawing grid와 기본 8 mm의 고정 인쇄 크기를 사용합니다. 피난 유도 표지는 단색 녹색 plate, 소방 표지는 단색 적색 plate를 쓰며 pictogram은 흰색으로 도려낸 형태입니다. Schematex는 자체 geometry를 그리며 ISO 또는 NFPA 도안을 삽입하거나 본떠 그리지 않습니다.
 
-## 3. 대피 route
+좌표로 배치하는 표지 vocabulary는 다음과 같습니다.
 
-`route primary here -> corridor -> stair -> exit1`의 방 사이에는 선언된 `door` 또는 `opening`이 있어야 합니다. 중간 방은 반드시 적어야 하며 engine이 경로를 임의로 찾지 않습니다.
+- 출구와 구조: `exit`, `exit-final`, `assembly`, `refuge`, `shelter`, `escape-ladder`, `rescue-window`, `emergency-door-push`, `emergency-door-slide`
+- 의료 및 긴급 지원: `first-aid`, `aed`, `stretcher`, `doctor`, `eyewash`, `safety-shower`, `emergency-phone`, `break-glass`
+- 소방 설비: `extinguisher`, `hose-reel`, `fire-ladder`, `fire-equipment`, `call-point`, `fire-phone`, `riser`
+- 도면 및 금지: `here`, `not-an-exit`, `no-elevator`, `alarm-sounder`
+- Door overlays: `fire-door`와 `smoke-door`는 좌표가 아니라 기존 door에 부착됩니다
 
-## 4. Compliance profile
+축약형을 쓰거나 `safety`를 명시할 수 있습니다.
 
-`iso`는 ISO 23601/7010/3864, `nfpa`는 NFPA 170/NFPA 101, `uae`는 영어/아랍어 이중 언어 규칙을 적용합니다.
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "집결지 A"
+fire-door between corridor stairA rating "EI30"
+```
 
-## 5. 인쇄 scale
+Room 좌표는 해당 room을 기준으로 한 상대 좌표입니다. `outside at x,y`는 plan 전체의 절대 좌표입니다. `side north|south|east|west`는 표지를 벽에 맞추고, `hand left|right`는 자동으로 선택된 방향 variant를 덮어씁니다.
 
-sheet와 orientation을 선언하면 모든 floor plate에 공통 scale을 계산합니다. 표지는 8 mm로 유지되며 ISO/UAE에서 1:250보다 거친 scale은 error입니다.
+## 3. 피난 경로
 
-## 6. Layer와 여러 층
+Route는 작성자가 정한 sequence이며 자동으로 추론한 path가 아닙니다.
 
-일반 가구, 면적, 치수는 숨기고 계단, elevator, north, route와 표지는 유지합니다. `floor N "Label"`과 같은 stair ID로 층간 정렬을 확인합니다.
+```
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
+```
+
+서로 다른 room 사이의 각 hop은 선언된 `door` 또는 `opening`을 지나야 합니다. 중간 room도 명시해야 합니다. Schematex는 각 opening을 통과하는 결정적인 직교 segment를 그리고, 모서리를 둥글게 처리하며, `here`에서 멀어지는 방향의 chevron을 2 m마다 배치합니다. `secondary`는 점선, `accessible`은 휠체어 마커가 포함된 선, `rescue`는 파란색으로 표시됩니다.
+
+Routes는 `exit`, `exit-final`, `assembly` 중 하나에서 끝나야 합니다. 두 routes는 서로 다른 최종 출구에서 끝나고 room sequence의 구조도 다를 때에만 독립적인 것으로 간주됩니다.
+
+## 4. Compliance profiles
+
+| Profile | 용도 | 주요 차이점 |
+| --- | --- | --- |
+| `iso`(기본값) | DIN/BS 및 국제 ISO 23601 도면 | ISO 7010 표지, scale 한계 1:250, 표지 7 mm 이상 |
+| `nfpa` | 미국의 비상 피난 안내도 | NFPA 170 variants, 두 routes가 없으면 error, `no-elevator` 자동 추가 |
+| `uae` | UAE Civil Defence 제출 도면 | 노란색 현재 위치 마커, 영문·아랍어 labels, ISO에서 파생된 scale 한계 |
+
+문서 앞부분에서 profile을 선택합니다.
+
+```
+compliance nfpa
+```
+
+Profile 선택은 glyph variants와 validation을 바꾸지만 room geometry는 바꾸지 않습니다.
+
+## 5. 인쇄 scale과 sheet 크기
+
+`sheet a4|a3|a2|letter|tabloid`를 `landscape` 또는 `portrait`와 함께 선언합니다. Schematex는 15 mm margin을 제외하고, 가장 큰 floor plate를 인쇄 가능한 두 축에 맞춘 뒤, 분모를 일반적인 값(`1:50`, `1:100`, `1:200`, `1:250` 등)으로 올림합니다.
+
+안전 표지는 종이에서 항상 8 mm입니다. Scale은 collision check를 위해 이 고정된 인쇄 크기를 임시 plan-space footprint로 환산합니다. 건물이 커져도 표지는 작아지지 않습니다. ISO와 UAE 도면에서 1:250보다 작은 축척은 error입니다.
+
+Render된 모든 sheet에는 다음과 같은 주석이 표시됩니다.
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Layers와 여러 층 도면
+
+Evacuation mode는 rooms, walls, openings, door swings, stairs, elevators, columns, room names, north, routes, 안전 표지, legend, scale note를 유지합니다. 일반 가구, 면적 텍스트, 치수선은 자동으로 숨깁니다. 위치 파악에 특정 가구가 꼭 필요할 때만 `show furniture`를 추가하십시오.
+
+여러 층 syntax는 floorplan에서 그대로 가져옵니다.
+
+```
+evacuation "건물 피난안내도" unit m stack horizontal
+floor 0 "1층"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "2층"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+모든 plates는 하나의 scale을 공유합니다. `S1`을 재사용하면 같은 계단실로 등록되어 아래쪽 층에는 UP, 위쪽 층에는 DN이 표시됩니다. 좌표 차이가 0.1 m를 넘으면 warning이 발생합니다. 각 층은 여전히 독립적인 게시 도면으로 validation됩니다.
 
 ## 7. 필수 legend
 
-Tier M legend는 항상 켜져 있고 `legend: off`는 허용되지 않습니다.
+Legend는 Tier M입니다. 항상 표시되며 사용된 모든 표현을 피난 경로, 출구, 소방 설비, 응급 처치, 구조 요소 group으로 나누어 보여 줍니다. ISO profiles는 label에 안전 표지 식별 code를 포함하고, NFPA는 ISO code를 생략합니다.
 
-## 8. Validation
+공통 legend directives로 labels나 sections의 이름을 바꿀 수 있지만, ISO 23601과 NFPA 170이 legend를 의무화하므로 `legend: off`는 parse error입니다.
 
-현재 위치, 출구, 개구부 연속성, 독립 route, 누락된 방, 종점, 표지 충돌, 이중 언어, elevator 금지, legend, 색상, scale과 알 수 없는 표지를 검사하며 표준 근거를 함께 표시합니다.
+## 8. Validation messages
+
+Engine은 게시 전에 다음 항목을 모두 검사합니다.
+
+1. 각 층에 `here` 마커가 있습니다.
+2. 각 층에 비상구가 있습니다.
+3. Route의 hop이 선언된 opening을 통과합니다.
+4. 두 피난 routes가 구조적으로 독립적입니다(NFPA는 error, ISO/UAE는 warning).
+5. 연결된 rooms가 route에 포함되거나 자체 출구를 갖습니다.
+6. Routes가 출구 또는 집결지에서 끝납니다.
+7. 고정 크기 안전 표지가 읽을 수 있는 상태를 유지하고 서로 겹치지 않습니다.
+8. UAE labels에 ` / `로 구분된 비어 있지 않은 영문과 아랍어 부분이 있습니다.
+9. Elevator가 있는 NFPA/UAE 도면에는 `no-elevator` 마커 하나가 자동으로 추가됩니다.
+10. Legend를 끌 수 없습니다.
+11. `monochrome`은 error를 보고하지만 진단을 위해 semantic safety colors로 계속 render합니다.
+12. ISO/UAE 인쇄 scale은 1:250보다 작지 않습니다.
+13. 알 수 없는 sign kind에는 유효한 이름 목록과 가장 가까운 후보가 표시됩니다.
+
+각 diagnostic에는 근거가 되는 기준이 명시되므로 작성자는 ISO 23601, NFPA 170/NFPA 101, UAE Civil Defence 지침 중 어느 규정에 따른 수정인지 알 수 있습니다.
+
+## 9. 문법
+
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
+
+## 관련 예제
+
+- [두 피난 경로가 있는 사무실 층](/examples#evacuation)
+- [NFPA를 적용한 미국 창고](/examples#evacuation)
+- [영문·아랍어 병기 진료소 도면](/examples#evacuation)

--- a/website/content/docs/evacuation.pt-BR.mdx
+++ b/website/content/docs/evacuation.pt-BR.mdx
@@ -1,49 +1,177 @@
 ---
-title: Planta de evacuação
+title: Planta de rota de fuga
 ---
 
-## Sobre plantas de evacuação
+## Sobre plantas de rota de fuga
 
-Uma **planta de evacuação** afixada mostra “você está aqui”, as rotas até as saídas finais e a posição de alarmes, equipamentos de incêndio e primeiros socorros. O Schematex usa geometria mensurável e valida ISO 23601, NFPA 170 ou o profile bilíngue da UAE Civil Defence.
+Uma **planta de rota de fuga** é o diagrama de segurança afixado que informa onde a pessoa está, quais rotas levam às saídas de emergência e onde ficam os alarmes, equipamentos de combate a incêndio, primeiros socorros e o ponto de encontro. O Schematex a constrói sobre geometria `floorplan` mensurável e verifica regras que uma ferramenta de desenho não consegue detectar: marcador de localização ausente, trechos de rota interrompidos, saídas não independentes, escala de impressão, tamanho da sinalização de segurança e legenda obrigatória.
 
-<Playground initial={`evacuation "Planta de evacuação" unit m
+O mecanismo oferece três regimes selecionáveis: ISO 23601 / ISO 7010 / ISO 3864, NFPA 170 Capítulo 11 em conjunto com a NFPA 101 e plantas bilíngues da UAE Civil Defence. O resultado é um SVG editável para apoiar a revisão por profissional habilitado; ele não substitui a aprovação da autoridade competente.
+
+<Playground initial={`evacuation "Pavimento de escritórios — Planta de rota de fuga" unit m
 compliance iso
 sheet a3 landscape
-room sala "Sala" at 0,0 size 6x4
-here in sala at 2,2
-exit-final saida in sala at 6,2 side east "SAÍDA"
-route primary here -> saida`} height={460} />
+room office "Escritório aberto" at 0,0 size 6x5
+room lobby "Hall dos elevadores" below office size 6x2.4
+room stairA "Escada A" left-of lobby size 3x2.4
+room stairB "Escada B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "SAÍDA"
+exit-final xB in stairB at 3,1.2 side east "SAÍDA"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. Local publicado
+## 1. Comece pelo local de instalação
 
-Cada cópia precisa de um único `here`. Para vários pontos de instalação, renderize uma cópia por local e altere somente essa linha.
+Troque o header para `evacuation` (alias `escapeplan`), declare o `sheet` de destino e adicione exatamente um marcador `here` no ponto em que esta cópia será afixada:
 
-## 2. Sinalização
+```
+evacuation "2º andar — Planta de rota de fuga" unit m
+compliance iso
+sheet a3 landscape
+room office "Escritório" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "SAÍDA"
+route primary here -> x1
+```
 
-Os símbolos usam uma grade fixa de 24×24 e 8 mm impressos. Verde representa condição segura e vermelho, equipamento de incêndio. O vocabulário inclui saídas, ponto de encontro, extintor, acionador, primeiros socorros, AED e proibições.
+Um edifício pode precisar de várias cópias afixadas. Mantenha a geometria e as rotas idênticas e renderize uma cópia por ponto de instalação, alterando somente a linha `here`.
 
-## 3. Rotas
+## 2. Sinalização de segurança
 
-`route primary here -> corredor -> escada -> saida` só atravessa `door` ou `opening` declarados. Os ambientes intermediários devem ser nomeados; o engine não inventa caminhos.
+As placas usam uma grade fixa de desenho de 24×24 unidades e um tamanho impresso fixo de 8 mm por padrão, independentemente da escala da planta. Os sinais de condição segura têm plate verde sólida, e os de combate a incêndio, plate vermelha sólida; os pictogramas são recortes brancos. O Schematex desenha geometria original, sem incorporar nem decalcar arte da ISO ou da NFPA.
 
-## 4. Profiles
+O vocabulário baseado em coordenadas é:
 
-`iso` aplica ISO 23601/7010/3864, `nfpa` aplica NFPA 170/NFPA 101 e `uae` exige rótulos em inglês e árabe.
+- Saídas e resgate: `exit`, `exit-final`, `assembly`, `refuge`, `shelter`, `escape-ladder`, `rescue-window`, `emergency-door-push`, `emergency-door-slide`
+- Assistência médica e de emergência: `first-aid`, `aed`, `stretcher`, `doctor`, `eyewash`, `safety-shower`, `emergency-phone`, `break-glass`
+- Equipamentos de combate a incêndio: `extinguisher`, `hose-reel`, `fire-ladder`, `fire-equipment`, `call-point`, `fire-phone`, `riser`
+- Planta e proibição: `here`, `not-an-exit`, `no-elevator`, `alarm-sounder`
+- Overlays de portas: `fire-door` e `smoke-door` são vinculados a uma porta existente, e não a uma coordenada
 
-## 5. Escala de impressão
+Use a forma curta ou escreva `safety` explicitamente:
 
-Declare sheet e orientation. Todas as placas de piso compartilham a escala calculada, enquanto os símbolos continuam com 8 mm. ISO/UAE limita a escala a 1:250.
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "Ponto de encontro A"
+fire-door between corridor stairA rating "EI30"
+```
 
-## 6. Camadas e pavimentos
+As coordenadas de um ambiente são relativas a ele. `outside at x,y` usa uma coordenada absoluta da planta. `side north|south|east|west` encaixa o sinal na parede; `hand left|right` substitui a variante direcional selecionada automaticamente.
 
-Móveis comuns, áreas e cotas ficam ocultos; escadas, elevadores, norte, rotas e símbolos permanecem. `floor N "Rótulo"` cria várias placas e IDs de escada compartilhados validam o alinhamento.
+## 3. Rotas de fuga
+
+Uma route é uma sequência definida pelo autor, e não um caminho inferido:
+
+```
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
+```
+
+Cada passagem entre ambientes diferentes deve cruzar uma `door` ou `opening` declarada. Informe explicitamente os ambientes intermediários. O Schematex desenha segmentos ortogonais determinísticos através de cada abertura, arredonda as curvas e insere chevrons a cada 2 m apontando para longe de `here`. `secondary` usa traço descontínuo, `accessible` inclui o símbolo de cadeira de rodas e `rescue` é azul.
+
+As routes devem terminar em `exit`, `exit-final` ou `assembly`. Duas routes só são independentes quando terminam em saídas finais diferentes e suas sequências de ambientes têm diferenças estruturais.
+
+## 4. Compliance profiles
+
+| Profile | Quando usar | Diferenças importantes |
+| --- | --- | --- |
+| `iso` (padrão) | Plantas DIN/BS/internacionais conforme ISO 23601 | sinais ISO 7010, limite de escala 1:250, sinais ≥7 mm |
+| `nfpa` | Diagramas de evacuação de emergência dos EUA | variantes NFPA 170, a falta de duas rotas é um erro, `no-elevator` automático |
+| `uae` | Documentos apresentados à UAE Civil Defence | marcador de localização amarelo, labels em inglês/árabe, limite de escala derivado da ISO |
+
+Selecione o profile próximo ao início:
+
+```
+compliance nfpa
+```
+
+A seleção do profile altera as variantes dos glyphs e a validação, nunca a geometria dos ambientes.
+
+## 5. Escala de impressão e tamanho do sheet
+
+Declare `sheet a4|a3|a2|letter|tabloid` com `landscape` ou `portrait`. O Schematex desconta uma margem de 15 mm, ajusta a maior floor plate aos dois eixos imprimíveis e arredonda o denominador para um valor convencional (`1:50`, `1:100`, `1:200`, `1:250` e assim por diante).
+
+Os sinais de segurança permanecem com 8 mm no papel. A escala converte temporariamente esse tamanho físico fixo em uma área no espaço da planta para verificar colisões; os sinais não encolhem com o edifício. Em plantas ISO e UAE, uma escala menos detalhada que 1:250 é um erro.
+
+Cada sheet renderizado inclui uma nota como:
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Layers e plantas de vários pavimentos
+
+O evacuation mode mantém ambientes, paredes, aberturas, arcos de abertura das portas, escadas, elevadores, colunas, nomes dos ambientes, norte, rotas, sinais de segurança, legenda e nota de escala. Ele oculta automaticamente móveis comuns, texto de área e linhas de cota. Adicione `show furniture` somente quando um item específico for necessário para orientação.
+
+A sintaxe de vários pavimentos é herdada de floorplan:
+
+```
+evacuation "Plantas de rota de fuga do edifício" unit m stack horizontal
+floor 0 "Térreo"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "Primeiro pavimento"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+Todas as plates compartilham uma escala. Reutilizar `S1` registra a mesma caixa de escada: a ocorrência inferior recebe UP, as superiores recebem DN e uma diferença de coordenadas maior que 0,1 m gera um aviso. Cada pavimento continua sendo validado como uma planta afixada independente.
 
 ## 7. Legenda obrigatória
 
-A legenda Tier M está sempre ativa. `legend: off` é erro porque ISO 23601 e NFPA 170 exigem a explicação dos símbolos usados.
+A legenda é Tier M: está sempre presente e lista todas as codificações usadas, agrupadas em Rotas de fuga, Saídas, Equipamentos de combate a incêndio, Primeiros socorros e Elementos estruturais. Profiles ISO incluem nos labels o código de identificação do sinal; NFPA omite os códigos ISO.
 
-## 8. Validação
+Você pode renomear labels ou seções com as diretivas legend compartilhadas, mas `legend: off` gera um erro de parsing porque ISO 23601 e NFPA 170 exigem a legenda.
 
-O engine verifica local, saída, continuidade, independência, salas sem rota, destino, legibilidade, bilinguismo, elevador, legenda, cores, escala e vocabulário, citando a norma em cada mensagem.
+## 8. Mensagens de validação
+
+O mecanismo verifica todos estes itens antes da publicação:
+
+1. Cada pavimento tem um marcador `here`.
+2. Cada pavimento tem uma saída.
+3. Os trechos da route cruzam uma abertura declarada.
+4. Duas rotas de fuga são estruturalmente independentes (erro no NFPA; aviso no ISO/UAE).
+5. Ambientes conectados aparecem em uma route ou têm uma saída própria.
+6. As routes terminam em uma saída ou em um ponto de encontro.
+7. Sinais de segurança com tamanho fixo permanecem legíveis e não se sobrepõem.
+8. Labels UAE contêm partes não vazias em inglês e árabe separadas por ` / `.
+9. Plantas NFPA/UAE com elevadores recebem automaticamente um marcador `no-elevator`.
+10. A legenda não pode ser desativada.
+11. `monochrome` informa um erro, mas ainda renderiza com as cores semânticas de segurança para diagnóstico.
+12. A escala impressa das plantas ISO/UAE não é menos detalhada que 1:250.
+13. Tipos de sinal desconhecidos listam os nomes válidos e sugerem a opção mais próxima.
+
+Cada diagnóstico informa a fonte normativa aplicável, para que o autor saiba se a correção decorre da ISO 23601, da NFPA 170/NFPA 101 ou das orientações da UAE Civil Defence.
+
+## 9. Gramática
+
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
+
+## Exemplos relacionados
+
+- [Pavimento de escritórios com duas rotas de fuga](/examples#evacuation)
+- [Armazém dos EUA conforme NFPA](/examples#evacuation)
+- [Planta de clínica em inglês e árabe](/examples#evacuation)

--- a/website/content/docs/evacuation.zh-Hans.mdx
+++ b/website/content/docs/evacuation.zh-Hans.mdx
@@ -4,46 +4,174 @@ title: 疏散图
 
 ## 关于疏散图
 
-张贴式**疏散图**要说明“您在此处”、通往最终出口的路线，以及报警、消防设备和急救设施的位置。Schematex 在可量测的 floorplan 几何上绘制这些信息，并按 ISO 23601、NFPA 170 或 UAE Civil Defence 双语 profile 校验。
+**疏散图**是张贴在现场的生命安全图，告诉人员当前所在位置、通往最终安全出口的疏散路线，以及报警装置、消防器材、急救设施和集合点的位置。Schematex 基于可量测的 `floorplan` 几何生成图纸，并检查普通绘图工具无法识别的规则：当前位置标记缺失、路线分段断开、出口不独立、打印比例尺、安全标志尺寸和强制图例。
 
-<Playground initial={`evacuation "楼层疏散图" unit m
+引擎支持三套可选规范：ISO 23601 / ISO 7010 / ISO 3864、结合 NFPA 101 使用的 NFPA 170 Chapter 11，以及 UAE Civil Defence 双语疏散图。输出是可编辑的 SVG，可供专业人员审核，但不能取代主管部门的正式批准。
+
+<Playground initial={`evacuation "办公楼层 — 疏散图" unit m
 compliance iso
 sheet a3 landscape
-room room "房间" at 0,0 size 6x4
-here in room at 2,2
-exit-final exit1 in room at 6,2 side east "出口"
-route primary here -> exit1`} height={460} />
+room office "开放式办公室" at 0,0 size 6x5
+room lobby "电梯厅" below office size 6x2.4
+room stairA "楼梯 A" left-of lobby size 3x2.4
+room stairB "楼梯 B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "安全出口"
+exit-final xB in stairB at 3,1.2 side east "安全出口"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. 张贴位置
+## 1. 从张贴位置开始
 
-每张图必须有且只有一个 `here`。同一栋楼有多个张贴点时，保持平面和路线不变，只修改 `here` 那一行并分别 render。
+把 header 改为 `evacuation`（别名为 `escapeplan`），声明目标 `sheet`，并在这份疏散图实际张贴的位置添加且只添加一个 `here` 标记：
 
-## 2. 安全符号
+```
+evacuation "2 层 — 疏散图" unit m
+compliance iso
+sheet a3 landscape
+room office "办公室" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "安全出口"
+route primary here -> x1
+```
 
-符号画在固定 24×24 grid 上，默认印刷尺寸为 8 mm。绿色表示安全与逃生，红色表示消防设备。可用词汇包括出口、集合点、灭火器、手动报警、急救、AED 和禁止标记。
+一栋建筑可能需要张贴许多份疏散图。几何和疏散路线应保持一致，只修改 `here` 这一行，为每个张贴点分别 render 一份。
+
+## 2. 安全标志
+
+安全标志使用固定的 24×24 绘制网格，并采用固定的打印尺寸（默认 8 mm），与 floorplan 比例尺无关。安全条件标志使用实心绿色 plate，消防标志使用实心红色 plate，pictogram 以白色反白形状呈现。Schematex 绘制原创几何，不会嵌入或描摹 ISO、NFPA 的官方图形。
+
+按坐标放置的标志类型如下：
+
+- 出口与救援：`exit`、`exit-final`、`assembly`、`refuge`、`shelter`、`escape-ladder`、`rescue-window`、`emergency-door-push`、`emergency-door-slide`
+- 医疗与紧急援助：`first-aid`、`aed`、`stretcher`、`doctor`、`eyewash`、`safety-shower`、`emergency-phone`、`break-glass`
+- 消防器材：`extinguisher`、`hose-reel`、`fire-ladder`、`fire-equipment`、`call-point`、`fire-phone`、`riser`
+- 图面与禁令：`here`、`not-an-exit`、`no-elevator`、`alarm-sounder`
+- 门的 overlay：`fire-door` 和 `smoke-door` 附着到现有 door，而不是放在一个坐标上
+
+可以使用简写，也可以显式写出 `safety`：
+
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "集合点 A"
+fire-door between corridor stairA rating "EI30"
+```
+
+房间坐标相对于该房间。`outside at x,y` 使用整个 plan 的绝对坐标。`side north|south|east|west` 把标志吸附到墙上；`hand left|right` 可覆盖自动选择的方向 variant。
 
 ## 3. 疏散路线
 
-`route primary here -> corridor -> stair -> exit1` 的相邻房间必须由已声明的 `door` 或 `opening` 连通。中间房间要明确写出；engine 不会自行寻路。
+Route 是作者明确编写的 sequence，不是引擎推断出来的 path：
 
-## 4. Compliance profile
+```
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
+```
 
-`iso` 使用 ISO 23601/7010/3864；`nfpa` 使用 NFPA 170/NFPA 101；`uae` 强制英文 / 阿拉伯文双语标签。
+不同房间之间的每个 hop 都必须穿过已声明的 `door` 或 `opening`。所有中间房间都要显式写出。Schematex 会确定性地绘制穿过各个开口的正交线段，对转角作圆角处理，并每隔 2 m 放置一个背离 `here` 方向的 chevron。`secondary` 使用虚线，`accessible` 带轮椅标记，`rescue` 使用蓝色。
 
-## 5. 打印比例尺
+Routes 必须终止于 `exit`、`exit-final` 或 `assembly`。两条路线只有在通往不同的最终出口、且房间 sequence 的结构也不同时，才算相互独立。
 
-声明 sheet 与方向后，所有楼层 plate 共用计算出的常规比例尺，符号始终保持 8 mm。ISO/UAE 下比 1:250 更粗的比例尺会报 error。
+## 4. Compliance profiles
 
-## 6. 图层与多楼层
+| Profile | 适用场景 | 主要差异 |
+| --- | --- | --- |
+| `iso`（默认） | DIN、BS 及国际 ISO 23601 疏散图 | ISO 7010 标志、比例尺不得粗于 1:250、标志 ≥7 mm |
+| `nfpa` | 美国应急疏散图 | NFPA 170 variants、未提供两条路线时报 error、自动添加 `no-elevator` |
+| `uae` | UAE Civil Defence 报审图 | 黄色当前位置标记、英文/阿拉伯文 labels、沿用 ISO 的比例尺下限 |
 
-普通家具、面积文字和尺寸标注自动隐藏；楼梯、电梯、北向、路线与安全符号保留。`floor N "标签"` 生成多个 plate，共用的 stair ID 用于校验垂直对齐。
+在文档开头附近选择 profile：
+
+```
+compliance nfpa
+```
+
+Profile 只会改变 glyph variants 和校验规则，不会改变房间几何。
+
+## 5. 打印比例尺与 sheet 尺寸
+
+用 `landscape` 或 `portrait` 声明 `sheet a4|a3|a2|letter|tabloid`。Schematex 会扣除 15 mm 页边距，把最大的 floor plate 同时适配到两个可打印方向，再将比例尺分母向上取整到常规值（`1:50`、`1:100`、`1:200`、`1:250` 等）。
+
+安全标志在纸面上始终保持 8 mm。比例尺会把这个固定的纸面尺寸临时换算回 plan-space footprint，用于碰撞检查；建筑变大时，标志不会随之缩小。ISO 和 UAE 疏散图的比例尺粗于 1:250 时会报 error。
+
+每张 render 后的 sheet 都会带有类似以下的说明：
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Layers 与多楼层疏散图
+
+Evacuation mode 会保留房间、墙体、开口、门扇开启弧、楼梯、电梯、柱、房间名称、指北针、疏散路线、安全标志、图例和比例尺说明，并自动隐藏普通家具、面积文字和尺寸标注。只有某件家具对现场辨向确有必要时，才添加 `show furniture`。
+
+多楼层 syntax 继承自 floorplan：
+
+```
+evacuation "建筑疏散图" unit m stack horizontal
+floor 0 "一层"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "二层"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+所有 plates 共用一个比例尺。重复使用 `S1` 会把各层楼梯注册为同一座楼梯间：低层标为 UP，高层标为 DN；坐标错位超过 0.1 m 会产生 warning。每个楼层仍按一张独立张贴的疏散图进行校验。
 
 ## 7. 强制图例
 
-Tier M legend 始终开启，`legend: off` 是 parse error。
+图例属于 Tier M：它始终显示，并列出图中用到的所有编码，按疏散路线、出口、消防器材、急救设施和结构元素分组。ISO profiles 会在 label 中包含安全标志识别 code；NFPA 不显示 ISO code。
 
-## 8. 校验
+可以用共享 legend directives 重命名 labels 或 sections，但 `legend: off` 会产生 parse error，因为 ISO 23601 和 NFPA 170 都要求必须有图例。
 
-engine 会检查当前位置、出口、开口连续性、独立路线、无路线房间、路线终点、符号碰撞、双语、电梯禁用、图例、颜色、比例尺和未知符号；每条消息都带标准出处。
+## 8. 校验消息
+
+引擎会在发布前完成以下所有检查：
+
+1. 每个楼层都有一个 `here` 标记。
+2. 每个楼层都有出口。
+3. Route 的每次跨房间 hop 都穿过已声明的开口。
+4. 两条疏散路线在结构上相互独立（NFPA 报 error；ISO/UAE 报 warning）。
+5. 相连的房间出现在某条 route 上，或拥有自己的出口。
+6. Routes 终止于出口或集合点。
+7. 固定尺寸的安全标志保持清晰可辨，且相互不重叠。
+8. UAE labels 包含以 ` / ` 分隔的非空英文和阿拉伯文两部分。
+9. 含电梯的 NFPA/UAE 疏散图会自动获得一个 `no-elevator` 标记。
+10. 图例不能关闭。
+11. `monochrome` 会报 error，但仍以语义化安全颜色 render，便于诊断。
+12. ISO/UAE 的打印比例尺不得粗于 1:250。
+13. 未知 sign kind 会列出有效名称，并建议最接近的匹配项。
+
+每条 diagnostic 都会标明所依据的标准，让作者知道应根据 ISO 23601、NFPA 170/NFPA 101 还是 UAE Civil Defence 指南进行修正。
+
+## 9. 语法
+
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
+
+## 相关示例
+
+- [包含两条疏散路线的办公楼层](/examples#evacuation)
+- [采用 NFPA profile 的美国仓库](/examples#evacuation)
+- [英文/阿拉伯文双语诊所疏散图](/examples#evacuation)

--- a/website/content/docs/evacuation.zh-Hant.mdx
+++ b/website/content/docs/evacuation.zh-Hant.mdx
@@ -4,46 +4,174 @@ title: 疏散圖
 
 ## 關於疏散圖
 
-張貼式**疏散圖**要說明「您在此處」、通往最終出口的路線，以及警報、消防設備與急救設施的位置。Schematex 在可量測的 floorplan 幾何上繪製這些資訊，並依 ISO 23601、NFPA 170 或 UAE Civil Defence 雙語 profile 驗證。
+**疏散圖**是張貼在現場的生命安全圖，用來告知人員目前所在位置、通往最終安全出口的疏散路線，以及警報裝置、消防設備、急救設施與集合點的位置。Schematex 依據可量測的 `floorplan` 幾何產生圖面，並檢查一般繪圖工具無法辨識的規則：目前位置標記缺漏、路線分段中斷、出口不獨立、列印比例尺、安全標誌尺寸與強制圖例。
 
-<Playground initial={`evacuation "樓層疏散圖" unit m
+引擎支援三套可選規範：ISO 23601 / ISO 7010 / ISO 3864、搭配 NFPA 101 使用的 NFPA 170 Chapter 11，以及 UAE Civil Defence 雙語疏散圖。輸出是可編輯的 SVG，可協助專業人員審查，但不能取代主管機關的正式核准。
+
+<Playground initial={`evacuation "辦公樓層 — 疏散圖" unit m
 compliance iso
 sheet a3 landscape
-room room "房間" at 0,0 size 6x4
-here in room at 2,2
-exit-final exit1 in room at 6,2 side east "出口"
-route primary here -> exit1`} height={460} />
+room office "開放式辦公室" at 0,0 size 6x5
+room lobby "電梯廳" below office size 6x2.4
+room stairA "樓梯 A" left-of lobby size 3x2.4
+room stairB "樓梯 B" right-of lobby size 3x2.4
+opening between office lobby at 50% width 1.6
+door between lobby stairA at 50% width 1.1
+door between lobby stairB at 50% width 1.1
+here in office at 3,2.5
+exit-final xA in stairA at 0,1.2 side west "安全出口"
+exit-final xB in stairB at 3,1.2 side east "安全出口"
+extinguisher f1 in lobby at 2,1.8 class "ABC"
+route primary here -> lobby -> stairB -> xB
+route secondary here -> lobby -> stairA -> xA`} height={620} />
 
 ---
 
-## 1. 張貼位置
+## 1. 從張貼位置開始
 
-每張圖必須有且只有一個 `here`。同一棟樓有多個張貼點時，保持平面與路線不變，只修改 `here` 那一行並分別 render。
+將 header 改為 `evacuation`（別名為 `escapeplan`），宣告目標 `sheet`，並在這份疏散圖實際張貼的位置加入且只加入一個 `here` 標記：
 
-## 2. 安全符號
+```
+evacuation "2 樓 — 疏散圖" unit m
+compliance iso
+sheet a3 landscape
+room office "辦公室" at 0,0 size 6x5
+here in office at 3,2.5
+exit-final x1 in office at 6,2.5 side east "安全出口"
+route primary here -> x1
+```
 
-符號畫在固定 24×24 grid 上，預設印刷尺寸為 8 mm。綠色表示安全與逃生，紅色表示消防設備。詞彙包括出口、集合點、滅火器、手動警報、急救、AED 與禁止標記。
+一棟建築可能需要張貼許多份疏散圖。幾何與疏散路線應保持一致，只修改 `here` 這一行，針對每個張貼點分別 render 一份。
+
+## 2. 安全標誌
+
+安全標誌使用固定的 24×24 繪圖網格，並採固定的列印尺寸（預設 8 mm），與 floorplan 比例尺無關。安全狀態標誌使用實心綠色 plate，消防標誌使用實心紅色 plate，pictogram 則以白色反白形狀呈現。Schematex 繪製原創幾何，不會嵌入或描摹 ISO、NFPA 的官方圖形。
+
+可依座標放置的標誌類型如下：
+
+- 出口與救援：`exit`、`exit-final`、`assembly`、`refuge`、`shelter`、`escape-ladder`、`rescue-window`、`emergency-door-push`、`emergency-door-slide`
+- 醫療與緊急協助：`first-aid`、`aed`、`stretcher`、`doctor`、`eyewash`、`safety-shower`、`emergency-phone`、`break-glass`
+- 消防設備：`extinguisher`、`hose-reel`、`fire-ladder`、`fire-equipment`、`call-point`、`fire-phone`、`riser`
+- 圖面與禁止：`here`、`not-an-exit`、`no-elevator`、`alarm-sounder`
+- 門的 overlay：`fire-door` 與 `smoke-door` 附著在既有 door，而不是放置於單一座標
+
+可以使用簡寫，也可以明確寫出 `safety`：
+
+```
+extinguisher ext1 in corridor at 1.2,0.3 side north class "ABC"
+safety first-aid aid1 in lobby at 4.8,1.8
+assembly muster outside at 14,10 "集合點 A"
+fire-door between corridor stairA rating "EI30"
+```
+
+房間座標是相對於該房間的座標。`outside at x,y` 使用整份 plan 的絕對座標。`side north|south|east|west` 會將標誌吸附至牆面；`hand left|right` 可覆寫自動選取的方向 variant。
 
 ## 3. 疏散路線
 
-`route primary here -> corridor -> stair -> exit1` 的相鄰房間必須由已宣告的 `door` 或 `opening` 連通。中間房間要明確寫出；engine 不會自行尋路。
+Route 是由作者明確編寫的 sequence，不是引擎推算出的 path：
 
-## 4. Compliance profile
+```
+route primary here -> corridor -> stairB -> exitB
+route secondary here -> corridor -> lobby -> stairA -> exitA
+route accessible here -> corridor -> refugeA
+route rescue fireEntry -> serviceCorridor -> riserRoom
+```
 
-`iso` 使用 ISO 23601/7010/3864；`nfpa` 使用 NFPA 170/NFPA 101；`uae` 強制英文 / 阿拉伯文雙語標籤。
+不同房間之間的每個 hop 都必須穿過已宣告的 `door` 或 `opening`。所有中間房間都要明確列出。Schematex 會以確定方式繪製穿過各個開口的正交線段，將轉角圓滑化，並每隔 2 m 放置一個背離 `here` 方向的 chevron。`secondary` 使用虛線，`accessible` 帶有輪椅標記，`rescue` 使用藍色。
 
-## 5. 列印比例尺
+Routes 必須終止於 `exit`、`exit-final` 或 `assembly`。兩條路線只有在通往不同的最終出口，而且房間 sequence 的結構也不同時，才算彼此獨立。
 
-宣告 sheet 與方向後，所有樓層 plate 共用計算出的常規比例尺，符號始終保持 8 mm。ISO/UAE 下比 1:250 更粗的比例尺會報 error。
+## 4. Compliance profiles
 
-## 6. 圖層與多樓層
+| Profile | 適用情境 | 主要差異 |
+| --- | --- | --- |
+| `iso`（預設） | DIN、BS 與國際 ISO 23601 疏散圖 | ISO 7010 標誌、比例尺不得粗於 1:250、標誌 ≥7 mm |
+| `nfpa` | 美國緊急疏散圖 | NFPA 170 variants、未提供兩條 routes 時回報 error、自動加入 `no-elevator` |
+| `uae` | UAE Civil Defence 送審圖 | 黃色目前位置標記、英文/阿拉伯文 labels、沿用 ISO 的比例尺下限 |
 
-一般家具、面積文字與尺寸標註自動隱藏；樓梯、電梯、北向、路線與安全符號保留。`floor N "標籤"` 產生多個 plate，共用 stair ID 用於驗證垂直對齊。
+在文件開頭附近選擇 profile：
+
+```
+compliance nfpa
+```
+
+Profile 只會改變 glyph variants 與驗證規則，不會改變房間幾何。
+
+## 5. 列印比例尺與 sheet 尺寸
+
+以 `landscape` 或 `portrait` 宣告 `sheet a4|a3|a2|letter|tabloid`。Schematex 會扣除 15 mm 邊界，讓最大的 floor plate 同時適配兩個可列印方向，再將比例尺分母向上取整為常用值（`1:50`、`1:100`、`1:200`、`1:250` 等）。
+
+安全標誌在紙面上始終維持 8 mm。比例尺會將這個固定紙面尺寸暫時換算回 plan-space footprint，以進行碰撞檢查；建築變大時，標誌不會跟著縮小。ISO 與 UAE 疏散圖的比例尺粗於 1:250 時會回報 error。
+
+每張 render 完成的 sheet 都會帶有類似以下的說明：
+
+```
+Scale 1:200 on A3 (landscape) · symbols 8.0 mm · ISO 23601 ✓
+```
+
+## 6. Layers 與多樓層疏散圖
+
+Evacuation mode 會保留房間、牆體、開口、門扇開啟弧、樓梯、電梯、柱、房間名稱、指北針、疏散路線、安全標誌、圖例與比例尺說明，並自動隱藏一般家具、面積文字和尺寸標註。只有特定家具確實有助於現場辨向時，才加入 `show furniture`。
+
+多樓層 syntax 繼承自 floorplan：
+
+```
+evacuation "建築疏散圖" unit m stack horizontal
+floor 0 "一樓"
+room lobby at 0,0 size 8x5
+furniture stairs S1 in lobby at 0.4,0.4
+
+floor 1 "二樓"
+room landing at 0,0 size 8x5
+furniture stairs S1 in landing at 0.4,0.4
+```
+
+所有 plates 共用一個比例尺。重複使用 `S1` 會將各層樓梯登記為同一座樓梯間：低樓層標為 UP，高樓層標為 DN；座標錯位超過 0.1 m 時會產生 warning。每個樓層仍會以獨立張貼的疏散圖進行驗證。
 
 ## 7. 強制圖例
 
-Tier M legend 永遠開啟，`legend: off` 是 parse error。
+圖例屬於 Tier M：它始終顯示，並列出圖中使用的所有編碼，依疏散路線、出口、消防設備、急救設施與結構元素分組。ISO profiles 會在 label 中包含安全標誌識別 code；NFPA 不顯示 ISO code。
 
-## 8. 驗證
+可以使用共用 legend directives 重新命名 labels 或 sections，但 `legend: off` 會產生 parse error，因為 ISO 23601 與 NFPA 170 都要求必須有圖例。
 
-engine 會檢查目前位置、出口、開口連續性、獨立路線、無路線房間、路線終點、符號碰撞、雙語、電梯禁用、圖例、顏色、比例尺與未知符號；每則訊息都帶標準出處。
+## 8. 驗證訊息
+
+引擎會在發布前完成以下所有檢查：
+
+1. 每個樓層都有一個 `here` 標記。
+2. 每個樓層都有出口。
+3. Route 的每次跨房間 hop 都穿過已宣告的開口。
+4. 兩條疏散路線在結構上彼此獨立（NFPA 回報 error；ISO/UAE 回報 warning）。
+5. 相連的房間出現在某條 route 上，或擁有自己的出口。
+6. Routes 終止於出口或集合點。
+7. 固定尺寸的安全標誌保持清楚可辨，且彼此不重疊。
+8. UAE labels 包含以 ` / ` 分隔的非空英文與阿拉伯文兩部分。
+9. 包含電梯的 NFPA/UAE 疏散圖會自動取得一個 `no-elevator` 標記。
+10. 圖例無法關閉。
+11. `monochrome` 會回報 error，但仍以語意化安全色彩 render，以便診斷。
+12. ISO/UAE 的列印比例尺不得粗於 1:250。
+13. 未知 sign kind 會列出有效名稱，並建議最接近的項目。
+
+每則 diagnostic 都會標明所依據的規範，讓作者知道應依 ISO 23601、NFPA 170/NFPA 101 或 UAE Civil Defence 指引進行修正。
+
+## 9. 語法
+
+```text
+plan       ::= ("evacuation"|"escapeplan") string? ("unit" ("m"|"ft"))? statement*
+statement  ::= floorplan-statement | compliance | sheet | safety | route | rated-door | legend
+compliance ::= "compliance" ("iso"|"nfpa"|"uae")
+sheet      ::= "sheet" ("a4"|"a3"|"a2"|"letter"|"tabloid") ("landscape"|"portrait")?
+safety     ::= "safety"? kind id? ("in" room "at" coord | "outside" "at" coord)
+               ("side" wallside)? ("hand" ("left"|"right"))? ("rotate" num)?
+               ("class" string)? string?
+route      ::= "route" ("primary"|"secondary"|"accessible"|"rescue")?
+               anchor ("->" anchor)+ string?
+rated-door ::= ("fire-door"|"smoke-door")
+               ("between" room room | room wallside ("at" pct)?) ("rating" string)?
+```
+
+## 相關範例
+
+- [包含兩條疏散路線的辦公樓層](/examples#evacuation)
+- [採用 NFPA profile 的美國倉庫](/examples#evacuation)
+- [英文/阿拉伯文雙語診所疏散圖](/examples#evacuation)

--- a/website/content/docs/floorplan.de.mdx
+++ b/website/content/docs/floorplan.de.mdx
@@ -208,16 +208,23 @@ Kommentare laufen von `#` bis zum Zeilenende. CJK-Anführungszeichen (`""`) werd
 - [27-Schreibtisch-Klassenzimmer](/examples#floorplan) — `grid … count`-Kürzung, `unit ft`
 - [Hochzeitsempfang für 120 Personen](/examples#floorplan) — automatisch bestuhlte Bankettrundes, Tanzfläche
 
+## Interaktive Bearbeitung
+
+Möbel und elektrische Einbauten lassen sich unabhängig in Raumkoordinaten verschieben. Ein einfacher Raum zeigt Resize-Handles an der Ost- und Südseite sowie an der Ecke; sie schreiben die ursprünglichen Abmessungen neu. Der Raumkörper selbst lässt sich nicht ziehen, damit die Möbelauswahl eindeutig bleibt. Öffnungen in gemeinsamen Wänden werden weiterhin anhand der Topologie validiert.
+
 ## Mehrgeschossige Plansätze
 
-`floor N "Bezeichnung"` teilt eine Quelle in gerahmte Geschossplatten mit gemeinsamem Maßstab. `stack horizontal|vertical` bestimmt die Anordnung. Eine optionale Möbel-ID wie `S1` registriert denselben Treppenlauf: unten UP, oben DN; mehr als 0,1 m Versatz warnt. Raum-, Tür-, Möbel- und Array-Referenzen dürfen keine Geschossgrenze überschreiten.
+Mit `floor N "Bezeichnung"` wird eine Quelle in gerahmte Geschossplatten aufgeteilt. Alle plates verwenden denselben Zeichnungsmaßstab; `stack horizontal|vertical` bestimmt die Anordnung auf dem sheet.
 
 ```
 floorplan "Zweistöckiges Haus" unit m stack horizontal
 floor 0 "Erdgeschoss"
-room flur at 0,0 size 6x4
-furniture stairs S1 in flur at 4,0.4
+room hall at 0,0 size 6x4
+furniture stairs S1 in hall at 4,0.4
+
 floor 1 "Obergeschoss"
-room diele at 0,0 size 6x4
-furniture stairs S1 in diele at 4,0.4
+room landing at 0,0 size 6x4
+furniture stairs S1 in landing at 4,0.4
 ```
+
+Die optionale furniture-Instanz-ID (`S1`) registriert denselben Treppenlauf über mehrere Geschosse. Das untere Vorkommen wird zu UP, die oberen zu DN; ein Versatz von mehr als 0,1 m erzeugt eine Warnung. Raumreferenzen, Türen, furniture und arrays dürfen keine Geschossabschnitte überschreiten.

--- a/website/content/docs/floorplan.es.mdx
+++ b/website/content/docs/floorplan.es.mdx
@@ -208,16 +208,23 @@ Los comentarios van desde `#` hasta el final de la línea. Las comillas CJK (`""
 - [Aula de 27 escritorios](/examples#floorplan) — truncamiento `grid … count`, `unit ft`
 - [Recepción de boda para 120](/examples#floorplan) — mesas redondas de banquete con asiento automático, pista de baile
 
+## Edición interactiva
+
+El mobiliario y los elementos eléctricos se mueven de forma independiente en las coordenadas de la sala. Una sala sencilla muestra resize handles en los lados este y sur y en la esquina; estos reescriben las dimensiones originales. El cuerpo de la sala no se arrastra, de modo que la selección del mobiliario no resulte ambigua. Las aberturas en paredes compartidas siguen sujetas a validación topológica.
+
 ## Conjuntos de varias plantas
 
-`floor N "Etiqueta"` divide una fuente en placas con escala compartida; `stack horizontal|vertical` elige la composición. Un id opcional como `S1` registra la misma escalera: UP abajo, DN arriba, con aviso si se desplaza más de 0,1 m. Las referencias no pueden cruzar plantas.
+Use `floor N "Etiqueta"` para dividir una fuente en floor plates enmarcadas. Todas las plates comparten una escala de dibujo; `stack horizontal|vertical` controla su disposición en el sheet.
 
 ```
-floorplan "Casa de dos plantas" unit m
+floorplan "Casa de dos plantas" unit m stack horizontal
 floor 0 "Planta baja"
 room hall at 0,0 size 6x4
 furniture stairs S1 in hall at 4,0.4
+
 floor 1 "Primera planta"
 room landing at 0,0 size 6x4
 furniture stairs S1 in landing at 4,0.4
 ```
+
+El id opcional de la instancia de furniture (`S1`) registra el mismo tramo de escalera entre plantas. La aparición inferior pasa a ser UP y las superiores, DN; un desplazamiento mayor de 0,1 m genera una advertencia. Las referencias de salas, puertas, furniture y arrays no pueden cruzar secciones de planta.

--- a/website/content/docs/floorplan.fr.mdx
+++ b/website/content/docs/floorplan.fr.mdx
@@ -208,16 +208,23 @@ Les commentaires vont de `#` jusqu'à la fin de la ligne. Les guillemets CJK (`"
 - [Salle de classe de 27 bureaux](/examples#floorplan) — troncature `grid … count`, `unit ft`
 - [Réception de mariage pour 120 personnes](/examples#floorplan) — banquettes rondes avec placement automatique, piste de danse
 
+## Édition interactive
+
+Le mobilier et les équipements électriques se déplacent indépendamment dans les coordonnées de la pièce. Une pièce simple présente des resize handles à l’est, au sud et dans l’angle ; ils réécrivent ses dimensions natives. Le corps de la pièce ne se déplace pas par glisser-déposer, afin que la sélection du mobilier reste sans ambiguïté. Les ouvertures dans les murs communs restent soumises à la validation topologique.
+
 ## Jeux de plans multi-étages
 
-`floor N "Libellé"` divise une source en plaques partageant la même échelle; `stack horizontal|vertical` règle la composition. Un identifiant facultatif comme `S1` relie le même escalier: UP en bas, DN en haut, avec avertissement au-delà de 0,1 m de décalage. Les références ne traversent pas les étages.
+Utilisez `floor N "Libellé"` pour diviser une source en floor plates encadrées. Toutes les plates partagent la même échelle de dessin ; `stack horizontal|vertical` règle leur disposition sur le sheet.
 
 ```
-floorplan "Maison à deux étages" unit m
+floorplan "Maison à deux étages" unit m stack horizontal
 floor 0 "Rez-de-chaussée"
 room hall at 0,0 size 6x4
 furniture stairs S1 in hall at 4,0.4
+
 floor 1 "Étage"
-room palier at 0,0 size 6x4
-furniture stairs S1 in palier at 4,0.4
+room landing at 0,0 size 6x4
+furniture stairs S1 in landing at 4,0.4
 ```
+
+L’id facultatif de l’instance de furniture (`S1`) enregistre la même volée d’escalier entre les étages. L’occurrence inférieure devient UP et les occurrences supérieures DN ; un décalage supérieur à 0,1 m déclenche un avertissement. Les références de pièces, les portes, le furniture et les arrays ne peuvent pas franchir une section d’étage.

--- a/website/content/docs/floorplan.ja.mdx
+++ b/website/content/docs/floorplan.ja.mdx
@@ -208,16 +208,23 @@ coord     ::= num "," num          dims ::= num "x" num          pct ::= num "%"
 - [27台のデスク教室](/examples#floorplan) — `grid … count` 切り捨て、`unit ft`
 - [120名のウェディングレセプション](/examples#floorplan) — 自動着席の宴会ラウンドテーブル、ダンスフロア
 
+## Interactive editing
+
+家具と電気器具は、room 座標内で個別に移動できます。単純な room には東側、南側、隅に resize handles が表示され、元の寸法を書き換えます。Room 本体はドラッグできないため、家具を迷わず選択できます。共有壁の openings には引き続き topology validation が適用されます。
+
 ## 複数階の plan set
 
-`floor N "Label"` で一つの source を同一 scale の floor plate に分割し、`stack horizontal|vertical` で配置を選びます。`S1` のような任意の furniture ID は同じ階段を登録し、下階は UP、上階は DN になります。0.1 m を超えるずれは warning で、参照は階をまたげません。
+`floor N "Label"` を使うと、一つの source を枠付きの floor plates に分割できます。すべての plates は同じ drawing scale を共有し、`stack horizontal|vertical` で sheet 上の配置を指定します。
 
 ```
-floorplan "Two-Storey House" unit m
-floor 0 "Ground Floor"
+floorplan "2階建て住宅" unit m stack horizontal
+floor 0 "1階"
 room hall at 0,0 size 6x4
 furniture stairs S1 in hall at 4,0.4
-floor 1 "First Floor"
+
+floor 1 "2階"
 room landing at 0,0 size 6x4
 furniture stairs S1 in landing at 4,0.4
 ```
+
+任意の furniture instance ID（`S1`）は、複数階にある同じ階段を登録します。下階の表示は UP、上階の表示は DN になり、ずれが 0.1 m を超えると warning が出ます。Room references、doors、furniture、arrays は floor sections をまたげません。

--- a/website/content/docs/floorplan.ko.mdx
+++ b/website/content/docs/floorplan.ko.mdx
@@ -208,16 +208,23 @@ coord     ::= num "," num          dims ::= num "x" num          pct ::= num "%"
 - [27-desk classroom](/examples#floorplan) — `grid … count` 잘라내기, `unit ft`
 - [Wedding reception for 120](/examples#floorplan) — 자동 좌석 배치된 연회 원형 테이블, 댄스 플로어
 
+## Interactive editing
+
+가구와 전기 설비는 room 좌표 안에서 각각 이동할 수 있습니다. 단순한 room은 동쪽, 남쪽, 모서리에 resize handles를 표시하며, 이 handles가 원래 치수를 다시 씁니다. Room 본체는 드래그되지 않으므로 가구를 명확하게 선택할 수 있습니다. 공유 벽의 openings에는 계속 topology validation이 적용됩니다.
+
 ## 여러 층 plan set
 
-`floor N "Label"`로 하나의 source를 같은 scale의 floor plate로 나누고 `stack horizontal|vertical`로 배치를 정합니다. `S1` 같은 선택 furniture ID는 같은 계단을 등록해 아래층은 UP, 위층은 DN이 됩니다. 0.1 m보다 큰 오프셋은 warning이며 참조는 층을 넘을 수 없습니다.
+`floor N "Label"`을 사용하면 하나의 source를 테두리가 있는 floor plates로 나눌 수 있습니다. 모든 plates는 같은 drawing scale을 공유하며 `stack horizontal|vertical`로 sheet 위의 배치를 지정합니다.
 
 ```
-floorplan "Two-Storey House" unit m
-floor 0 "Ground Floor"
+floorplan "2층 주택" unit m stack horizontal
+floor 0 "1층"
 room hall at 0,0 size 6x4
 furniture stairs S1 in hall at 4,0.4
-floor 1 "First Floor"
+
+floor 1 "2층"
 room landing at 0,0 size 6x4
 furniture stairs S1 in landing at 4,0.4
 ```
+
+선택 사항인 furniture instance ID(`S1`)는 여러 층의 같은 계단을 등록합니다. 아래쪽 항목은 UP, 위쪽 항목은 DN이 되며 0.1 m보다 큰 오프셋은 warning을 발생시킵니다. Room references, doors, furniture, arrays는 floor sections를 넘어갈 수 없습니다.

--- a/website/content/docs/floorplan.pt-BR.mdx
+++ b/website/content/docs/floorplan.pt-BR.mdx
@@ -208,16 +208,23 @@ Comentários vão de `#` até o final da linha. Aspas CJK (`""`) são aceitas co
 - [Sala de aula com 27 mesas](/examples#floorplan) — truncamento `grid … count`, `unit ft`
 - [Recepção de casamento para 120 pessoas](/examples#floorplan) — mesas de banquete com assentos automáticos, pista de dança
 
+## Edição interativa
+
+Móveis e elementos elétricos se movem de forma independente nas coordenadas do ambiente. Um ambiente simples apresenta resize handles a leste, ao sul e no canto, que reescrevem as dimensões originais. O corpo do ambiente não pode ser arrastado, mantendo inequívoca a seleção dos móveis. As aberturas em paredes compartilhadas continuam sujeitas à validação topológica.
+
 ## Conjuntos de vários pavimentos
 
-`floor N "Rótulo"` divide uma fonte em placas com escala comum; `stack horizontal|vertical` escolhe a composição. Um id opcional como `S1` registra a mesma escada: UP embaixo, DN em cima, com aviso acima de 0,1 m de deslocamento. Referências não podem atravessar pavimentos.
+Use `floor N "Rótulo"` para dividir uma fonte em floor plates emolduradas. Todas as plates compartilham uma escala de desenho; `stack horizontal|vertical` controla a disposição no sheet.
 
 ```
-floorplan "Casa de dois pavimentos" unit m
+floorplan "Casa de dois pavimentos" unit m stack horizontal
 floor 0 "Térreo"
 room hall at 0,0 size 6x4
 furniture stairs S1 in hall at 4,0.4
+
 floor 1 "Pavimento superior"
 room landing at 0,0 size 6x4
 furniture stairs S1 in landing at 4,0.4
 ```
+
+O id opcional da instância de furniture (`S1`) registra o mesmo lance de escada entre pavimentos. A ocorrência inferior se torna UP e as superiores, DN; um deslocamento maior que 0,1 m gera um aviso. Referências de ambientes, portas, furniture e arrays não podem atravessar seções de pavimento.

--- a/website/content/docs/floorplan.zh-Hans.mdx
+++ b/website/content/docs/floorplan.zh-Hans.mdx
@@ -208,16 +208,23 @@ coord     ::= num "," num          dims ::= num "x" num          pct ::= num "%"
 - [27 张桌子的教室](/examples#floorplan) — `grid … count` 截断、`unit ft`
 - [120 人婚宴](/examples#floorplan) — 自动排座宴会圆桌、舞池
 
+## 交互编辑
+
+家具和电气设备可以在房间坐标内独立移动。简单房间会显示东侧、南侧和转角 resize handles，用来重写原始尺寸；房间主体本身不能拖动，从而避免家具选择产生歧义。共享墙上的 openings 仍会接受 topology validation。
+
 ## 多楼层平面图
 
-用 `floor N "标签"` 把同一份 source 分成共用比例尺的楼层 plate；`stack horizontal|vertical` 控制拼版方向。`S1` 这样的可选 furniture ID 会注册同一段楼梯：低层自动标 UP，高层标 DN，错位超过 0.1 m 会 warning。房间、门、家具和 array 引用不能跨层。
+用 `floor N "标签"` 把同一份 source 分成带边框的楼层 plates。所有 plates 共用一个绘图比例尺；`stack horizontal|vertical` 控制它们在 sheet 上的拼版方向。
 
 ```
-floorplan "两层住宅" unit m
+floorplan "两层住宅" unit m stack horizontal
 floor 0 "一层"
 room hall at 0,0 size 6x4
 furniture stairs S1 in hall at 4,0.4
+
 floor 1 "二层"
 room landing at 0,0 size 6x4
 furniture stairs S1 in landing at 4,0.4
 ```
+
+可选的 furniture instance ID（`S1`）会注册跨楼层的同一段楼梯。低层自动标为 UP，高层标为 DN，错位超过 0.1 m 会产生 warning。房间引用、门、furniture 和 arrays 不能跨越 floor sections。

--- a/website/content/docs/floorplan.zh-Hant.mdx
+++ b/website/content/docs/floorplan.zh-Hant.mdx
@@ -208,16 +208,23 @@ coord     ::= num "," num          dims ::= num "x" num          pct ::= num "%"
 - [27 張桌子的教室](/examples#floorplan) — `grid … count` 截斷，`unit ft`
 - [120 人婚宴](/examples#floorplan) — 自動座位宴會圓桌，舞池
 
+## 互動編輯
+
+家具與電氣設備可在房間座標內獨立移動。簡單房間會顯示東側、南側與轉角 resize handles，用來改寫原始尺寸；房間本體無法拖動，因此選取家具時不會產生歧義。共用牆上的 openings 仍會接受 topology validation。
+
 ## 多樓層平面圖
 
-用 `floor N "標籤"` 把同一份 source 分成共用比例尺的樓層 plate；`stack horizontal|vertical` 控制排版方向。`S1` 這類可選 furniture ID 會登記同一段樓梯：低層自動標 UP，高層標 DN，錯位超過 0.1 m 會 warning。房間、門、家具與 array 參照不能跨層。
+用 `floor N "標籤"` 把同一份 source 分成帶框線的樓層 plates。所有 plates 共用一個繪圖比例尺；`stack horizontal|vertical` 控制它們在 sheet 上的排版方向。
 
 ```
-floorplan "兩層住宅" unit m
+floorplan "兩層住宅" unit m stack horizontal
 floor 0 "一樓"
 room hall at 0,0 size 6x4
 furniture stairs S1 in hall at 4,0.4
+
 floor 1 "二樓"
 room landing at 0,0 size 6x4
 furniture stairs S1 in landing at 4,0.4
 ```
+
+可選的 furniture instance ID（`S1`）會登記跨樓層的同一段樓梯。低樓層自動標為 UP，高樓層標為 DN，錯位超過 0.1 m 時會產生 warning。房間參照、門、furniture 與 arrays 不能跨越 floor sections。


### PR DESCRIPTION
## Summary
- expand all eight non-English evacuation docs to the full English structure, including every table, DSL block, validation rule, grammar section, and related examples
- keep DSL keywords and identifiers in English while localizing quoted labels because those labels render on the posted safety plan
- restore floorplan locale parity for interactive editing and complete the multi-floor examples and cross-floor constraints

## Validation
- `node scripts/check-doc-dsls.mjs` (passes; reports only the nine pre-existing Prisma diagnostics)
- `npm run typecheck`
- `npm run build`
- evacuation parity: every locale is 177 lines / 5 table rows / 14 code fences / 11 sections
- floorplan parity: every locale is 230 lines / 11 table rows / 18 code fences / 12 sections