### PR TITLE
fix(prisma): accept a wholesale-indented block → 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.3] — 2026-07-27
+
+### Fixed — `prisma` rejected any wholesale-indented block, and said the wrong thing about why
+
+The PRISMA parser is indentation-significant, and it measured indent levels from the absolute left margin. A block indented as a whole — pasted out of a markdown fence, lifted from a JSX template literal, or emitted by a model that indents its entire answer — therefore failed on its very first line, with a message that pointed at the wrong thing.
+
+- **Common leading margin is stripped before levels are measured.** Only relative indentation is meaningful, so a uniformly indented block now parses identically to the flat form at any margin width, including odd ones that are not multiples of the two-space level. Relative nesting is untouched.
+- **The error names the real defect.** Indentation and keyword are now separate checks. The failure previously reported `first non-blank line must be "prisma", got "prisma"` — self-contradictory, because the message printed the trimmed text while the indent test was what actually failed — sending readers hunting for a typo that was not there. A header sitting deeper than its body now says exactly that.
+- **`check-doc-dsls` validates the string the site renders.** The script read `initial={\`…\`}` straight out of the MDX source, while the MDX compiler hands the component that block with its common margin already removed. Nine `prisma` docs were consequently reported as broken for a condition that never reached a reader; the script now dedents the same way the compiler does.
+
+---
+
 ## [1.0.2] — 2026-07-26
 
 ### Added — multi-floor plans and standards-aware evacuation diagrams

--- a/docs/reference/28-PRISMA-STANDARD.md
+++ b/docs/reference/28-PRISMA-STANDARD.md
@@ -448,6 +448,7 @@ When a reason list grows beyond what a side box can hold at default width, the r
 - Reason and source names containing spaces or punctuation can be quoted: `"wrong study design"=70`.
 - Trailing commas allowed.
 - Unknown keys inside a stage block are a parse error (not warning) — keeps stages well-defined.
+- **A common leading margin is stripped before indent levels are measured.** Only *relative* indentation is meaningful, so a block indented wholesale — pasted from a markdown fence, a JSX template literal, or an LLM reply that indents its whole answer — parses identically to the flat form, at any margin width including odd ones. The `prisma` header must still be the least-indented line in the block; a header sitting deeper than the body is a parse error naming the indentation, not the keyword.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "schematex",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schematex",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 51 industry-standard diagrams from a text DSL, with open-source React editing, AI tools, and MCP. Pure SVG, zero runtime dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/check-doc-dsls.mjs
+++ b/scripts/check-doc-dsls.mjs
@@ -9,6 +9,20 @@ let total = 0;
 let failed = 0;
 const failures = [];
 
+/**
+ * Reproduce what the MDX compiler hands the component. A `<Playground>` written
+ * with its DSL indented for readability reaches React with the common leading
+ * margin already stripped and relative nesting intact — so reading the raw
+ * source and rendering it verbatim checks a string the site never renders.
+ */
+function dedent(body) {
+  const lines = body.split('\n');
+  const widths = lines.filter((l) => l.trim()).map((l) => l.length - l.trimStart().length);
+  if (!widths.length) return body;
+  const base = Math.min(...widths);
+  return base === 0 ? body : lines.map((l) => (l.trim() ? l.slice(base) : l)).join('\n');
+}
+
 for (const file of files) {
   const src = readFileSync(join(DOCS, file), 'utf8');
   // Match <Playground ... initial={`...`} ...>  — capture the template literal body.
@@ -18,7 +32,7 @@ for (const file of files) {
   while ((m = re.exec(src)) !== null) {
     idx++;
     total++;
-    const dsl = m[1];
+    const dsl = dedent(m[1]);
     const firstLine = dsl.trim().split('\n')[0];
     try {
       const svg = render(dsl);

--- a/src/diagrams/prisma/parser.ts
+++ b/src/diagrams/prisma/parser.ts
@@ -38,21 +38,32 @@ interface RawLine {
 }
 
 function preprocess(src: string): RawLine[] {
-  const out: RawLine[] = [];
   const rows = src.split(/\r?\n/);
+  const kept: { spaces: number; text: string; line: number }[] = [];
   for (let i = 0; i < rows.length; i++) {
     const raw = rows[i] ?? "";
     // Strip end-of-line comments but preserve `#` inside quotes.
     const stripped = stripComment(raw);
     if (!stripped.trim()) continue;
-    const indentSpaces = stripped.length - stripped.replace(/^\s+/, "").length;
-    out.push({
-      indent: Math.floor(indentSpaces / 2),
+    kept.push({
+      spaces: stripped.length - stripped.replace(/^\s+/, "").length,
       text: stripped.trim(),
       line: i + 1,
     });
   }
-  return out;
+
+  // Only *relative* indentation carries meaning here, so strip the common
+  // leading margin before measuring levels. Without this, a block pasted from
+  // an indented context — a markdown fence, a JSX template literal, an LLM
+  // reply that indents its whole answer — fails on the very first line.
+  const base = kept.reduce((min, l) => Math.min(min, l.spaces), Infinity);
+  const offset = Number.isFinite(base) ? base : 0;
+
+  return kept.map((l) => ({
+    indent: Math.floor((l.spaces - offset) / 2),
+    text: l.text,
+    line: l.line,
+  }));
 }
 
 function stripComment(raw: string): string {
@@ -364,8 +375,18 @@ export function parsePrisma(src: string): PrismaAST {
   if (lines.length === 0) throw new PrismaParseError("empty input");
 
   const header = lines.shift()!;
-  if (header.indent !== 0 || header.text.toLowerCase() !== "prisma") {
+  if (header.text.toLowerCase() !== "prisma") {
     throw new PrismaParseError(`first non-blank line must be "prisma", got "${header.text}"`, header.line);
+  }
+  // Reachable only when the header sits *deeper* than some later line — a
+  // uniform margin is already removed by preprocess(). Reported separately so
+  // the message names the real defect instead of echoing a correct-looking
+  // header back at the caller.
+  if (header.indent !== 0) {
+    throw new PrismaParseError(
+      `the "prisma" header is indented — it must be the least-indented line in the block`,
+      header.line,
+    );
   }
 
   // Meta lines: indent 0, "key: value", before any stage block.

--- a/tests/prisma/parser.test.ts
+++ b/tests/prisma/parser.test.ts
@@ -146,3 +146,49 @@ describe("prisma parser", () => {
     expect(ast.previousStudies?.n).toBe(19);
   });
 });
+
+/** Indent the whole block by `n` spaces, leaving blank lines blank. */
+function shift(dsl: string, n: number): string {
+  const pad = " ".repeat(n);
+  return dsl
+    .split("\n")
+    .map((l) => (l.trim() ? pad + l : l))
+    .join("\n");
+}
+
+describe("prisma parser — common leading indentation", () => {
+  it("parses a block indented by 2 spaces exactly like the flat form", () => {
+    // The shape docs and LLM replies actually produce: the whole DSL sits
+    // inside an indented context (a JSX template literal, a markdown fence).
+    expect(parsePrisma(shift(MINIMAL_2020_SINGLE, 2))).toEqual(parsePrisma(MINIMAL_2020_SINGLE));
+  });
+
+  it("parses a block indented by an odd number of spaces", () => {
+    // 3 is not a multiple of the 2-space level width — the margin must be
+    // removed before levels are measured, not floor-divided along with them.
+    expect(parsePrisma(shift(MINIMAL_2020_SINGLE, 3))).toEqual(parsePrisma(MINIMAL_2020_SINGLE));
+  });
+
+  it("preserves relative nesting under a deep common margin", () => {
+    const ast = parsePrisma(shift(MINIMAL_2020_SINGLE, 8));
+    expect(ast.identification.n).toBe(1418);
+    expect(ast.identification.sources?.length).toBe(4);
+    expect(ast.screening.excluded.reasons?.length).toBe(2);
+    expect(ast.warnings).toEqual([]);
+  });
+
+  it("keeps the dual-column form intact when indented", () => {
+    expect(parsePrisma(shift(DUAL, 2))).toEqual(parsePrisma(DUAL));
+  });
+
+  it("rejects a header indented deeper than the body, and names the real defect", () => {
+    const dsl = "  prisma\n" + MINIMAL_2020_SINGLE.replace(/^\s*\nprisma\n/, "");
+    expect(() => parsePrisma(dsl)).toThrow(PrismaParseError);
+    expect(() => parsePrisma(dsl)).toThrow(/header is indented/);
+  });
+
+  it("still reports a wrong header keyword as a wrong keyword", () => {
+    const dsl = MINIMAL_2020_SINGLE.replace("prisma\n", "prizma\n");
+    expect(() => parsePrisma(dsl)).toThrow(/first non-blank line must be "prisma", got "prizma"/);
+  });
+});


### PR DESCRIPTION
## What

`prisma` is one of the few indentation-significant DSLs, and it measured indent levels from the absolute left margin. A block indented **as a whole** therefore failed on its very first line:

```
  prisma
  mode: 2020-single
  identification:
    databases:
      n: 1418
```

→ `Line 2: first non-blank line must be "prisma", got "prisma"`

That is the shape a DSL arrives in when it is pasted out of a markdown fence, lifted from a JSX template literal, or emitted by a model that indents its whole answer — the "Made for AI" path.

## Changes

**1. Common leading margin is stripped before levels are measured** (`src/diagrams/prisma/parser.ts`).

Only *relative* indentation is meaningful. `preprocess()` now finds the minimum indent across non-blank lines and subtracts it, so any margin width parses identically to the flat form — including odd widths that are not multiples of the two-space level. Relative nesting is untouched.

**2. The error names the real defect.**

The old message printed the *trimmed* header text while the *indent* test was what failed, producing the self-contradictory `must be "prisma", got "prisma"` and sending readers hunting for a typo that was not there. Indentation and keyword are now separate checks with separate messages. A header sitting deeper than its body now says so.

**3. `check-doc-dsls` validates the string the site renders** (`scripts/check-doc-dsls.mjs`).

The script read `initial={\`…\`}` straight out of the MDX source and rendered it verbatim. The MDX compiler hands the component that block with its common margin **already stripped** — verified against the live React prop: React receives `"\nprisma\nmode: …"` with indents `0,2,4`, not the raw `2,4,6`. So the script was checking a string the site never renders, and reported nine `prisma` docs as broken for a condition no reader ever hit. It now dedents the same way the compiler does; its output is byte-identical to the observed React prop.

**No website content changed** — the docs pages were never broken, and touching nine translated files for a runtime no-op would have been churn.

## Tests

Six cases in `tests/prisma/parser.test.ts`. Five fail without the parser change, verified by reverting it:

| case | asserts |
|---|---|
| 2-space uniform indent | AST deep-equals the flat form |
| 3-space (odd) indent | margin is removed, not floor-divided with the levels |
| 8-space deep margin | relative nesting, source list, and zero-warning arithmetic survive |
| dual-column form indented | AST deep-equals the flat form |
| header deeper than body | still rejected, message names the indentation |
| `prizma` typo | still reported as a wrong keyword — regression guard |

## Gate

`typecheck` · `test` 178 files / 2298 tests · `lint` 0 errors · `build` · `gallery:check` exit 0 · `check-doc-dsls` **0 failures across 1,882 blocks** (was 9)

Docs: `docs/reference/28-PRISMA-STANDARD.md` §6.7 Parser tolerances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)