### PR TITLE
fix: make generated DSL parsing fail-soft

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,5 +1,6 @@
 import type { DiagramPlugin, DiagramType, RenderConfig, SceneItem, SourceRange } from "./types";
 import {
+  findArtifactWrapperRanges,
   parseFrontmatter,
   stripLineComment,
   UNIVERSAL_COMMENT_MARKERS,
@@ -237,24 +238,11 @@ function textLines(source: string): TextLine[] {
  * appended title are left alone — the frontmatter is silently dropped rather
  * than producing a misleading parse error.
  */
-/**
- * Strip a Markdown code fence wrapping the whole input. LLMs very frequently
- * wrap their diagram output in ```` ```mermaid … ``` ```` / ```` ``` … ``` ````
- * fences; left in place the first line (` ```mermaid `) is treated as the
- * diagram header and the entire diagram fails to detect/parse. We remove a
- * leading fence line and a trailing fence line independently (so a truncated
- * artifact with only an opening fence is still recovered). A bare ```` ``` ````
- * line is never valid diagram syntax, so this is safe; inputs with no fence are
- * returned untouched.
- */
-function stripCodeFences(input: MappedText): MappedText {
+/** Blank globally invalid LLM wrappers while preserving source offsets. */
+function blankArtifactWrappers(input: MappedText): MappedText {
   let result = input;
-  const opening = /^\uFEFF?[ \t]*```[A-Za-z0-9_-]*[ \t]*(?:\r?\n|$)/.exec(result.text);
-  if (opening) result = blankMapped(result, 0, opening[0].length);
-  const closing = /(?:^|\r?\n)[ \t]*```[ \t]*$/.exec(result.text);
-  if (closing) {
-    const fenceAt = closing.index + (closing[0].startsWith("\n") ? 1 : closing[0].startsWith("\r\n") ? 2 : 0);
-    result = blankMapped(result, fenceAt, result.text.length);
+  for (const range of findArtifactWrapperRanges(input.text)) {
+    result = blankMapped(result, range.start, range.end);
   }
   return result;
 }
@@ -415,7 +403,7 @@ function appendFrontmatterTitle(
 }
 
 function preprocess(source: string): PreparedInput {
-  let mapped = stripCodeFences(originalMappedText(source));
+  let mapped = blankArtifactWrappers(originalMappedText(source));
   const frontmatter = blankFrontmatter(mapped);
   const locator = createSourceLocator(source);
   const frontmatterTitleRange = frontmatter.titleRange

--- a/src/core/dsl-preprocess.ts
+++ b/src/core/dsl-preprocess.ts
@@ -1,10 +1,15 @@
 /**
  * DSL preprocessing shared across all diagram parsers.
  *
- * Two cross-cutting Mermaid-compat features are normalized here so each
+ * Three cross-cutting input features are normalized here so each
  * per-diagram parser sees a consistent surface:
  *
- *   1. **Frontmatter** — Mermaid allows a YAML-style block at the top of
+ *   1. **LLM wrappers** — Markdown fences, leaked `<artifact>` tags, and
+ *      model tool-call framing are never diagram syntax. They are removed
+ *      before detection so every parser and every public entry point inherits
+ *      the same recovery behavior.
+ *
+ *   2. **Frontmatter** — Mermaid allows a YAML-style block at the top of
  *      the input:
  *
  *          ---
@@ -18,14 +23,149 @@
  *      (`flowchart TD "..."`, `genogram "..."`) can merge the frontmatter
  *      title in if no inline one was provided.
  *
- *   2. **Comments** — different parsers historically supported different
+ *   3. **Comments** — different parsers historically supported different
  *      comment markers (`#`, `//`, Mermaid's `%%`). {@link stripLineComment}
  *      strips all three, respecting double-quoted regions so URLs with `//`
  *      and CSS-style values containing `#` don't get truncated.
  *
- * Both helpers are intentionally narrow: they only do what every parser
+ * These helpers are intentionally narrow: they only do what every parser
  * needs. Diagram-specific lexing stays in each parser.
  */
+
+export interface DslRemovalRange {
+  start: number;
+  end: number;
+}
+
+const ANTHROPIC_CONTROL_TAG =
+  /<\/?(?:antml:)?(?:function_calls|invoke|parameter)\b[^>]*>/gi;
+const DEEPSEEK_CONTROL_TAG = /<[^<>]*｜[^<>]*>/g;
+const SCALAR_PARAMETER_LINE =
+  /^[ \t]*<(?:antml:)?parameter\b[^>]*>[ \t]*(?:true|false|null|undefined|-?\d+(?:\.\d+)?|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')[ \t]*<\/(?:antml:)?parameter>[ \t]*(?:\r?\n|$)/gim;
+
+function blankRange(text: string, start: number, end: number): string {
+  return (
+    text.slice(0, start) +
+    text.slice(start, end).replace(/[^\r\n]/g, " ") +
+    text.slice(end)
+  );
+}
+
+function mergeRemovalRanges(ranges: DslRemovalRange[]): DslRemovalRange[] {
+  const sorted = [...ranges].sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: DslRemovalRange[] = [];
+  for (const range of sorted) {
+    const previous = merged[merged.length - 1];
+    if (!previous || range.start > previous.end) {
+      merged.push({ ...range });
+      continue;
+    }
+    previous.end = Math.max(previous.end, range.end);
+  }
+  return merged;
+}
+
+function collectMatches(
+  text: string,
+  pattern: RegExp,
+  ranges: DslRemovalRange[]
+): string {
+  let result = text;
+  pattern.lastIndex = 0;
+  for (const match of text.matchAll(pattern)) {
+    const start = match.index;
+    if (start === undefined || match[0].length === 0) continue;
+    const end = start + match[0].length;
+    ranges.push({ start, end });
+    result = blankRange(result, start, end);
+  }
+  return result;
+}
+
+/**
+ * Locate wrappers that can never be valid Schematex DSL.
+ *
+ * The returned ranges refer to the original UTF-16 input. The core API blanks
+ * them instead of deleting them so diagnostics and editing source ranges still
+ * point at the authored text. {@link stripArtifactWrappers} uses the same
+ * ranges for callers that want the compact, cleaned string.
+ */
+export function findArtifactWrapperRanges(text: string): DslRemovalRange[] {
+  if (!text) return [];
+
+  const ranges: DslRemovalRange[] = [];
+  let working = text;
+
+  // Markdown fence around the whole artifact. Blank it first so a nested
+  // <artifact> opener becomes the first significant token for the next pass.
+  const openingFence =
+    /^\uFEFF?\s*```[A-Za-z0-9_-]*[ \t]*(?:\r?\n|$)/.exec(working);
+  if (openingFence) {
+    ranges.push({ start: 0, end: openingFence[0].length });
+    working = blankRange(working, 0, openingFence[0].length);
+  }
+  const closingFence = /(?:^|\r?\n)[ \t]*```[ \t]*$/.exec(working);
+  if (closingFence) {
+    const newlineLength = closingFence[0].startsWith("\r\n")
+      ? 2
+      : closingFence[0].startsWith("\n")
+        ? 1
+        : 0;
+    const start = closingFence.index + newlineLength;
+    ranges.push({ start, end: working.length });
+    working = blankRange(working, start, working.length);
+  }
+
+  // Only treat <artifact> as a wrapper when it is the first significant token.
+  // Angle-bracket syntax elsewhere (for example circuit <ep>) stays untouched.
+  const artifactOpen = /^\uFEFF?\s*<artifact\b[^>]*>[ \t]*(?:\r?\n)?/i.exec(
+    working
+  );
+  if (artifactOpen) {
+    ranges.push({ start: 0, end: artifactOpen[0].length });
+    working = blankRange(working, 0, artifactOpen[0].length);
+
+    const artifactClose = /(?:\r?\n)?[ \t]*<\/artifact>[ \t\r\n]*$/i.exec(
+      working
+    );
+    if (artifactClose) {
+      ranges.push({
+        start: artifactClose.index,
+        end: artifactClose.index + artifactClose[0].length,
+      });
+      working = blankRange(
+        working,
+        artifactClose.index,
+        artifactClose.index + artifactClose[0].length
+      );
+    }
+  }
+
+  // A standalone scalar parameter line contains control metadata, not DSL.
+  // Removing only its tags would leave e.g. `false` as a bogus diagram line.
+  working = collectMatches(working, SCALAR_PARAMETER_LINE, ranges);
+  working = collectMatches(working, ANTHROPIC_CONTROL_TAG, ranges);
+  collectMatches(working, DEEPSEEK_CONTROL_TAG, ranges);
+
+  return mergeRemovalRanges(ranges);
+}
+
+/**
+ * Strip model-authored wrappers from DSL text.
+ *
+ * Clean input is returned byte-for-byte unchanged. This pure helper mirrors
+ * the shared core preprocessing behavior and is useful to downstream callers
+ * that need the normalized source itself.
+ */
+export function stripArtifactWrappers(text: string): string {
+  const ranges = findArtifactWrapperRanges(text);
+  if (ranges.length === 0) return text;
+  let result = text;
+  for (const range of [...ranges].reverse()) {
+    result = result.slice(0, range.start) + result.slice(range.end);
+  }
+  return result;
+}
 
 export interface DslFrontmatter {
   /** Parsed key/value pairs from the `---` block. Empty if no block found. */

--- a/src/core/identifier.ts
+++ b/src/core/identifier.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared identifier grammar for every diagram DSL.
+ *
+ * Identifiers may contain Unicode letters, combining marks, decimal digits,
+ * underscores, and hyphens. Identifiers start with a Unicode letter or
+ * underscore; digits, combining marks, and hyphens are allowed thereafter.
+ */
+export const IDENTIFIER_SOURCE =
+  String.raw`[\p{L}_][\p{L}\p{N}\p{M}_-]*`;
+
+/** Dot-qualified identifiers used by UML/class and port-reference grammars. */
+export const QUALIFIED_IDENTIFIER_SOURCE =
+  String.raw`${IDENTIFIER_SOURCE}(?:\.${IDENTIFIER_SOURCE})*`;
+
+const IDENTIFIER_RE = new RegExp(`^(?:${IDENTIFIER_SOURCE})$`, "u");
+const QUALIFIED_IDENTIFIER_RE = new RegExp(
+  `^(?:${QUALIFIED_IDENTIFIER_SOURCE})$`,
+  "u"
+);
+const IDENTIFIER_CHAR_RE = /[\p{L}\p{N}\p{M}_-]/u;
+
+export function isIdentifier(value: string): boolean {
+  return IDENTIFIER_RE.test(value);
+}
+
+export function isQualifiedIdentifier(value: string): boolean {
+  return QUALIFIED_IDENTIFIER_RE.test(value);
+}
+
+export function isIdentifierChar(value: string): boolean {
+  return IDENTIFIER_CHAR_RE.test(value);
+}
+
+export function readIdentifier(
+  source: string,
+  start = 0
+): { value: string; end: number } | null {
+  const match = new RegExp(IDENTIFIER_SOURCE, "uy");
+  match.lastIndex = start;
+  const result = match.exec(source);
+  if (!result) return null;
+  return { value: result[0], end: match.lastIndex };
+}
+
+export function readQualifiedIdentifier(
+  source: string,
+  start = 0
+): { value: string; end: number } | null {
+  const match = new RegExp(QUALIFIED_IDENTIFIER_SOURCE, "uy");
+  match.lastIndex = start;
+  const result = match.exec(source);
+  if (!result) return null;
+  return { value: result[0], end: match.lastIndex };
+}

--- a/src/diagrams/blockdiagram/parser.ts
+++ b/src/diagrams/blockdiagram/parser.ts
@@ -5,7 +5,22 @@ import type {
   SummingJunction,
   BlockRole,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
 import { matchQuotedTitle } from "../../core/quotes";
+
+const BLOCK_DECL_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\s*=\\s*block\\s*\\(\\s*"([^"]*)"\\s*\\)\\s*(?:\\[([^\\]]*)\\])?\\s*$`,
+  "u"
+);
+const SUM_DECL_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\s*=\\s*sum\\s*\\(([^)]*)\\)\\s*$`,
+  "u"
+);
+const SIGNAL_DECL_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\s*=\\s*signal\\s*\\(\\s*"([^"]*)"\\s*\\)\\s*(?:\\[([^\\]]*)\\])?\\s*$`,
+  "u"
+);
+const BRACKETED_IDENTIFIER_RE = new RegExp(`^\\[(${IDENTIFIER_SOURCE})\\]$`, "u");
 
 export class BlockDiagramParseError extends Error {
   constructor(
@@ -110,9 +125,7 @@ export function parseBlockDiagram(text: string): BlockAST {
     }
 
     // block:  ID = block("label") [role: X, name: "Y"]
-    const blockMatch = line.match(
-      /^([A-Za-z_]\w*)\s*=\s*block\s*\(\s*"([^"]*)"\s*\)\s*(?:\[([^\]]*)\])?\s*$/
-    );
+    const blockMatch = line.match(BLOCK_DECL_RE);
     if (blockMatch) {
       const id = blockMatch[1];
       const label = blockMatch[2];
@@ -124,9 +137,7 @@ export function parseBlockDiagram(text: string): BlockAST {
     }
 
     // sum:  ID = sum(+a, -b, ...)
-    const sumMatch = line.match(
-      /^([A-Za-z_]\w*)\s*=\s*sum\s*\(([^)]*)\)\s*$/
-    );
+    const sumMatch = line.match(SUM_DECL_RE);
     if (sumMatch) {
       const id = sumMatch[1];
       const rawInputs = sumMatch[2]
@@ -143,9 +154,7 @@ export function parseBlockDiagram(text: string): BlockAST {
     }
 
     // signal:  ID = signal("label") [discrete]
-    const sigMatch = line.match(
-      /^([A-Za-z_]\w*)\s*=\s*signal\s*\(\s*"([^"]*)"\s*\)\s*(?:\[([^\]]*)\])?\s*$/
-    );
+    const sigMatch = line.match(SIGNAL_DECL_RE);
     if (sigMatch) {
       const id = sigMatch[1];
       const label = sigMatch[2];
@@ -178,7 +187,7 @@ export function parseBlockDiagram(text: string): BlockAST {
         }
         if (bracketStart >= 0) {
           const inner = body.slice(bracketStart + 1, -1).trim();
-          const isBareId = /^[A-Za-z_]\w*$/.test(inner);
+          const isBareId = isIdentifier(inner);
           if (!isBareId) {
             body = body.slice(0, bracketStart).trim();
             if (inner.startsWith('"') && inner.endsWith('"') && !inner.slice(1, -1).includes(',')) {
@@ -194,11 +203,11 @@ export function parseBlockDiagram(text: string): BlockAST {
         throw new BlockDiagramParseError(`Invalid connection: ${line}`, lineNo, undefined, line);
       }
       const endpoints = parts.map((p) => {
-        const m = /^\[([A-Za-z_]\w*)\]$/.exec(p);
+        const m = BRACKETED_IDENTIFIER_RE.exec(p);
         return m ? m[1] : p;
       });
       for (const ep of endpoints) {
-        if (!/^[A-Za-z_]\w*$/.test(ep)) continue;
+        if (!isIdentifier(ep)) continue;
         const exists =
           blocks.some((b) => b.id === ep) ||
           sums.some((s) => s.id === ep) ||

--- a/src/diagrams/bpmn/parser.ts
+++ b/src/diagrams/bpmn/parser.ts
@@ -44,6 +44,10 @@ import type {
   BpmnPool,
   BpmnTaskMarker,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE, readIdentifier } from "../../core/identifier";
+
+const FLOW_OBJECT_PREFIX_RE = new RegExp(`^${IDENTIFIER_SOURCE}\\s*:`, "u");
+const FLOW_OBJECT_RE = new RegExp(`^(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`, "u");
 
 export class BpmnParseError extends Error {
   constructor(message: string, public line: number) {
@@ -306,7 +310,7 @@ function parsePool(
 
     // Pool with no lanes — flow objects directly inside pool. Treat as a
     // single implicit lane.
-    if (cur.text.match(/^[A-Za-z_][\w]*\s*:/)) {
+    if (FLOW_OBJECT_PREFIX_RE.test(cur.text)) {
       // create implicit lane lazily
       let implicit = pool.lanes
         .map((id) => lanesById.get(id))
@@ -381,7 +385,7 @@ function parseFlowObject(
   objectOwner: Map<string, { poolId: string; laneId: string }>
 ): number {
   const ln = lines[idx]!;
-  const m = ln.text.match(/^([A-Za-z_][\w]*)\s*:\s*(.+)$/);
+  const m = ln.text.match(FLOW_OBJECT_RE);
   if (!m) {
     throw new BpmnParseError(
       `expected 'id: kind ...' (got '${ln.text.slice(0, 40)}')`,
@@ -543,9 +547,9 @@ function parseFlowLine(
       if (!q) return null;
       return { ep: q.value, rest: q.rest };
     }
-    const m = t.match(/^([A-Za-z_][\w]*)\s*/);
-    if (!m) return null;
-    return { ep: m[1]!, rest: t.slice(m[0].length) };
+    const id = readIdentifier(t);
+    if (!id) return null;
+    return { ep: id.value, rest: t.slice(id.end).trimStart() };
   }
 
   const head = takeEndpoint(text);

--- a/src/diagrams/breadboard/layout.ts
+++ b/src/diagrams/breadboard/layout.ts
@@ -18,6 +18,7 @@ import type {
   BreadboardPart,
 } from "../../core/types";
 import { partSpec, HOLE_PITCH } from "./parts";
+import { PIN_ALIASES } from "./pin-aliases";
 
 export const BB_CONST = {
   PITCH: HOLE_PITCH,
@@ -143,7 +144,20 @@ function placePart(
   let anchor: BreadboardCoord;
   if (part.placement.kind === "point") anchor = part.placement.at;
   else if (part.placement.kind === "span") anchor = part.placement.from;
-  else throw new Error(`Grid/module part '${part.id}' must use @coord placement`);
+  else if (spec.category === "module") {
+    const centeredCol = Math.max(1, Math.round(sub.cols / 2));
+    if (part.placement.side === "beside-left") {
+      anchor = { kind: "hole", col: 2, row: "a" };
+    } else if (part.placement.side === "beside-right") {
+      anchor = { kind: "hole", col: Math.max(1, sub.cols - 1), row: "a" };
+    } else if (part.placement.side === "below") {
+      anchor = { kind: "hole", col: centeredCol, row: "j" };
+    } else {
+      anchor = { kind: "hole", col: centeredCol, row: "a" };
+    }
+  } else {
+    throw new Error(`Grid part '${part.id}' must use @coord placement`);
+  }
   const anchorXY = holeXY(sub, anchor);
 
   // For module parts (sensors / displays): anchor is the first pin (lower-left of module),
@@ -215,6 +229,15 @@ function addPinAliases(
       setAlias(pins, `GPIO${n}`, xy);
       setAlias(pins, `IO${n}`, xy);
     }
+
+    const picoGpio = /^GP(\d+)$/i.exec(name);
+    if (picoGpio) {
+      const n = picoGpio[1]!;
+      setAlias(pins, `GPIO${n}`, xy);
+      setAlias(pins, `IO${n}`, xy);
+      setAlias(pins, `D${n}`, xy);
+      setAlias(pins, n, xy);
+    }
   }
 
   const alias = (canonical: string, ...aliases: string[]): void => {
@@ -245,6 +268,52 @@ function addPinAliases(
   if (kind === "mcu-esp32" || kind === "mcu-pico") {
     alias("VIN", "5V", "VBUS", "USB");
   }
+
+  const catalogAliases = PIN_ALIASES[kind];
+  if (catalogAliases) {
+    for (const [canonical, aliases] of Object.entries(catalogAliases)) {
+      alias(canonical, ...aliases);
+    }
+  }
+}
+
+function editDistance(a: string, b: string): number {
+  const left = Array.from(a.toUpperCase());
+  const right = Array.from(b.toUpperCase());
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let i = 0; i < left.length; i++) {
+    const current = [i + 1];
+    for (let j = 0; j < right.length; j++) {
+      current.push(
+        Math.min(
+          current[j]! + 1,
+          previous[j + 1]! + 1,
+          previous[j]! + (left[i] === right[j] ? 0 : 1)
+        )
+      );
+    }
+    previous = current;
+  }
+  return previous[right.length]!;
+}
+
+function nearestPinName(
+  requested: string,
+  pins: Record<string, { x: number; y: number }>
+): string | undefined {
+  const byFoldedName = new Map<string, string>();
+  for (const name of Object.keys(pins)) {
+    const folded = name.toUpperCase();
+    const previous = byFoldedName.get(folded);
+    if (!previous || name.length < previous.length) byFoldedName.set(folded, name);
+  }
+  return [...byFoldedName.values()].sort((a, b) => {
+    const distance = editDistance(requested, a) - editDistance(requested, b);
+    if (distance !== 0) return distance;
+    const lengthDelta =
+      Math.abs(requested.length - a.length) - Math.abs(requested.length - b.length);
+    return lengthDelta || a.localeCompare(b);
+  })[0];
 }
 
 function endpointXY(
@@ -257,11 +326,17 @@ function endpointXY(
   if (!part) throw new Error(`Wire references unknown part '${ep.partId}'`);
   const pin = part.pins[ep.pin] ?? part.pins[ep.pin.toUpperCase()] ?? part.pins[ep.pin.toLowerCase()];
   if (!pin) {
-    const known = Object.keys(part.pins)
+    const known = partSpec(part.part.kind, part.part.args).pins
+      .map((candidate) => candidate.name)
       .filter((name, idx, all) => all.indexOf(name) === idx)
       .slice(0, 24)
       .join(", ");
-    throw new Error(`Part '${ep.partId}' has no pin named '${ep.pin}' (known pins: ${known})`);
+    const suggestion = nearestPinName(ep.pin, part.pins);
+    throw new Error(
+      `Part '${ep.partId}' has no pin named '${ep.pin}'.` +
+      (suggestion ? ` Did you mean '${suggestion}'?` : "") +
+      ` (known pins: ${known})`
+    );
   }
   // Return a copy so post-layout translation doesn't double-shift this point
   // through both part.pins[name] and lw.fromXY.

--- a/src/diagrams/breadboard/parser.ts
+++ b/src/diagrams/breadboard/parser.ts
@@ -23,6 +23,7 @@ import type {
   BreadboardWire,
   BreadboardWireColor,
 } from "../../core/types";
+import { isIdentifier } from "../../core/identifier";
 import { createSourceLocator } from "../../core/source-range";
 
 export class BreadboardParseError extends Error {
@@ -216,7 +217,7 @@ function parsePart(rawLine: string, lineNumber: number): BreadboardPart {
     throw new BreadboardParseError(`Part declaration must use 'id: kind ...' syntax`, lineNumber);
   }
   const id = rawLine.slice(0, colonIdx).trim();
-  if (!/^[a-zA-Z][\w-]*$/.test(id)) {
+  if (!isIdentifier(id)) {
     throw new BreadboardParseError(`Invalid part id '${id}'`, lineNumber);
   }
   const after = rawLine.slice(colonIdx + 1).trim();

--- a/src/diagrams/breadboard/parts.ts
+++ b/src/diagrams/breadboard/parts.ts
@@ -297,12 +297,18 @@ function mcuSpec(
   geometry: { width: number; height: number; cornerR: number }
 ): PartSpec {
   const { width, height, cornerR } = geometry;
+  const maxVerticalIndex = Math.max(
+    0,
+    ...slots
+      .filter((slot) => slot.side === "left" || slot.side === "right")
+      .map((slot) => slot.idx)
+  );
+  const verticalStride = Math.min(12, (height - 34) / Math.max(1, maxVerticalIndex));
   const pins: PartPin[] = slots.map((s) => {
-    const stride = 12;
-    if (s.side === "left") return { name: s.name, x: 4, y: 14 + s.idx * stride };
-    if (s.side === "right") return { name: s.name, x: width - 4, y: 14 + s.idx * stride };
-    if (s.side === "top") return { name: s.name, x: 14 + s.idx * stride, y: 4 };
-    return { name: s.name, x: 14 + s.idx * stride, y: height - 4 };
+    if (s.side === "left") return { name: s.name, x: 4, y: 14 + s.idx * verticalStride };
+    if (s.side === "right") return { name: s.name, x: width - 4, y: 14 + s.idx * verticalStride };
+    if (s.side === "top") return { name: s.name, x: 14 + s.idx * 12, y: 4 };
+    return { name: s.name, x: 14 + s.idx * 12, y: height - 4 };
   });
   return {
     kind,
@@ -366,27 +372,109 @@ const UNO_SLOTS: McuPinSlot[] = [
   { name: "A5", side: "left", idx: 11 },
 ];
 
+// Arduino Nano classic (A000005) — the full two-row header, not an Uno slice.
+const NANO_SLOTS: McuPinSlot[] = [
+  { name: "D1", side: "left", idx: 0 },
+  { name: "D0", side: "left", idx: 1 },
+  { name: "RST", side: "left", idx: 2 },
+  { name: "GND", side: "left", idx: 3 },
+  { name: "D2", side: "left", idx: 4 },
+  { name: "D3", side: "left", idx: 5 },
+  { name: "D4", side: "left", idx: 6 },
+  { name: "D5", side: "left", idx: 7 },
+  { name: "D6", side: "left", idx: 8 },
+  { name: "D7", side: "left", idx: 9 },
+  { name: "D8", side: "left", idx: 10 },
+  { name: "D9", side: "left", idx: 11 },
+  { name: "D10", side: "left", idx: 12 },
+  { name: "D11", side: "left", idx: 13 },
+  { name: "D12", side: "left", idx: 14 },
+  { name: "D13", side: "right", idx: 0 },
+  { name: "3V3", side: "right", idx: 1 },
+  { name: "AREF", side: "right", idx: 2 },
+  { name: "A0", side: "right", idx: 3 },
+  { name: "A1", side: "right", idx: 4 },
+  { name: "A2", side: "right", idx: 5 },
+  { name: "A3", side: "right", idx: 6 },
+  { name: "A4", side: "right", idx: 7 },
+  { name: "A5", side: "right", idx: 8 },
+  { name: "A6", side: "right", idx: 9 },
+  { name: "A7", side: "right", idx: 10 },
+  { name: "5V", side: "right", idx: 11 },
+  { name: "RST", side: "right", idx: 12 },
+  { name: "GND", side: "right", idx: 13 },
+  { name: "VIN", side: "right", idx: 14 },
+];
+
 const ESP32_SLOTS: McuPinSlot[] = [
   { name: "3V3", side: "left", idx: 0 },
-  { name: "GND", side: "left", idx: 1 },
-  { name: "GPIO15", side: "left", idx: 2 },
-  { name: "GPIO2", side: "left", idx: 3 },
-  { name: "GPIO4", side: "left", idx: 4 },
-  { name: "GPIO5", side: "left", idx: 5 },
-  { name: "GPIO18", side: "left", idx: 6 },
-  { name: "GPIO19", side: "left", idx: 7 },
-  { name: "GPIO21", side: "left", idx: 8 },
-  { name: "GPIO22", side: "left", idx: 9 },
+  { name: "EN", side: "left", idx: 1 },
+  { name: "GPIO36", side: "left", idx: 2 },
+  { name: "GPIO39", side: "left", idx: 3 },
+  { name: "GPIO34", side: "left", idx: 4 },
+  { name: "GPIO35", side: "left", idx: 5 },
+  { name: "GPIO32", side: "left", idx: 6 },
+  { name: "GPIO33", side: "left", idx: 7 },
+  { name: "GPIO25", side: "left", idx: 8 },
+  { name: "GPIO26", side: "left", idx: 9 },
+  { name: "GPIO27", side: "left", idx: 10 },
+  { name: "GPIO14", side: "left", idx: 11 },
+  { name: "GPIO12", side: "left", idx: 12 },
+  { name: "GND", side: "left", idx: 13 },
+  { name: "GPIO13", side: "left", idx: 14 },
   { name: "VIN", side: "right", idx: 0 },
-  { name: "GND", side: "right", idx: 1 },
-  { name: "GPIO13", side: "right", idx: 2 },
-  { name: "GPIO12", side: "right", idx: 3 },
-  { name: "GPIO14", side: "right", idx: 4 },
-  { name: "GPIO27", side: "right", idx: 5 },
-  { name: "GPIO26", side: "right", idx: 6 },
-  { name: "GPIO25", side: "right", idx: 7 },
-  { name: "GPIO33", side: "right", idx: 8 },
-  { name: "GPIO32", side: "right", idx: 9 },
+  { name: "GPIO23", side: "right", idx: 1 },
+  { name: "GPIO22", side: "right", idx: 2 },
+  { name: "GPIO1", side: "right", idx: 3 },
+  { name: "GPIO3", side: "right", idx: 4 },
+  { name: "GPIO21", side: "right", idx: 5 },
+  { name: "GND", side: "right", idx: 6 },
+  { name: "GPIO19", side: "right", idx: 7 },
+  { name: "GPIO18", side: "right", idx: 8 },
+  { name: "GPIO5", side: "right", idx: 9 },
+  { name: "GPIO17", side: "right", idx: 10 },
+  { name: "GPIO16", side: "right", idx: 11 },
+  { name: "GPIO4", side: "right", idx: 12 },
+  { name: "GPIO0", side: "right", idx: 13 },
+  { name: "GPIO2", side: "right", idx: 14 },
+  { name: "GPIO15", side: "right", idx: 15 },
+];
+
+const PICO_SLOTS: McuPinSlot[] = [
+  { name: "GP0", side: "left", idx: 0 },
+  { name: "GP1", side: "left", idx: 1 },
+  { name: "GND", side: "left", idx: 2 },
+  { name: "GP2", side: "left", idx: 3 },
+  { name: "GP3", side: "left", idx: 4 },
+  { name: "GP4", side: "left", idx: 5 },
+  { name: "GP5", side: "left", idx: 6 },
+  { name: "GP6", side: "left", idx: 7 },
+  { name: "GP7", side: "left", idx: 8 },
+  { name: "GP8", side: "left", idx: 9 },
+  { name: "GP9", side: "left", idx: 10 },
+  { name: "GP10", side: "left", idx: 11 },
+  { name: "GP11", side: "left", idx: 12 },
+  { name: "GP12", side: "left", idx: 13 },
+  { name: "GP13", side: "left", idx: 14 },
+  { name: "GP14", side: "left", idx: 15 },
+  { name: "GP15", side: "left", idx: 16 },
+  { name: "VBUS", side: "right", idx: 0 },
+  { name: "VSYS", side: "right", idx: 1 },
+  { name: "3V3_EN", side: "right", idx: 2 },
+  { name: "3V3", side: "right", idx: 3 },
+  { name: "ADC_VREF", side: "right", idx: 4 },
+  { name: "GP28", side: "right", idx: 5 },
+  { name: "AGND", side: "right", idx: 6 },
+  { name: "GP27", side: "right", idx: 7 },
+  { name: "GP26", side: "right", idx: 8 },
+  { name: "RUN", side: "right", idx: 9 },
+  { name: "GP22", side: "right", idx: 10 },
+  { name: "GP21", side: "right", idx: 11 },
+  { name: "GP20", side: "right", idx: 12 },
+  { name: "GP19", side: "right", idx: 13 },
+  { name: "GP18", side: "right", idx: 14 },
+  { name: "GP17", side: "right", idx: 15 },
+  { name: "GP16", side: "right", idx: 16 },
 ];
 
 // ─── Sensor / display modules ────────────────────────────────
@@ -445,9 +533,9 @@ export const PART_CATALOG: Record<BreadboardPartKind, PartSpec> = {
   dip: dipSpec(),
   header: HEADER,
   "mcu-uno": mcuSpec("mcu-uno", "#0d9488", "Arduino Uno", UNO_SLOTS, { width: 110, height: 200, cornerR: 6 }),
-  "mcu-nano": mcuSpec("mcu-nano", "#0d9488", "Arduino Nano", UNO_SLOTS.slice(0, 18), { width: 90, height: 180, cornerR: 4 }),
+  "mcu-nano": mcuSpec("mcu-nano", "#0d9488", "Arduino Nano", NANO_SLOTS, { width: 90, height: 180, cornerR: 4 }),
   "mcu-esp32": mcuSpec("mcu-esp32", "#1e293b", "ESP32 DevKit", ESP32_SLOTS, { width: 110, height: 180, cornerR: 4 }),
-  "mcu-pico": mcuSpec("mcu-pico", "#1e3a8a", "Raspberry Pi Pico", ESP32_SLOTS, { width: 100, height: 180, cornerR: 4 }),
+  "mcu-pico": mcuSpec("mcu-pico", "#1e3a8a", "Raspberry Pi Pico", PICO_SLOTS, { width: 100, height: 180, cornerR: 4 }),
   potentiometer: moduleSpec("potentiometer", 54, 46, "#eab308", ["1", "2", "3"], "POT"),
   "sensor-hcsr04": moduleSpec("sensor-hcsr04", 100, 60, "#1e3a8a", ["VCC", "TRIG", "ECHO", "GND"], "HC-SR04"),
   "sensor-dht11": moduleSpec("sensor-dht11", 70, 60, "#1e40af", ["VCC", "DATA", "GND"], "DHT11"),

--- a/src/diagrams/breadboard/pin-aliases.ts
+++ b/src/diagrams/breadboard/pin-aliases.ts
@@ -1,0 +1,89 @@
+import type { BreadboardPartKind } from "../../core/types";
+
+/**
+ * Common names found in board/module pinout sheets and maker documentation.
+ * Keys are canonical catalog pin names; values are accepted DSL aliases.
+ */
+export const PIN_ALIASES: Partial<
+  Record<BreadboardPartKind, Record<string, readonly string[]>>
+> = {
+  button: {
+    "1": ["pin1", "leg1"],
+    "2": ["pin2", "leg2"],
+    "3": ["pin3", "leg3"],
+    "4": ["pin4", "leg4"],
+  },
+  "mcu-nano": {
+    D0: ["RX", "RX0", "GPIO0", "IO0", "0"],
+    D1: ["TX", "TX0", "GPIO1", "IO1", "1"],
+    A4: ["SDA"],
+    A5: ["SCL"],
+    RST: ["RESET"],
+    VIN: ["RAW"],
+  },
+  "mcu-uno": {
+    RX: ["D0", "RX0", "GPIO0", "IO0", "0"],
+    TX: ["D1", "TX0", "GPIO1", "IO1", "1"],
+    A4: ["SDA"],
+    A5: ["SCL"],
+    RST: ["RESET"],
+    VIN: ["RAW"],
+  },
+  "mcu-esp32": {
+    GPIO1: ["TX", "TX0"],
+    GPIO3: ["RX", "RX0"],
+    GPIO21: ["SDA"],
+    GPIO22: ["SCL"],
+    GPIO36: ["VP", "SVP", "SENSOR_VP"],
+    GPIO39: ["VN", "SVN", "SENSOR_VN"],
+    VIN: ["5V", "VBUS", "USB"],
+    EN: ["ENABLE", "RESET", "RST"],
+  },
+  "mcu-pico": {
+    VBUS: ["VIN", "5V", "USB"],
+    VSYS: ["RAW"],
+    "3V3": ["3V3_OUT", "VCC", "VDD"],
+    "3V3_EN": ["3V3EN"],
+    ADC_VREF: ["VREF"],
+    RUN: ["RESET", "RST"],
+  },
+  "sensor-hcsr04": {
+    VCC: ["5V", "VIN"],
+    TRIG: ["TRIGGER"],
+  },
+  "sensor-dht11": {
+    VCC: ["5V", "VIN"],
+    DATA: ["DAT", "OUT", "SIG", "SIGNAL"],
+  },
+  "sensor-dht22": {
+    VCC: ["5V", "VIN"],
+    DATA: ["DAT", "OUT", "SIG", "SIGNAL"],
+  },
+  "sensor-vl53l0x": {
+    VIN: ["VCC", "5V", "3V3"],
+  },
+  "display-oled-ssd1306": {
+    VCC: ["VIN", "5V", "3V3"],
+    SCL: ["SCK", "CLK"],
+  },
+  "display-lcd-1602-i2c": {
+    VCC: ["VIN", "5V"],
+    SCL: ["SCK", "CLK"],
+  },
+  "display-tm1637": {
+    CLK: ["SCK", "CLOCK"],
+    DIO: ["DATA", "DAT"],
+    VCC: ["VIN", "5V"],
+  },
+  "module-rotary-ky040": {
+    CLK: ["A"],
+    DT: ["B"],
+    SW: ["BUTTON", "KEY"],
+    VCC: ["VIN", "5V"],
+  },
+  "actuator-servo-sg90": {
+    GND: ["BROWN", "BLACK"],
+    VCC: ["5V", "VIN", "RED"],
+    SIG: ["SIGNAL", "PWM", "DATA", "ORANGE", "YELLOW"],
+  },
+};

--- a/src/diagrams/ecomap/parser.ts
+++ b/src/diagrams/ecomap/parser.ts
@@ -6,6 +6,7 @@ import type {
   RelationshipType,
   Sex,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE } from "../../core/identifier";
 import { parseLegendDirective } from "../../core/legend-parser";
 
 // ─── Error ─────────────────────────────────────────────────
@@ -46,8 +47,12 @@ const CONNECTION_OPS: Record<string, ConnectionOpInfo> = {
 const OP_PATTERN =
   "===>|<===|===|<=>|==>|<==|<->|-->|<--|~=~|~x~|~~~|-\\/-|---|==|- -";
 const CONNECTION_RE = new RegExp(
-  `^([a-zA-Z][a-zA-Z0-9_-]*)\\s+(${OP_PATTERN})\\s+([a-zA-Z][a-zA-Z0-9_-]*)(.*)$`
+  `^(${IDENTIFIER_SOURCE})\\s+(${OP_PATTERN})\\s+(${IDENTIFIER_SOURCE})(.*)$`,
+  "u"
 );
+const HEADER_RE = new RegExp(`^ecomap(?::(${IDENTIFIER_SOURCE}))?\\s*(?:"([^"]*)")?\\s*$`, "iu");
+const CENTER_RE = new RegExp(`^center:\\s*(${IDENTIFIER_SOURCE})\\s*(\\[.*\\])?\\s*$`, "u");
+const SYSTEM_RE = new RegExp(`^(${IDENTIFIER_SOURCE})\\s*(\\[.*\\])?\\s*$`, "u");
 
 // ─── Public API ────────────────────────────────────────────
 
@@ -78,9 +83,7 @@ export function parseEcomap(text: string): DiagramAST {
   // Mermaid-style header tolerance: `ecomap`, `ecomap "Title"`,
   // `ecomap:mode`, `ecomap:mode "Title"`. The `:mode` is captured as
   // metadata for future use; current renderer ignores it.
-  const headerMatch = header.match(
-    /^ecomap(?::([a-zA-Z][\w-]*))?\s*(?:"([^"]*)")?\s*$/i
-  );
+  const headerMatch = header.match(HEADER_RE);
   if (!headerMatch)
     throw new EcomapParseError(
       `Expected 'ecomap' header (got '${header}')`,
@@ -111,9 +114,7 @@ export function parseEcomap(text: string): DiagramAST {
     }
 
     // Center definition
-    const centerMatch = trimmed.match(
-      /^center:\s*([a-zA-Z][a-zA-Z0-9_-]*)\s*(\[.*\])?\s*$/
-    );
+    const centerMatch = trimmed.match(CENTER_RE);
     if (centerMatch) {
       const id = centerMatch[1].toLowerCase();
       centerId = id;
@@ -175,9 +176,7 @@ export function parseEcomap(text: string): DiagramAST {
     }
 
     // System definition
-    const sysMatch = trimmed.match(
-      /^([a-zA-Z][a-zA-Z0-9_-]*)\s*(\[.*\])?\s*$/
-    );
+    const sysMatch = trimmed.match(SYSTEM_RE);
     if (sysMatch) {
       const id = sysMatch[1].toLowerCase();
       if (!knownIds.has(id)) {

--- a/src/diagrams/entity/parser.ts
+++ b/src/diagrams/entity/parser.ts
@@ -7,6 +7,7 @@ import type {
   JurisdictionDef,
   ClusterDef,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
 import { matchQuotedTitle } from "../../core/quotes";
 
 export class EntityParseError extends Error {
@@ -227,7 +228,10 @@ export function parseEntityDSL(text: string): EntityAST {
 
     // entity id "Name" type[@jurisdiction] [props]
     const entityMatch = line.match(
-      /^entity\s+([A-Za-z][A-Za-z0-9_-]*)\s+"([^"]*)"\s+([a-zA-Z]+)(?:@([A-Za-z]{2,3}))?(?:\s*\[([^\]]*)\])?\s*$/
+      new RegExp(
+        `^entity\\s+(${IDENTIFIER_SOURCE})\\s+"([^"]*)"\\s+([a-zA-Z]+)(?:@([A-Za-z]{2,3}))?(?:\\s*\\[([^\\]]*)\\])?\\s*$`,
+        "u"
+      )
     );
     if (entityMatch) {
       const id = entityMatch[1];
@@ -269,12 +273,15 @@ export function parseEntityDSL(text: string): EntityAST {
     if (edgeInfo) {
       const left = line.slice(0, edgeInfo.idx).trim();
       const rest = line.slice(edgeInfo.idx + edgeInfo.len).trim();
-      if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(left)) {
+      if (!isIdentifier(left)) {
         throw new EntityParseError(`Invalid edge source on line: ${line}`);
       }
       // rest: "target [: pct] [props]" OR "target [props]"
       const restMatch = rest.match(
-        /^([A-Za-z][A-Za-z0-9_-]*)(?:\s*:\s*([^[]+?))?(?:\s*\[([^\]]*)\])?\s*$/
+        new RegExp(
+          `^(${IDENTIFIER_SOURCE})(?:\\s*:\\s*([^[]+?))?(?:\\s*\\[([^\\]]*)\\])?\\s*$`,
+          "u"
+        )
       );
       if (!restMatch) {
         throw new EntityParseError(`Cannot parse edge: ${line}`);

--- a/src/diagrams/epc/parser.ts
+++ b/src/diagrams/epc/parser.ts
@@ -32,6 +32,7 @@ import type {
   EpcEdge,
   EpcNode,
 } from "./types";
+import { isIdentifier, readIdentifier } from "../../core/identifier";
 import { analyseEpc } from "./analysis";
 
 export class EpcParseError extends Error {
@@ -220,10 +221,11 @@ function ensureRef(ast: EpcAst, id: string, _lineNo: number): void {
 // ─── Token helpers ────────────────────────────────────────────
 
 function parseIdAndLabel(s: string, lineNo: number): { id: string; label?: string } {
-  const m = /^([A-Za-z_]\w*)/.exec(s.trim());
-  if (!m) throw new EpcParseError(`expected a node id, got "${truncate(s, 40)}"`, lineNo);
-  const id = m[1]!;
-  const rest = s.trim().slice(id.length).trim();
+  const trimmed = s.trim();
+  const token = readIdentifier(trimmed);
+  if (!token) throw new EpcParseError(`expected a node id, got "${truncate(s, 40)}"`, lineNo);
+  const id = token.value;
+  const rest = trimmed.slice(token.end).trim();
   if (rest === "") return { id };
   const q = matchQuoted(rest);
   if (q) return { id, label: q.value };
@@ -232,7 +234,7 @@ function parseIdAndLabel(s: string, lineNo: number): { id: string; label?: strin
 }
 
 function isId(s: string): boolean {
-  return /^[A-Za-z_]\w*$/.test(s);
+  return isIdentifier(s);
 }
 
 /** True when the line has a top-level `->` (not inside quotes). */

--- a/src/diagrams/erd/parser.ts
+++ b/src/diagrams/erd/parser.ts
@@ -6,6 +6,7 @@ import type {
   ErdNotation,
   ErdRef,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE } from "../../core/identifier";
 import { createSourceLocator } from "../../core/source-range";
 import type { SourceRange } from "../../core/types";
 
@@ -222,9 +223,10 @@ export function parseErd(text: string): ErdAst {
 
 // ─── Mermaid `erDiagram` paste-compat parser ──────────────────
 
-const MERMAID_NAME = /[A-Za-z_][\w-]*/;
+const MERMAID_NAME_SOURCE = IDENTIFIER_SOURCE;
 const REL_RE = new RegExp(
-  `^(${MERMAID_NAME.source})\\s+([}|o][o|]|\\|\\||\\|o)(\\.\\.|--|~~)([}|o][{|]|\\|\\||o\\|)\\s+(${MERMAID_NAME.source})\\s*(?::\\s*(.*))?$`
+  `^(${MERMAID_NAME_SOURCE})\\s+([}|o][o|]|\\|\\||\\|o)(\\.\\.|--|~~)([}|o][{|]|\\|\\||o\\|)\\s+(${MERMAID_NAME_SOURCE})\\s*(?::\\s*(.*))?$`,
+  "u"
 );
 
 /**
@@ -334,8 +336,8 @@ function parseMermaidErd(
     }
 
     // Entity block: `NAME {` (multi-line) or `NAME { ... }` (inline).
-    const inlineBlock = new RegExp(`^(${MERMAID_NAME.source})\\s*\\{\\s*(.*?)\\s*\\}$`).exec(t);
-    const openBlock = new RegExp(`^(${MERMAID_NAME.source})\\s*\\{$`).exec(t);
+    const inlineBlock = new RegExp(`^(${MERMAID_NAME_SOURCE})\\s*\\{\\s*(.*?)\\s*\\}$`, "u").exec(t);
+    const openBlock = new RegExp(`^(${MERMAID_NAME_SOURCE})\\s*\\{$`, "u").exec(t);
     if (inlineBlock) {
       const e = ensure(inlineBlock[1]!);
       let from = t.indexOf(inlineBlock[2]!);
@@ -471,7 +473,7 @@ function parseTableBlock(
 
 function splitDecl(declRaw: string, lineNumber: number): { id: string; name: string } {
   void lineNumber;
-  const aliasMatch = /^"([^"]+)"\s+as\s+([A-Za-z_][\w]*)$/i.exec(declRaw);
+  const aliasMatch = new RegExp(`^"([^"]+)"\\s+as\\s+(${IDENTIFIER_SOURCE})$`, "iu").exec(declRaw);
   if (aliasMatch) {
     return { id: aliasMatch[2]!, name: aliasMatch[1]! };
   }
@@ -503,7 +505,10 @@ function parseAttributeLine(
 
   // FK target: ` -> Table.col` or ` => Table.col`
   let fkTarget: string | undefined;
-  const arrowMatch = /\s+(?:->|=>)\s+([A-Za-z_][\w]*\.[A-Za-z_][\w]*)\s*$/.exec(s);
+  const arrowMatch = new RegExp(
+    `\\s+(?:->|=>)\\s+(${IDENTIFIER_SOURCE}\\.${IDENTIFIER_SOURCE})\\s*$`,
+    "u"
+  ).exec(s);
   if (arrowMatch) {
     fkTarget = arrowMatch[1];
     s = s.slice(0, arrowMatch.index).trim();

--- a/src/diagrams/eventtree/parser.ts
+++ b/src/diagrams/eventtree/parser.ts
@@ -28,6 +28,7 @@ import type {
   EventTreeOutcome,
   EventTreePatternToken,
 } from "./types";
+import { readIdentifier } from "../../core/identifier";
 
 export class EventTreeParseError extends Error {
   constructor(message: string, public line?: number) {
@@ -222,10 +223,11 @@ function validate(ast: EventTreeAst): void {
 // ─── Helpers ──────────────────────────────────────────────────
 
 function parseIdAndLabel(s: string, lineNo: number): { id: string; label?: string; remainder: string } {
-  const m = /^([A-Za-z_]\w*)/.exec(s.trim());
-  if (!m) throw new EventTreeParseError(`expected an id, got "${truncate(s, 40)}"`, lineNo);
-  const id = m[1]!;
-  let rest = s.trim().slice(id.length).trim();
+  const trimmed = s.trim();
+  const token = readIdentifier(trimmed);
+  if (!token) throw new EventTreeParseError(`expected an id, got "${truncate(s, 40)}"`, lineNo);
+  const id = token.value;
+  let rest = trimmed.slice(token.end).trim();
   const q = matchQuoted(rest);
   let label: string | undefined;
   if (q) { label = q.value; rest = rest.slice(q.length).trim(); }

--- a/src/diagrams/faulttree/parser.ts
+++ b/src/diagrams/faulttree/parser.ts
@@ -18,6 +18,7 @@ import type {
   FaultTreeGateKind,
   FaultTreeProbMethod,
 } from "./types";
+import { IDENTIFIER_SOURCE, isIdentifier, readIdentifier } from "../../core/identifier";
 
 export class FaultTreeParseError extends Error {
   constructor(message: string, public line?: number) {
@@ -212,7 +213,7 @@ function parseGateExpr(s: string, lineNo: number): FaultTreeGate {
 
 function parseTransfer(ast: FaultTreeAst, rest: string, lineNo: number): void {
   // transfer-out:  ID -> "name"
-  const out = /^([A-Za-z_]\w*)\s*->\s*(.+)$/.exec(rest);
+  const out = new RegExp(`^(${IDENTIFIER_SOURCE})\\s*->\\s*(.+)$`, "u").exec(rest);
   if (out) {
     const q = matchQuoted(out[2]!.trim());
     const name = q ? q.value : out[2]!.trim();
@@ -325,10 +326,11 @@ function upsertEvent(ast: FaultTreeAst, ev: FaultTreeEvent): void {
 }
 
 function parseIdAndLabel(s: string, lineNo: number): { id: string; label?: string; remainder: string } {
-  const m = /^([A-Za-z_]\w*)/.exec(s.trim());
-  if (!m) throw new FaultTreeParseError(`expected an event id, got "${truncate(s, 40)}"`, lineNo);
-  const id = m[1]!;
-  let rest = s.trim().slice(id.length).trim();
+  const trimmed = s.trim();
+  const token = readIdentifier(trimmed);
+  if (!token) throw new FaultTreeParseError(`expected an event id, got "${truncate(s, 40)}"`, lineNo);
+  const id = token.value;
+  let rest = trimmed.slice(token.end).trim();
   const q = matchQuoted(rest);
   let label: string | undefined;
   if (q) { label = q.value; rest = rest.slice(q.length).trim(); }
@@ -353,7 +355,7 @@ function splitRefs(s: string, lineNo: number): string[] {
 }
 
 function isId(s: string): boolean {
-  return /^[A-Za-z_]\w*$/.test(s);
+  return isIdentifier(s);
 }
 
 /** Index of a top-level `=` (not inside parens or quotes), or -1. */

--- a/src/diagrams/fbd/parser.ts
+++ b/src/diagrams/fbd/parser.ts
@@ -22,9 +22,23 @@ import type {
   FbdDataType,
   FbdWire,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
 import { matchQuotedTitle } from "../../core/quotes";
 import { createSourceLocator } from "../../core/source-range";
 import { BLOCK_SPECS, isStdBlock, getBlockSpec } from "./blocks";
+
+const VAR_DECL_RE = new RegExp(
+  `^(var|var_input|var_output|var_in_out|var_global|var_external)\\s+(${IDENTIFIER_SOURCE})\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*(?:=\\s*(.+))?$`,
+  "iu"
+);
+const PORT_REF_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\.([A-Za-z_][A-Za-z0-9_]*)$`,
+  "u"
+);
+const ASSIGNMENT_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\s*=\\s*([A-Za-z_][A-Za-z0-9_]*\\s*\\(.*\\))\\s*(\\[[^\\]]*\\])?\\s*$`,
+  "u"
+);
 
 export class FbdParseError extends Error {
   line?: number;
@@ -97,7 +111,7 @@ function stripBrackets(s: string): string {
 }
 
 function parseVarDecl(line: RawLine): FbdVarDecl | null {
-  const m = line.text.match(/^(var|var_input|var_output|var_in_out|var_global|var_external)\s+([a-zA-Z_]\w*)\s*:\s*([a-zA-Z_]\w*)\s*(?:=\s*(.+))?$/i);
+  const m = line.text.match(VAR_DECL_RE);
   if (!m) return null;
   const scope = SCOPE_KEYWORDS[m[1].toLowerCase()] ?? "local";
   const name = m[2];
@@ -391,7 +405,7 @@ function bindArg(
   }
 
   // Port reference  Inst.PortName ?
-  const portRef = arg.raw.match(/^([A-Za-z_]\w*)\.([A-Za-z_]\w*)$/);
+  const portRef = arg.raw.match(PORT_REF_RE);
   if (portRef) {
     const srcId = portRef[1];
     const srcPort = portRef[2];
@@ -422,7 +436,7 @@ function bindArg(
 
   // Plain variable reference
   const varName = arg.raw;
-  if (!/^[A-Za-z_]\w*$/.test(varName)) {
+  if (!isIdentifier(varName)) {
     throw new FbdParseError(`Invalid argument: ${arg.raw}`, lineNo, arg.raw);
   }
   ensureVar(state, varName, port.dataType === "any" ? "bool" : port.dataType);
@@ -550,7 +564,7 @@ export function parseFbd(text: string): FbdAst {
 function parseStatement(state: ParserState, line: RawLine): void {
   const text = line.text;
   // Form A:  Inst = BLOCK(args) [props]
-  const m = text.match(/^([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*\s*\(.*\))\s*(\[[^\]]*\])?\s*$/);
+  const m = text.match(ASSIGNMENT_RE);
   if (m) {
     const lhs = m[1];
     const callStr = m[2];

--- a/src/diagrams/fishbone/parser.ts
+++ b/src/diagrams/fishbone/parser.ts
@@ -7,7 +7,14 @@ import type {
   FishboneSides,
   SourceRange,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE } from "../../core/identifier";
 import { createSourceLocator } from "../../core/source-range";
+
+const STRUCTURED_CATEGORY_RE = new RegExp(
+  `^category\\s+(${IDENTIFIER_SOURCE})\\s+("[^"]*"|[^\\s[]+)(?:\\s*(\\[.*\\]))?\\s*$`,
+  "iu"
+);
+const CATEGORY_CAUSE_RE = new RegExp(`^(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`, "u");
 
 export class FishboneParseError extends Error {
   public line?: number;
@@ -229,9 +236,7 @@ export function parseFishboneDSL(text: string): FishboneAST {
       implicitActiveCatId = null;
       implicitBulletIndent = null;
       const compact = trimmed.match(/^category\s+([^:]+?)\s*:\s*(.+)$/i);
-      const structured = trimmed.match(
-        /^category\s+([a-zA-Z][\w-]*)\s+("[^"]*"|[^\s[]+)(?:\s*(\[.*\]))?\s*$/i
-      );
+      const structured = trimmed.match(STRUCTURED_CATEGORY_RE);
 
       if (structured) {
         const id = structured[1]!;
@@ -278,7 +283,7 @@ export function parseFishboneDSL(text: string): FishboneAST {
     }
 
     // <categoryId> : "cause"
-    const causeMatch = trimmed.match(/^([a-zA-Z][\w-]*)\s*:\s*(.+)$/);
+    const causeMatch = trimmed.match(CATEGORY_CAUSE_RE);
     if (causeMatch) {
       const catId = causeMatch[1]!;
       const cat = getCat(catId);

--- a/src/diagrams/flowchart/parser.ts
+++ b/src/diagrams/flowchart/parser.ts
@@ -51,6 +51,12 @@ import type {
   FlowchartSubgraph,
   SourceRange,
 } from "../../core/types";
+import {
+  IDENTIFIER_SOURCE,
+  isIdentifier,
+  isIdentifierChar,
+  readIdentifier,
+} from "../../core/identifier";
 import { createSourceLocator } from "../../core/source-range";
 
 export class FlowchartParseError extends Error {
@@ -58,7 +64,8 @@ export class FlowchartParseError extends Error {
     message: string,
     public line: number,
     public column: number,
-    public source?: string
+    public source?: string,
+    public hint?: string
   ) {
     super(`[line ${line}:${column}] ${message}`);
     this.name = "FlowchartParseError";
@@ -99,16 +106,23 @@ function labelToken(
   };
 }
 
-/** Find a shape closer while allowing delimiters inside an ASCII quoted label. */
+/**
+ * Find a shape closer while allowing quoted text and balanced delimiters in an
+ * unquoted label (`A[Review (phase 1)]`, `B(Calculate f(x))`, ...).
+ */
 function findCloser(line: string, start: number, closer: string): number {
   let inQuote = false;
+  const nestedClosers: string[] = [];
   for (let i = start; i <= line.length - closer.length; i++) {
     const ch = line[i]!;
     if (ch === '"' && (i === 0 || line[i - 1] !== "\\")) {
       inQuote = !inQuote;
       continue;
     }
-    if (!inQuote && line.startsWith(closer, i)) return i;
+    if (inQuote) continue;
+    if (nestedClosers.length === 0 && line.startsWith(closer, i)) return i;
+    if (ch === "(") nestedClosers.push(")");
+    else if (nestedClosers[nestedClosers.length - 1] === ch) nestedClosers.pop();
   }
   return -1;
 }
@@ -231,8 +245,6 @@ function parseShapeSuffix(
   return null;
 }
 
-const ID_CHAR = /[A-Za-z0-9_-]/;
-
 interface EdgeOp {
   kind: FlowchartEdgeKind;
   bidirectional: boolean;
@@ -334,10 +346,10 @@ function parseEdgeOp(line: string, pos: number): EdgeOp | null {
 
 /** Parse one node reference: identifier + optional shape-suffix. */
 function parseNodeRef(line: string, pos: number): { ref: NodeRef; end: number } | null {
-  let i = pos;
-  while (i < line.length && ID_CHAR.test(line[i]!)) i++;
-  if (i === pos) return null;
-  const id = line.slice(pos, i);
+  const identifier = readIdentifier(line, pos);
+  if (!identifier) return null;
+  const id = identifier.value;
+  const i = identifier.end;
   const shape = parseShapeSuffix(line, i);
   if (shape) {
     return {
@@ -491,7 +503,9 @@ function parseChainStatement(
         throw new FlowchartParseError(
           `expected edge operator, got ${JSON.stringify(tail.slice(0, 10))}`,
           lineNo,
-          pos + 1
+          pos + 1,
+          line,
+          'If this is label text, put it inside the node shape and quote it, for example A["label with spaces (and parentheses)"].'
         );
       }
       break;
@@ -542,11 +556,11 @@ function parseSubgraphHeader(rest: string, idx: number): FlowchartSubgraph {
   if (!s) return { id: defaultId, label: defaultId, children: [], subgraphs: [] };
 
   // id [label]  — Mermaid: `subgraph ide1 [one]`
-  const idBracket = /^(\w[\w-]*)\s+\[([^\]]*)\]$/.exec(s);
+  const idBracket = new RegExp(`^(${IDENTIFIER_SOURCE})\\s+\\[([^\\]]*)\\]$`, "u").exec(s);
   if (idBracket) return { id: idBracket[1]!, label: idBracket[2]!, children: [], subgraphs: [] };
 
   // id "label"
-  const idQuoted = /^(\w[\w-]*)\s+"([^"]*)"$/.exec(s);
+  const idQuoted = new RegExp(`^(${IDENTIFIER_SOURCE})\\s+"([^"]*)"$`, "u").exec(s);
   if (idQuoted) return { id: idQuoted[1]!, label: idQuoted[2]!, children: [], subgraphs: [] };
 
   // "label"  (no explicit id)
@@ -600,7 +614,7 @@ function extractInlineClasses(
   // Greedy left-to-right pass; restart after each substitution because the
   // index landscape changes. The pattern :::name allows hyphens to match
   // Mermaid's `\w[\w-]*` shape.
-  const re = /:::([A-Za-z_][\w-]*)/g;
+  const re = new RegExp(`:::(${IDENTIFIER_SOURCE})`, "gu");
   let m: RegExpExecArray | null;
   // Collect first; rewriting in-place would invalidate `re.lastIndex`.
   const hits: Array<{ start: number; end: number; name: string }> = [];
@@ -632,7 +646,7 @@ function extractInlineClasses(
     // Now walk leftward over the identifier characters.
     const idEnd = cursor;
     let idStart = idEnd;
-    while (idStart > 0 && /[A-Za-z0-9_-]/.test(before[idStart - 1]!)) idStart--;
+    while (idStart > 0 && isIdentifierChar(before[idStart - 1]!)) idStart--;
     if (idStart === idEnd) {
       // No identifier found — leave this `:::name` untouched so the parser
       // reports its native error.
@@ -767,11 +781,27 @@ export function parseFlowchart(source: string): FlowchartAST {
       continue;
     }
 
+    // Mermaid flowcharts have no `note for X` statement (that syntax belongs
+    // to sequence diagrams). Diagnose it explicitly instead of parsing `note`
+    // as a node id and reporting the opaque `expected edge operator: for X`.
+    if (/^note\s+for\s+/i.test(trimmed)) {
+      throw new FlowchartParseError(
+        "flowchart does not support 'note for <node>' statements",
+        i + 1,
+        rawOriginal.toLowerCase().indexOf("note") + 1,
+        rawOriginal,
+        'Put the note inside the target node label, for example F1["Father — Parents are P1 and P2"].'
+      );
+    }
+
     // ── icon statement: `icon A: server` or `icon A server` ──
     // A standalone statement (parallel to `class` / `style`) so it never
     // collides with the `A[label]` shape grammar. Attaches a built-in icon to
     // the node, rendered above its label.
-    const iconMatch = /^icon\s+(\w[\w-]*)\s*:?\s+([\w-]+)\s*$/.exec(trimmed);
+    const iconMatch = new RegExp(
+      `^icon\\s+(${IDENTIFIER_SOURCE})\\s*:?\\s+([\\w-]+)\\s*$`,
+      "u"
+    ).exec(trimmed);
     if (iconMatch) {
       const nid = iconMatch[1]!;
       const iconName = iconMatch[2]!;
@@ -787,10 +817,18 @@ export function parseFlowchart(source: string): FlowchartAST {
     }
 
     // ── class statement: `class A,B className` ───────────────
-    const classMatch = /^class\s+([\w,\s]+?)\s+(\w[\w-]*)\s*$/.exec(trimmed);
+    const classMatch = new RegExp(`^class\\s+(.+?)\\s+(${IDENTIFIER_SOURCE})\\s*$`, "u").exec(trimmed);
     if (classMatch) {
       const idList = classMatch[1]!.split(/[,\s]+/).map((s) => s.trim()).filter((s) => s.length > 0);
       const className = classMatch[2]!;
+      if (!idList.every(isIdentifier)) {
+        throw new FlowchartParseError(
+          "class statement contains an invalid node identifier",
+          i + 1,
+          1,
+          rawOriginal
+        );
+      }
       for (const nid of idList) {
         const existing = nodeMap.get(nid);
         if (!existing) {
@@ -805,7 +843,7 @@ export function parseFlowchart(source: string): FlowchartAST {
     }
 
     // ── classDef: store for future renderer use ──────────────
-    const classDefMatch = /^classDef\s+(\w[\w-]*)\s+(.+)$/.exec(trimmed);
+    const classDefMatch = new RegExp(`^classDef\\s+(${IDENTIFIER_SOURCE})\\s+(.+)$`, "u").exec(trimmed);
     if (classDefMatch) {
       const cdef: FlowchartClassDef = {
         id: classDefMatch[1]!,
@@ -819,7 +857,7 @@ export function parseFlowchart(source: string): FlowchartAST {
     }
 
     // ── style statement: `style nodeId fill:#f9f,...` ────────
-    const styleMatch = /^style\s+(\w[\w-]*)\s+(.+)$/.exec(trimmed);
+    const styleMatch = new RegExp(`^style\\s+(${IDENTIFIER_SOURCE})\\s+(.+)$`, "u").exec(trimmed);
     if (styleMatch) {
       const nid = styleMatch[1]!;
       const props = parseCssProps(styleMatch[2]!);

--- a/src/diagrams/idef0/parser.ts
+++ b/src/diagrams/idef0/parser.ts
@@ -39,6 +39,7 @@ import type {
   IcomRole,
 } from "./types";
 import { ICOM_SIDE } from "./types";
+import { isIdentifier, readIdentifier } from "../../core/identifier";
 
 export class Idef0ParseError extends Error {
   constructor(message: string, public line?: number) {
@@ -135,10 +136,10 @@ export function parseIdef0(text: string): Idef0Ast {
 // ─── Function box ─────────────────────────────────────────────
 
 function parseFunction(ast: Idef0Ast, rest: string, lineNo: number): void {
-  const idM = /^([A-Za-z_]\w*)/.exec(rest);
-  if (!idM) throw new Idef0ParseError(`function needs an id, got "${truncate(rest, 40)}"`, lineNo);
-  const id = idM[1]!;
-  let tail = rest.slice(id.length).trim();
+  const idMatch = readIdentifier(rest);
+  if (!idMatch) throw new Idef0ParseError(`function needs an id, got "${truncate(rest, 40)}"`, lineNo);
+  const id = idMatch.value;
+  let tail = rest.slice(idMatch.end).trim();
 
   let name = id;
   const q = matchQuoted(tail);
@@ -170,10 +171,10 @@ function parseFunction(ast: Idef0Ast, rest: string, lineNo: number): void {
 // ─── ICOM role arrow (one box endpoint + boundary) ────────────
 
 function parseRoleArrow(ast: Idef0Ast, role: IcomRole, rest: string, lineNo: number): void {
-  const idM = /^([A-Za-z_]\w*)/.exec(rest);
-  if (!idM) throw new Idef0ParseError(`${role} needs a box id, got "${truncate(rest, 40)}"`, lineNo);
-  const boxId = idM[1]!;
-  let tail = rest.slice(boxId.length).trim();
+  const idMatch = readIdentifier(rest);
+  if (!idMatch) throw new Idef0ParseError(`${role} needs a box id, got "${truncate(rest, 40)}"`, lineNo);
+  const boxId = idMatch.value;
+  let tail = rest.slice(idMatch.end).trim();
 
   let label = "";
   const q = matchQuoted(tail);
@@ -208,15 +209,16 @@ function parseFlowArrow(ast: Idef0Ast, t: string, lineNo: number): void {
   const lhs = t.slice(0, arrowIdx).trim();
   let rhs = t.slice(arrowIdx + 2).trim();
 
-  const srcM = /^([A-Za-z_]\w*)$/.exec(lhs);
-  if (!srcM) throw new Idef0ParseError(`flow arrow source must be a box id, got "${truncate(lhs, 40)}"`, lineNo);
-  const srcId = srcM[1]!;
+  if (!isIdentifier(lhs)) throw new Idef0ParseError(`flow arrow source must be a box id, got "${truncate(lhs, 40)}"`, lineNo);
+  const srcId = lhs;
 
   // target:  Box  or  Box.role
-  const tgtM = /^([A-Za-z_]\w*)(?:\.([a-z]+))?/i.exec(rhs);
-  if (!tgtM) throw new Idef0ParseError(`flow arrow target must be a box id, got "${truncate(rhs, 40)}"`, lineNo);
-  const tgtId = tgtM[1]!;
-  const roleWord = tgtM[2]?.toLowerCase();
+  const targetId = readIdentifier(rhs);
+  if (!targetId) throw new Idef0ParseError(`flow arrow target must be a box id, got "${truncate(rhs, 40)}"`, lineNo);
+  const tgtId = targetId.value;
+  const afterId = rhs.slice(targetId.end);
+  const roleMatch = /^\s*\.([a-z]+)/i.exec(afterId);
+  const roleWord = roleMatch?.[1]?.toLowerCase();
 
   let role: IcomRole = "input"; // default: a flow lands on the target's input
   if (roleWord) {
@@ -235,7 +237,7 @@ function parseFlowArrow(ast: Idef0Ast, t: string, lineNo: number): void {
     role = roleWord as IcomRole;
   }
 
-  rhs = rhs.slice(tgtM[0].length).trim();
+  rhs = afterId.slice(roleMatch?.[0].length ?? 0).trim();
   let label = "";
   const q = matchQuoted(rhs);
   if (q) {

--- a/src/diagrams/logic/parser.ts
+++ b/src/diagrams/logic/parser.ts
@@ -7,7 +7,21 @@ import type {
   LogicGateStyle,
   LogicGateModule,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE } from "../../core/identifier";
 import { matchQuotedTitle } from "../../core/quotes";
+
+const MODULE_OPEN_RE = new RegExp(
+  `^module\\s+(?:"([^"]+)"|(${IDENTIFIER_SOURCE}))\\s*\\{$`,
+  "u"
+);
+const OUTPUT_ASSIGN_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\s*<-\\s*(${IDENTIFIER_SOURCE})$`,
+  "u"
+);
+const GATE_DECL_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\s*=\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^)]*)\\)$`,
+  "u"
+);
 
 export class LogicParseError extends Error {
   constructor(message: string) {
@@ -61,7 +75,7 @@ export function parseLogic(text: string): LogicGateAST {
     if (!line) continue;
 
     // module "Label" {   or  module Label {
-    const modOpen = line.match(/^module\s+(?:"([^"]+)"|([a-zA-Z_][\w]*))\s*\{$/);
+    const modOpen = line.match(MODULE_OPEN_RE);
     if (modOpen) {
       const label = modOpen[1] ?? modOpen[2];
       const id = `mod_${moduleCounter++}`;
@@ -109,14 +123,14 @@ export function parseLogic(text: string): LogicGateAST {
     }
 
     // OUTPUT <- GATE  (map output to gate)
-    const assignMatch = line.match(/^([a-zA-Z_][\w]*)\s*<-\s*([a-zA-Z_][\w]*)$/);
+    const assignMatch = line.match(OUTPUT_ASSIGN_RE);
     if (assignMatch) {
       explicitOutputFrom.set(assignMatch[1], assignMatch[2]);
       continue;
     }
 
     // Gate: ID = GATE(a, b, ...)
-    const gateMatch = line.match(/^([a-zA-Z_][\w]*)\s*=\s*([A-Za-z_][\w]*)\s*\(([^)]*)\)$/);
+    const gateMatch = line.match(GATE_DECL_RE);
     if (gateMatch) {
       const id = gateMatch[1];
       const rawType = gateMatch[2].toUpperCase();

--- a/src/diagrams/orgchart/parser.ts
+++ b/src/diagrams/orgchart/parser.ts
@@ -7,6 +7,7 @@ import type {
   OrgchartNodeKind,
   OrgchartRoleIcon,
 } from "./types";
+import { isIdentifier } from "../../core/identifier";
 import { matchQuotedTitle } from "../../core/quotes";
 import { createSourceLocator, findFirstQuotedRange } from "../../core/source-range";
 
@@ -175,7 +176,7 @@ function parseNodeLine(line: string): {
   const colonIdx = rest.indexOf(":");
   if (colonIdx < 0) return null;
   const id = rest.slice(0, colonIdx).trim();
-  if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(id)) return null;
+  if (!isIdentifier(id)) return null;
 
   const tailRaw = rest.slice(colonIdx + 1);
   const tailLeading = tailRaw.length - tailRaw.trimStart().length;
@@ -297,7 +298,7 @@ export function parseOrgchart(text: string): OrgchartAST {
       if (idx < 0) continue;
       const left = line.slice(0, idx).trim();
       let rest = line.slice(idx + token.length).trim();
-      if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(left)) break;
+      if (!isIdentifier(left)) break;
       let props: Record<string, string> = {};
       const propsMatch = rest.match(/\[([^\]]*)\]\s*$/);
       if (propsMatch) {
@@ -305,7 +306,7 @@ export function parseOrgchart(text: string): OrgchartAST {
         rest = rest.slice(0, rest.length - propsMatch[0].length).trim();
       }
       const to = rest.split(/\s+/)[0];
-      if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(to)) break;
+      if (!isIdentifier(to)) break;
       const edge: OrgchartEdge = { from: left, to, kind };
       if (props.label) edge.label = props.label;
       edges.push(edge);

--- a/src/diagrams/pedigree/parser.ts
+++ b/src/diagrams/pedigree/parser.ts
@@ -9,6 +9,7 @@ import type {
   LegendEntry,
   ConditionFill,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
 import { parseLegendDirective } from "../../core/legend-parser";
 
 // ─── ParseError ─────────────────────────────────────────────
@@ -40,6 +41,15 @@ const GENETIC_STATUSES = new Set([
 ]);
 const MARKERS = new Set(["proband", "consultand", "evaluated"]);
 const VALID_STATUS = new Set(["deceased", "stillborn", "pregnancy", "sab", "tab", "ectopic"]);
+const LEGEND_ENTRY_RE = new RegExp(
+  `^legend:\\s*(${IDENTIFIER_SOURCE})\\s*=\\s*"([^"]*)"\\s*(?:\\(\\s*fill:\\s*([a-zA-Z-]+)\\s*\\))?$`,
+  "u"
+);
+const NUMERIC_PEDIGREE_ID_RE = /^\d+(?:\.\d+)+$/;
+
+function isPedigreeIdentifier(value: string): boolean {
+  return isIdentifier(value) || NUMERIC_PEDIGREE_ID_RE.test(value);
+}
 
 // ─── Public API ────────────────────────────────────────────
 
@@ -64,7 +74,7 @@ export function parsePedigree(text: string): DiagramAST {
   // The `:mode` suffix is captured into metadata so future renderers can
   // act on it (taxonomy mode, etc.); ignored downstream if unsupported.
   const headerMatch = headerLine.match(
-    /^pedigree(?::([a-zA-Z][\w-]*))?\s*(?:"([^"]*)")?\s*$/i
+    new RegExp(`^pedigree(?::(${IDENTIFIER_SOURCE}))?\\s*(?:"([^"]*)")?\\s*$`, "iu")
   );
   if (!headerMatch) {
     throw new PedigreeParseError(
@@ -104,9 +114,7 @@ export function parsePedigree(text: string): DiagramAST {
     }
 
     // Legend definition (legacy trait-fill DSL).
-    const legendMatch = trimmed.match(
-      /^legend:\s*([a-zA-Z][a-zA-Z0-9_-]*)\s*=\s*"([^"]*)"\s*(?:\(\s*fill:\s*([a-zA-Z-]+)\s*\))?$/
-    );
+    const legendMatch = trimmed.match(LEGEND_ENTRY_RE);
     if (legendMatch) {
       legend.push({
         id: legendMatch[1],
@@ -123,7 +131,7 @@ export function parsePedigree(text: string): DiagramAST {
       const { leftId, op, rightRaw } = coupleMatch;
       const lineNum = i + 1;
 
-      const { id: rightId, propsStr: rightProps } = parseIdWithProps(rightRaw);
+      const { id: rightId, propsStr: rightProps } = parseIdWithProps(rightRaw, lineNum);
       const leftKey = leftId.toLowerCase();
       const rightKey = rightId.toLowerCase();
 
@@ -155,7 +163,7 @@ export function parsePedigree(text: string): DiagramAST {
         if (leadingSpaces(childLine) <= coupleIndent) break;
 
         const childLineNum = i + 1;
-        const { id: childId, propsStr } = parseIdWithProps(childTrimmed);
+        const { id: childId, propsStr } = parseIdWithProps(childTrimmed, childLineNum);
         const childKey = childId.toLowerCase();
 
         individualsMap.set(childKey, buildIndividual(childId, propsStr, childLineNum));
@@ -169,7 +177,7 @@ export function parsePedigree(text: string): DiagramAST {
     }
 
     // Individual definition
-    const { id, propsStr } = parseIdWithProps(trimmed);
+    const { id, propsStr } = parseIdWithProps(trimmed, i + 1);
     const key = id.toLowerCase();
     const ind = buildIndividual(id, propsStr, i + 1);
     const existing = individualsMap.get(key);
@@ -209,7 +217,7 @@ function detectCoupleOp(trimmed: string): { leftId: string; op: typeof COUPLE_OP
       if (trimmed.substring(j, j + op.token.length) === op.token) {
         const left = trimmed.substring(0, j).trim();
         const right = trimmed.substring(j + op.token.length).trim();
-        if (left && right && /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(left)) {
+        if (left && right && isPedigreeIdentifier(left)) {
           return { leftId: left, op, rightRaw: right };
         }
       }
@@ -218,10 +226,15 @@ function detectCoupleOp(trimmed: string): { leftId: string; op: typeof COUPLE_OP
   return null;
 }
 
-function parseIdWithProps(raw: string): { id: string; propsStr: string | null } {
+function parseIdWithProps(raw: string, lineNumber: number): { id: string; propsStr: string | null } {
   const bracketIdx = raw.indexOf("[");
-  if (bracketIdx === -1) return { id: raw.trim(), propsStr: null };
+  if (bracketIdx === -1) {
+    const id = raw.trim();
+    if (!isPedigreeIdentifier(id)) throw new PedigreeParseError(`Invalid individual id '${id}'`, lineNumber);
+    return { id, propsStr: null };
+  }
   const id = raw.substring(0, bracketIdx).trim();
+  if (!isPedigreeIdentifier(id)) throw new PedigreeParseError(`Invalid individual id '${id}'`, lineNumber);
   const endBracket = raw.lastIndexOf("]");
   const propsStr = raw.substring(bracketIdx + 1, endBracket === -1 ? raw.length : endBracket);
   return { id, propsStr };

--- a/src/diagrams/pert/parser.ts
+++ b/src/diagrams/pert/parser.ts
@@ -23,6 +23,12 @@ import type {
   PertThreePoint,
   PertUnit,
 } from "./types";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
+
+const ATTACHED_DEP_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\+(\\d+(?:\\.\\d+)?)([dwh])?$`,
+  "u"
+);
 
 export class PertParseError extends Error {
   line?: number;
@@ -235,14 +241,14 @@ function parseDepRef(raw: string, unit: PertUnit, lineNo: number): PertDependenc
   }
 
   // Form 2: <id>+<lag>[<unit>]  (attached FS lag sugar; only '+' to avoid dash-id ambiguity)
-  const attached = ref.match(/^([A-Za-z_][\w-]*)\+(\d+(?:\.\d+)?)([dwh])?$/);
+  const attached = ref.match(ATTACHED_DEP_RE);
   if (attached) {
     checkUnit(attached[3]?.toLowerCase());
     return { pred: attached[1], type: "FS", lag: Number(attached[2]) };
   }
 
   // Form 3: bare id (FS, zero lag)
-  if (/^[A-Za-z_][\w-]*$/.test(ref)) {
+  if (isIdentifier(ref)) {
     return { pred: ref, type: "FS", lag: 0 };
   }
 
@@ -259,8 +265,8 @@ function parseTaskLine(ln: RawLine, ast: PertAst): void {
     throw new PertParseError(`malformed task line: ${ln.text}`, ln.line);
   }
   const id = head[1];
-  if (!/^[A-Za-z_][\w-]*$/.test(id)) {
-    throw new PertParseError(`invalid task id '${id}' (letters, digits, dashes, underscores; must start with a letter or _)`, ln.line);
+  if (!isIdentifier(id)) {
+    throw new PertParseError(`invalid task id '${id}' (Unicode letters/digits, dashes, underscores; must start with a letter, digit, or _)`, ln.line);
   }
   let rest = head[2].trim();
 

--- a/src/diagrams/pid/parser.ts
+++ b/src/diagrams/pid/parser.ts
@@ -9,7 +9,21 @@ import type {
   PidLine,
   PidLineType,
 } from "./types";
+import { IDENTIFIER_SOURCE } from "../../core/identifier";
 import { createSourceLocator } from "../../core/source-range";
+
+const EQUIPMENT_DECL_RE = new RegExp(
+  `^equip\\s+(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`,
+  "u"
+);
+const LINE_DECL_RE = new RegExp(
+  `^line\\s+(${IDENTIFIER_SOURCE})\\s+from\\s+(\\S+)\\s+to\\s+(\\S+)\\s*(.*)$`,
+  "u"
+);
+const INSTRUMENT_DECL_RE = new RegExp(
+  `^inst\\s+(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`,
+  "u"
+);
 
 export class PidParseError extends Error {
   constructor(message: string, public line?: number) {
@@ -228,7 +242,7 @@ export function parsePid(src: string): PidAST {
     currentInst = undefined;
 
     // ── equip ID : type [attrs] ───────────────────────────
-    const equipMatch = text.match(/^equip\s+([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.+)$/);
+    const equipMatch = text.match(EQUIPMENT_DECL_RE);
     if (equipMatch) {
       const id = equipMatch[1];
       const tail = equipMatch[2];
@@ -251,7 +265,7 @@ export function parsePid(src: string): PidAST {
     }
 
     // ── line ID from X.port to Y.port [attrs] ─────────────
-    const lineMatch = text.match(/^line\s+([A-Za-z0-9_-]+)\s+from\s+(\S+)\s+to\s+(\S+)\s*(.*)$/);
+    const lineMatch = text.match(LINE_DECL_RE);
     if (lineMatch) {
       const id = lineMatch[1];
       const fromTok = lineMatch[2];
@@ -280,7 +294,7 @@ export function parsePid(src: string): PidAST {
     // The tag accepts ISA loop tags with OR without a dash (`FT-101`, `PLC`,
     // `XV101`) — LLMs frequently emit dashless tags, and rejecting them blanked
     // the whole diagram.
-    const instMatch = text.match(/^inst\s+([A-Za-z][A-Za-z0-9]*(?:-[A-Za-z0-9]+)?)\s*:\s*(.+)$/);
+    const instMatch = text.match(INSTRUMENT_DECL_RE);
     if (instMatch) {
       const tag = instMatch[1];
       const { rest: catRest, attrs } = extractAttrs(instMatch[2]);

--- a/src/diagrams/sfc/parser.ts
+++ b/src/diagrams/sfc/parser.ts
@@ -22,7 +22,38 @@ import type {
   SfcVarDecl,
   SfcVarType,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE } from "../../core/identifier";
 import { matchQuotedTitle } from "../../core/quotes";
+
+const VAR_DECL_RE = new RegExp(
+  `^var\\s+(${IDENTIFIER_SOURCE})\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*(?:=\\s*(.+))?$`,
+  "iu"
+);
+const STEP_HEAD_RE = new RegExp(
+  `^step\\s+(${IDENTIFIER_SOURCE})\\s*(\\[[^\\]]*\\])?\\s*$`,
+  "u"
+);
+const TRANSITION_RE = new RegExp(
+  `^transition(?:\\s+(${IDENTIFIER_SOURCE}))?\\s+from\\s*:\\s*(${IDENTIFIER_SOURCE})\\s+to\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`,
+  "u"
+);
+const ALT_HEAD_RE = new RegExp(
+  `^alt\\s+from\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*:\\s*$`,
+  "u"
+);
+const MERGE_RE = new RegExp(`^merge_to\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*$`, "u");
+const SIM_HEAD_RE = new RegExp(
+  `^sim\\s+from\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`,
+  "u"
+);
+const SIM_MERGE_RE = new RegExp(
+  `^merge_to\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`,
+  "u"
+);
+const JUMP_RE = new RegExp(
+  `^jump\\s+from\\s*:\\s*(${IDENTIFIER_SOURCE})\\s+to\\s*:\\s*(${IDENTIFIER_SOURCE})\\s*$`,
+  "u"
+);
 
 export class SfcParseError extends Error {
   line?: number;
@@ -76,7 +107,7 @@ function tokenizeLines(text: string): RawLine[] {
 }
 
 function parseVarDecl(line: RawLine): SfcVarDecl | null {
-  const m = line.text.match(/^var\s+([a-zA-Z_]\w*)\s*:\s*([a-zA-Z_]\w*)\s*(?:=\s*(.+))?$/i);
+  const m = line.text.match(VAR_DECL_RE);
   if (!m) return null;
   const dt = m[2].toLowerCase();
   const decl: SfcVarDecl = {
@@ -102,7 +133,7 @@ interface ParseState {
 }
 
 function parseStepHead(line: RawLine): { id: string; kind: SfcStepKind; label?: string } | null {
-  const m = line.text.match(/^step\s+([a-zA-Z_]\w*)\s*(\[[^\]]*\])?\s*$/);
+  const m = line.text.match(STEP_HEAD_RE);
   if (!m) return null;
   const attrs = parseAttrs(m[2]);
   let kind: SfcStepKind = "normal";
@@ -198,7 +229,7 @@ function expectStep(state: ParseState, indent: number): SfcStep | null {
 
 function parseTransitionLine(line: RawLine): SfcTransition | null {
   // transition [id] from: A to: B: condition
-  const m = line.text.match(/^transition(?:\s+([a-zA-Z_]\w*))?\s+from\s*:\s*([a-zA-Z_]\w*)\s+to\s*:\s*([a-zA-Z_]\w*)\s*:\s*(.+)$/);
+  const m = line.text.match(TRANSITION_RE);
   if (!m) return null;
   const t: SfcTransition = {
     from: m[2],
@@ -213,7 +244,7 @@ function parseAltBlock(state: ParseState, indent: number): SfcNode | null {
   if (state.i >= state.lines.length) return null;
   const head = state.lines[state.i];
   if (head.indent !== indent) return null;
-  const m = head.text.match(/^alt\s+from\s*:\s*([a-zA-Z_]\w*)\s*:\s*$/);
+  const m = head.text.match(ALT_HEAD_RE);
   if (!m) return null;
   state.i++;
 
@@ -271,7 +302,7 @@ function parseAltBlock(state: ParseState, indent: number): SfcNode | null {
     throw new SfcParseError(`alt block missing merge_to clause`, head.lineNo, head.text);
   }
   const mergeLine = state.lines[state.i];
-  const mm = mergeLine.text.match(/^merge_to\s*:\s*([a-zA-Z_]\w*)\s*$/);
+  const mm = mergeLine.text.match(MERGE_RE);
   if (!mm) {
     throw new SfcParseError(`Expected "merge_to: STEP" (got: ${mergeLine.text})`, mergeLine.lineNo, mergeLine.text);
   }
@@ -283,7 +314,7 @@ function parseSimBlock(state: ParseState, indent: number): SfcNode | null {
   if (state.i >= state.lines.length) return null;
   const head = state.lines[state.i];
   if (head.indent !== indent) return null;
-  const m = head.text.match(/^sim\s+from\s*:\s*([a-zA-Z_]\w*)\s*:\s*(.+)$/);
+  const m = head.text.match(SIM_HEAD_RE);
   if (!m) return null;
   const condition = m[2].trim();
   state.i++;
@@ -319,7 +350,7 @@ function parseSimBlock(state: ParseState, indent: number): SfcNode | null {
     throw new SfcParseError(`sim block missing merge_to clause`, head.lineNo, head.text);
   }
   const mergeLine = state.lines[state.i];
-  const mm = mergeLine.text.match(/^merge_to\s*:\s*([a-zA-Z_]\w*)\s*:\s*(.+)$/);
+  const mm = mergeLine.text.match(SIM_MERGE_RE);
   if (!mm) {
     throw new SfcParseError(`Expected "merge_to: STEP: condition" (got: ${mergeLine.text})`, mergeLine.lineNo, mergeLine.text);
   }
@@ -382,7 +413,7 @@ export function parseSfc(text: string): SfcAst {
       continue;
     }
     // jump
-    const jm = ln.text.match(/^jump\s+from\s*:\s*([a-zA-Z_]\w*)\s+to\s*:\s*([a-zA-Z_]\w*)\s*$/);
+    const jm = ln.text.match(JUMP_RE);
     if (jm) {
       // Treat as a transition with TRUE condition; no special node type for v0.1.
       state.transitions.push({

--- a/src/diagrams/sociogram/parser.ts
+++ b/src/diagrams/sociogram/parser.ts
@@ -1,4 +1,5 @@
 import { parseLegendDirective } from "../../core/legend-parser";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
 import { matchQuotedTitle } from "../../core/quotes";
 
 export class SociogramParseError extends Error {
@@ -96,10 +97,10 @@ function findEdgeOp(line: string): { leftId: string; rightId: string; op: EdgeOp
     const leftId = line.slice(0, idx).trim();
     const afterOp = line.slice(idx + opStr.length + 2).trim();
 
-    if (!leftId || !/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(leftId)) continue;
+    if (!leftId || !isIdentifier(leftId)) continue;
 
     // Right side: ID [props]
-    const rightMatch = afterOp.match(/^([a-zA-Z][a-zA-Z0-9_-]*)(.*)/);
+    const rightMatch = afterOp.match(new RegExp(`^(${IDENTIFIER_SOURCE})(.*)`, "u"));
     if (!rightMatch) continue;
 
     const rightId = rightMatch[1];
@@ -114,7 +115,9 @@ function findEdgeOp(line: string): { leftId: string; rightId: string; op: EdgeOp
   }
 
   // Try -.> which has the dot embedded
-  const dashDotMatch = line.match(/^([a-zA-Z][a-zA-Z0-9_-]*)\s+-\.>\s+([a-zA-Z][a-zA-Z0-9_-]*)(.*)/);
+  const dashDotMatch = line.match(
+    new RegExp(`^(${IDENTIFIER_SOURCE})\\s+-\\.>\\s+(${IDENTIFIER_SOURCE})(.*)`, "u")
+  );
   if (dashDotMatch) {
     return {
       leftId: dashDotMatch[1],
@@ -245,7 +248,7 @@ export function parseSociogram(text: string): SociogramAST {
     if (currentGroup && indent >= 4) {
       const { clean, props } = extractProps(trimmed);
       const memberId = clean.split(/\s/)[0];
-      if (memberId && /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(memberId)) {
+      if (memberId && isIdentifier(memberId)) {
         currentGroup.members.push(memberId);
         if (!nodeIds.has(memberId)) {
           nodeIds.add(memberId);
@@ -295,7 +298,7 @@ export function parseSociogram(text: string): SociogramAST {
     // Node definition: ID [props]
     const { clean, props } = extractProps(trimmed);
     const nodeId = clean.split(/\s/)[0];
-    if (nodeId && /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(nodeId) && !nodeIds.has(nodeId)) {
+    if (nodeId && isIdentifier(nodeId) && !nodeIds.has(nodeId)) {
       nodeIds.add(nodeId);
       const node: SociogramNode = {
         id: nodeId,

--- a/src/diagrams/state/parser.ts
+++ b/src/diagrams/state/parser.ts
@@ -7,7 +7,44 @@ import type {
   StateNote,
   StateTransition,
 } from "./types";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
 import { createSourceLocator } from "../../core/source-range";
+
+const COMPOSITE_RE = new RegExp(
+  `^(?:composite|state)\\s+(${IDENTIFIER_SOURCE})\\s*\\{?\\s*$`,
+  "u"
+);
+const ALIAS_RE = new RegExp(
+  `^state\\s+"([^"]*)"\\s+as\\s+(${IDENTIFIER_SOURCE})\\s*$`,
+  "u"
+);
+const STEREOTYPE_RE = new RegExp(
+  `^state\\s+(${IDENTIFIER_SOURCE})\\s+<<\\s*(choice|fork|join|end)\\s*>>\\s*$`,
+  "u"
+);
+const STATE_LABEL_RE = new RegExp(`^state\\s+(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`, "u");
+const PSEUDO_RE = new RegExp(
+  `^(initial|final|choice|junction|fork|join|history|dhistory|terminate|entry_point|exit_point)\\s+(${IDENTIFIER_SOURCE})\\s*$`,
+  "u"
+);
+const NOTE_LINE_RE = new RegExp(
+  `^note\\s+(left[_ ]of|right[_ ]of)\\s+(${IDENTIFIER_SOURCE})\\s*:\\s*(.*)$`,
+  "u"
+);
+const NOTE_MERMAID_RE = new RegExp(
+  `^note\\s+(left[_ ]of|right[_ ]of)\\s+(${IDENTIFIER_SOURCE})\\s*$`,
+  "u"
+);
+const NOTE_BLOCK_RE = new RegExp(
+  `^note\\s+(left[_ ]of\\s+|right[_ ]of\\s+)?(${IDENTIFIER_SOURCE})\\s*\\{\\s*$`,
+  "u"
+);
+const TRANSITION_RE = new RegExp(
+  `^(\\[\\*\\]|${IDENTIFIER_SOURCE})\\s*-+>\\s*(\\[\\*\\]|${IDENTIFIER_SOURCE})\\s*(?::\\s*(.*))?$`,
+  "u"
+);
+const LABEL_ONLY_RE = new RegExp(`^(${IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`, "u");
+const BARE_IDENTIFIER_RE = new RegExp(`^(${IDENTIFIER_SOURCE})\\s*$`, "u");
 
 export class StateParseError extends Error {
   constructor(message: string, public line?: number) {
@@ -257,7 +294,7 @@ function ensureSimpleState(
 }
 
 function isIdent(tok: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(tok);
+  return isIdentifier(tok);
 }
 
 /**
@@ -374,7 +411,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── Composite definition: composite IDENT {  OR  state IDENT { (Mermaid) ──
-    const compMatch = text.match(/^(?:composite|state)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{?\s*$/);
+    const compMatch = text.match(COMPOSITE_RE);
     const isCompositeWithBrace = compMatch && text.endsWith("{");
     if (isCompositeWithBrace) {
       const id = compMatch![1];
@@ -386,7 +423,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── Mermaid alias: `state "Long name" as ID` ──
-    const aliasMatch = text.match(/^state\s+"([^"]*)"\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\s*$/);
+    const aliasMatch = text.match(ALIAS_RE);
     if (aliasMatch) {
       const node = ensureSimpleState(ctx, aliasMatch[2], parent);
       node.label = aliasMatch[1];
@@ -398,7 +435,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── Mermaid stereotype: `state ID <<choice>>` / `<<fork>>` / `<<join>>` / `<<end>>` ──
-    const stereoMatch = text.match(/^state\s+([A-Za-z_][A-Za-z0-9_]*)\s+<<\s*(choice|fork|join|end)\s*>>\s*$/);
+    const stereoMatch = text.match(STEREOTYPE_RE);
     if (stereoMatch) {
       const id = stereoMatch[1];
       const kind = MERMAID_STEREOTYPE[stereoMatch[2]];
@@ -419,7 +456,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── `state ID : description` (Mermaid declares + labels) ──
-    const stateLabelMatch = text.match(/^state\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+)$/);
+    const stateLabelMatch = text.match(STATE_LABEL_RE);
     if (stateLabelMatch) {
       const node = ensureSimpleState(ctx, stateLabelMatch[1], parent);
       const token = stateLabelMatch[2].trim();
@@ -431,9 +468,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── Schematex pseudo-state declaration: initial X / fork F / etc. ──
-    const pseudoMatch = text.match(
-      /^(initial|final|choice|junction|fork|join|history|dhistory|terminate|entry_point|exit_point)\s+([A-Za-z_][A-Za-z0-9_]*)\s*$/
-    );
+    const pseudoMatch = text.match(PSEUDO_RE);
     if (pseudoMatch) {
       const kindKw = pseudoMatch[1];
       const id = pseudoMatch[2];
@@ -466,9 +501,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
 
     // ── Notes ──
     // Single-line: `note right_of X : text`  /  `note right of X : text`
-    const noteSimple = text.match(
-      /^note\s+(left[_ ]of|right[_ ]of)\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/
-    );
+    const noteSimple = text.match(NOTE_LINE_RE);
     if (noteSimple) {
       const side = noteSimple[1].startsWith("left") ? "left" : "right";
       const target = noteSimple[2];
@@ -485,9 +518,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     // Block forms:
     //  Schematex:  note X { ... } or note left_of X { ... }
     //  Mermaid:    note right of X \n ... \n end note
-    const noteBlockMermaid = text.match(
-      /^note\s+(left[_ ]of|right[_ ]of)\s+([A-Za-z_][A-Za-z0-9_]*)\s*$/
-    );
+    const noteBlockMermaid = text.match(NOTE_MERMAID_RE);
     if (noteBlockMermaid) {
       const side = noteBlockMermaid[1].startsWith("left") ? "left" : "right";
       const target = noteBlockMermaid[2];
@@ -512,9 +543,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
       });
       continue;
     }
-    const noteBlockSchematex = text.match(
-      /^note\s+(left[_ ]of\s+|right[_ ]of\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\{\s*$/
-    );
+    const noteBlockSchematex = text.match(NOTE_BLOCK_RE);
     if (noteBlockSchematex) {
       const side = noteBlockSchematex[1]?.startsWith("left") ? "left" : "right";
       const target = noteBlockSchematex[2];
@@ -539,9 +568,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── Transition: A -> B [: label]  OR Mermaid `A --> B [: label]` ──
-    const transMatch = text.match(
-      /^(\[\*\]|[A-Za-z_][A-Za-z0-9_]*)\s*-+>\s*(\[\*\]|[A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*(.*))?$/
-    );
+    const transMatch = text.match(TRANSITION_RE);
     if (transMatch) {
       const fromTok = transMatch[1];
       const toTok = transMatch[2];
@@ -584,7 +611,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── Mermaid `Foo: description` to label an existing/new state ──
-    const labelOnlyMatch = text.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+)$/);
+    const labelOnlyMatch = text.match(LABEL_ONLY_RE);
     if (labelOnlyMatch && isIdent(labelOnlyMatch[1])) {
       const node = ensureSimpleState(ctx, labelOnlyMatch[1], parent);
       const token = labelOnlyMatch[2].trim();
@@ -596,7 +623,7 @@ export function parseStateDiagram(src: string): StateDiagramAST {
     }
 
     // ── Bare state declaration: `IDENT` ──
-    const bareIdent = text.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*$/);
+    const bareIdent = text.match(BARE_IDENTIFIER_RE);
     if (bareIdent) {
       ensureSimpleState(ctx, bareIdent[1], parent);
       i++;

--- a/src/diagrams/timeline/index.ts
+++ b/src/diagrams/timeline/index.ts
@@ -1,4 +1,5 @@
 import type { DiagramPlugin, RenderConfig } from "../../core/types";
+import type { SchematexDiagnostic } from "../../core/diagnostics";
 import { parseTimeline } from "./parser";
 import { renderTimeline } from "./renderer";
 
@@ -11,6 +12,20 @@ export const timeline: DiagramPlugin = {
   parse: parseTimeline,
   render(text, config?: RenderConfig) {
     return renderTimeline(text, config);
+  },
+  lint(text: string): SchematexDiagnostic[] {
+    try {
+      return (parseTimeline(text).warnings ?? []).map((warning) => ({
+        severity: "warning",
+        code: "timeline/undated-entry",
+        message: warning.message,
+        line: warning.line,
+        hint: `Add a date before the colon, or keep the entry undated.`,
+        fatal: false,
+      }));
+    } catch {
+      return [];
+    }
   },
 };
 

--- a/src/diagrams/timeline/parser.ts
+++ b/src/diagrams/timeline/parser.ts
@@ -317,6 +317,7 @@ export function parseTimeline(src: string): TimelineAST {
         if (!parsed) throw new TimelineParseError(`Unrecognized line in ${keyword}: ${child.text}`, child.line);
         parsed.event.trackId = trackId;
         ast.events.push(parsed.event);
+        if (parsed.warning) (ast.warnings ??= []).push(parsed.warning);
         i++;
         if (i < lines.length && /^note\s*:/i.test(lines[i]!.text) && lines[i]!.indent > child.indent) {
           const noteBody = lines[i]!.text.replace(/^note\s*:\s*/i, "");
@@ -332,6 +333,7 @@ export function parseTimeline(src: string): TimelineAST {
     const parsed = parseEventLine(text, L.line, nextId, ordinal, L.start, locator.range);
     if (parsed) {
       ast.events.push(parsed.event);
+      if (parsed.warning) (ast.warnings ??= []).push(parsed.warning);
       i++;
       // Optional note block on next line (indented)
       if (i < lines.length && /^note\s*:/i.test(lines[i]!.text) && lines[i]!.indent > L.indent) {
@@ -422,7 +424,11 @@ function parseEventLine(
   ordinal: { index: number },
   sourceStart?: number,
   locate?: (start: number, end: number) => import("../../core/types").SourceRange,
-): { event: TimelineEvent; hasNote: boolean } | null {
+): {
+  event: TimelineEvent;
+  hasNote: boolean;
+  warning?: { line: number; message: string };
+} | null {
   const { props, rest } = parseProperties(text, line);
   const split = splitDateAndBody(rest, line);
   const { date, end, body } = split;
@@ -433,6 +439,30 @@ function parseEventLine(
   //   "label"
   let kind: "point" | "range" | "milestone" = end ? "range" : "point";
   let bodyS = body.trim();
+  if (bodyS === "") {
+    ordinal.index += 1;
+    return {
+      event: {
+        id: nextId("ev"),
+        label: date,
+        kind: "point",
+        start: {
+          value: ordinal.index,
+          raw: "",
+          precision: "ordinal",
+        },
+        icon: props["icon"],
+        shape: props["shape"] as TimelineEventShape | undefined,
+        color: props["color"],
+        category: props["category"],
+      },
+      hasNote: false,
+      warning: {
+        line,
+        message: `Timeline entry "${date}" has no date/value after ':'. Rendered as an undated entry.`,
+      },
+    };
+  }
   if (/^milestone\b/i.test(bodyS)) {
     kind = "milestone";
     bodyS = bodyS.replace(/^milestone\s+/i, "");

--- a/src/diagrams/timeline/types.ts
+++ b/src/diagrams/timeline/types.ts
@@ -79,6 +79,11 @@ export interface TimelineTrack {
   label: string;
 }
 
+export interface TimelineWarning {
+  line: number;
+  message: string;
+}
+
 export interface TimelineAST {
   type: "timeline";
   title?: string;
@@ -91,6 +96,7 @@ export interface TimelineAST {
   eras: TimelineEra[];
   /** Explicit (named) tracks. Auto-packed events get synthesized ids. */
   tracks: TimelineTrack[];
+  warnings?: TimelineWarning[];
   metadata?: Record<string, string>;
 }
 

--- a/src/diagrams/umlclass/parser.ts
+++ b/src/diagrams/umlclass/parser.ts
@@ -21,7 +21,29 @@ import type {
   UmlClassVisibility,
 } from "./types";
 import type { SourceRange } from "../../core/types";
+import {
+  QUALIFIED_IDENTIFIER_SOURCE,
+  isQualifiedIdentifier,
+  readQualifiedIdentifier,
+} from "../../core/identifier";
 import { createSourceLocator } from "../../core/source-range";
+
+const CLASSIFIER_ALIAS_TOKEN_RE = new RegExp(
+  `\\bas\\s+("[^"]+"|${QUALIFIED_IDENTIFIER_SOURCE})`,
+  "iu"
+);
+const CLASSIFIER_ID_PREFIX_RE = new RegExp(
+  `^(${QUALIFIED_IDENTIFIER_SOURCE})`,
+  "u"
+);
+const CLASSIFIER_ALIAS_RE = new RegExp(
+  `^as\\s+(?:"([^"]+)"|(${QUALIFIED_IDENTIFIER_SOURCE}))`,
+  "iu"
+);
+const MEMBER_LINE_RE = new RegExp(
+  `^(${QUALIFIED_IDENTIFIER_SOURCE})\\s*:\\s*(.+)$`,
+  "u"
+);
 
 export class UmlClassParseError extends Error {
   constructor(message: string, public line?: number) {
@@ -221,7 +243,7 @@ export function parseUmlClass(text: string): UmlClassAst {
 }
 
 function classifierDisplayToken(line: string): { token: string; innerStart: number; innerEnd: number } | undefined {
-  const alias = /\bas\s+("[^"]+"|[A-Za-z_][\w.]*)/i.exec(line);
+  const alias = CLASSIFIER_ALIAS_TOKEN_RE.exec(line);
   if (alias) {
     const token = alias[1]!;
     return token.startsWith('"')
@@ -316,7 +338,7 @@ function tryParseClassifierHeader(line: string, lineNo: number): UmlClassClassif
     name = q.value;
     rest = rest.slice(q.length).trim();
   } else {
-    const idMatch = /^([A-Za-z_][\w.]*)/.exec(rest);
+    const idMatch = CLASSIFIER_ID_PREFIX_RE.exec(rest);
     if (!idMatch) {
       throw new UmlClassParseError(`expected classifier name`, lineNo);
     }
@@ -344,7 +366,7 @@ function tryParseClassifierHeader(line: string, lineNo: number): UmlClassClassif
   }
 
   // Optional `as Alias` — alias becomes the *display* name; id stays for refs.
-  const aliasMatch = /^as\s+(?:"([^"]+)"|([A-Za-z_][\w.]*))/i.exec(rest);
+  const aliasMatch = CLASSIFIER_ALIAS_RE.exec(rest);
   if (aliasMatch) {
     name = aliasMatch[1] ?? aliasMatch[2] ?? name;
     rest = rest.slice(aliasMatch[0].length).trim();
@@ -407,10 +429,10 @@ function parseNamespaceHeader(line: string): { name: string; label?: string } {
     return { name, ...(label ? { label } : {}) };
   }
   // Quoted label form: Name "Label".
-  const nameMatch = /^([A-Za-z_][\w.]*)/.exec(rest);
+  const nameMatch = readQualifiedIdentifier(rest);
   if (nameMatch) {
-    const name = nameMatch[0];
-    const tail = rest.slice(name.length).trim();
+    const name = nameMatch.value;
+    const tail = rest.slice(nameMatch.end).trim();
     const q = matchQuoted(tail);
     if (q) return { name, label: q.value };
     return { name };
@@ -443,7 +465,7 @@ function assignToPackage(ast: UmlClassAst, pkgId: string, classifierId: string):
 // ─── Single-line member / annotation (`Class : member`) ───────
 
 function tryParseMemberLine(line: string): { id: string; body: string } | undefined {
-  const m = /^([A-Za-z_][\w.]*)\s*:\s*(.+)$/.exec(line);
+  const m = MEMBER_LINE_RE.exec(line);
   if (!m) return undefined;
   const body = m[2]!.trim();
   if (!body) return undefined;
@@ -534,7 +556,7 @@ function splitInlineMembers(body: string): string[] {
       let j = i + 1;
       while (j < body.length && (body[j] === " " || body[j] === "\t")) j++;
       const next = body[j] ?? "";
-      const nextStartsMember = /[A-Za-z_/]/.test(next);
+      const nextStartsMember = /[\p{L}_/]/u.test(next);
       if (prevIsBoundary && nextStartsMember) {
         hasGlyphMember = true;
         if (i > start) { out.push(body.slice(start, i)); start = i; }
@@ -624,7 +646,7 @@ function parseMember(
     visibility === undefined &&
     colonIdx < 0 &&
     eqIdx < 0 &&
-    /^[A-Za-z_][\w.]*$/.test(body)
+    isQualifiedIdentifier(body)
   ) {
     return {
       kind: "literal",
@@ -679,7 +701,7 @@ function parseOperation(
         const lastSpace = rest.lastIndexOf(" ");
         const candType = rest.slice(0, lastSpace).trim();
         const candName = rest.slice(lastSpace + 1).trim();
-        if (/^[A-Za-z_][\w.]*$/.test(candName)) {
+        if (isQualifiedIdentifier(candName)) {
           ptype = candType;
           pname = candName;
         }
@@ -753,7 +775,7 @@ function parseAttribute(
     const lastSpace = rest.lastIndexOf(" ");
     const candType = rest.slice(0, lastSpace).trim();
     const candName = rest.slice(lastSpace + 1).trim();
-    if (/^[A-Za-z_][\w.]*$/.test(candName)) {
+    if (isQualifiedIdentifier(candName)) {
       type = candType;
       name = candName;
     }
@@ -923,8 +945,12 @@ function tokenise(s: string): Token[] {
       const q = matchQuoted(s.slice(i));
       if (q) { out.push({ kind: "quoted", value: q.value }); i += q.length; continue; }
     }
-    const m = /^[A-Za-z_][\w.]*/.exec(s.slice(i));
-    if (m) { out.push({ kind: "ident", value: m[0] }); i += m[0].length; continue; }
+    const identifier = readQualifiedIdentifier(s, i);
+    if (identifier) {
+      out.push({ kind: "ident", value: identifier.value });
+      i = identifier.end;
+      continue;
+    }
     i++; // skip stray punctuation
   }
   return out;

--- a/src/diagrams/usecase/parser.ts
+++ b/src/diagrams/usecase/parser.ts
@@ -19,6 +19,7 @@ import type {
   UsecaseRelKind,
   UsecaseRelation,
 } from "./types";
+import { IDENTIFIER_SOURCE } from "../../core/identifier";
 
 export class UsecaseParseError extends Error {
   line?: number;
@@ -306,7 +307,7 @@ function parseActorDecl(ln: RawLine, state: ParserState): boolean {
   }
   // optional `as ID`
   let id: string | undefined;
-  const asMatch = rest.match(/\s+as\s+([A-Za-z_]\w*)\s*$/);
+  const asMatch = rest.match(new RegExp(`\\s+as\\s+(${IDENTIFIER_SOURCE})\\s*$`, "u"));
   if (asMatch) {
     id = asMatch[1];
     rest = rest.slice(0, asMatch.index).trim();
@@ -348,7 +349,7 @@ function parseUsecaseDecl(ln: RawLine, state: ParserState): boolean {
   }
   // optional `as ID`
   let id: string | undefined;
-  const asMatch = rest.match(/\s+as\s+([A-Za-z_]\w*)\s*$/);
+  const asMatch = rest.match(new RegExp(`\\s+as\\s+(${IDENTIFIER_SOURCE})\\s*$`, "u"));
   if (asMatch) {
     id = asMatch[1];
     rest = rest.slice(0, asMatch.index).trim();
@@ -392,7 +393,7 @@ function parseUsecaseDecl(ln: RawLine, state: ParserState): boolean {
 // PlantUML inline form: :Name: [as ID]  or  (Name) [as ID]
 function parsePlantUmlInline(ln: RawLine, state: ParserState): boolean {
   // Actor: :Name:
-  let m = ln.text.match(/^:([^:]+):\s*(?:as\s+([A-Za-z_]\w*))?\s*$/);
+  let m = ln.text.match(new RegExp(`^:([^:]+):\\s*(?:as\\s+(${IDENTIFIER_SOURCE}))?\\s*$`, "u"));
   if (m) {
     const name = m[1].trim();
     const id = m[2] ?? defaultIdFor(name);
@@ -401,7 +402,7 @@ function parsePlantUmlInline(ln: RawLine, state: ParserState): boolean {
     return true;
   }
   // Use case: (Name)
-  m = ln.text.match(/^\(([^()]+)\)\s*(?:as\s+([A-Za-z_]\w*))?\s*$/);
+  m = ln.text.match(new RegExp(`^\\(([^()]+)\\)\\s*(?:as\\s+(${IDENTIFIER_SOURCE}))?\\s*$`, "u"));
   if (m) {
     const name = m[1].trim();
     const id = m[2] ?? defaultIdFor(name);

--- a/src/diagrams/venn/parser.ts
+++ b/src/diagrams/venn/parser.ts
@@ -20,11 +20,20 @@ import type {
   VennRegionValue,
   VennSet,
 } from "../../core/types";
+import { IDENTIFIER_SOURCE, isIdentifier } from "../../core/identifier";
 import {
   extractQuotedString,
   isOpenQuote,
   stripQuotes as stripQuotesShared,
 } from "../../core/quotes";
+
+const ONLY_REGION_RE = new RegExp(`^(${IDENTIFIER_SOURCE})\\s+only$`, "iu");
+const SET_DECL_RE = new RegExp(`^set\\s+(${IDENTIFIER_SOURCE})\\s+(.+)$`, "iu");
+const SET_ENUM_RE = new RegExp(`^(${IDENTIFIER_SOURCE})\\s*=\\s*\\{([^}]*)\\}\\s*$`, "u");
+const EULER_REL_RE = new RegExp(
+  `^(${IDENTIFIER_SOURCE})\\s+(subset|in|disjoint|overlap)\\s+(${IDENTIFIER_SOURCE})\\s*$`,
+  "iu"
+);
 
 export class VennParseError extends Error {
   constructor(message: string, public readonly line?: number) {
@@ -202,7 +211,7 @@ function parseRegionKey(
 ): { sets: string[]; only: boolean } {
   const trimmed = text.trim();
   // "A only"
-  const onlyMatch = /^([A-Za-z][\w-]*)\s+only$/i.exec(trimmed);
+  const onlyMatch = ONLY_REGION_RE.exec(trimmed);
   if (onlyMatch && onlyMatch[1]) {
     const id = onlyMatch[1];
     if (!knownSets.has(id)) {
@@ -216,7 +225,7 @@ function parseRegionKey(
     throw new VennParseError(`empty region key: "${text}"`);
   }
   for (const p of parts) {
-    if (!/^[A-Za-z][\w-]*$/.test(p)) {
+    if (!isIdentifier(p)) {
       throw new VennParseError(`invalid set ref "${p}" in region key`);
     }
     if (!knownSets.has(p)) {
@@ -276,7 +285,7 @@ export function parseVennDSL(input: string): VennAST {
     }
 
     // set <id> "label" [props?]
-    const setMatch = /^set\s+([A-Za-z][\w-]*)\s+(.+)$/i.exec(raw);
+    const setMatch = SET_DECL_RE.exec(raw);
     if (setMatch && setMatch[1] && setMatch[2]) {
       const id = setMatch[1];
       const rest = setMatch[2];
@@ -301,7 +310,7 @@ export function parseVennDSL(input: string): VennAST {
     }
 
     // Enumeration: ID = { ... }
-    const enumMatch = /^([A-Za-z][\w-]*)\s*=\s*\{([^}]*)\}\s*$/.exec(raw);
+    const enumMatch = SET_ENUM_RE.exec(raw);
     if (enumMatch && enumMatch[1] !== undefined && enumMatch[2] !== undefined) {
       const id = enumMatch[1];
       const items = splitTopLevelCommas(enumMatch[2])
@@ -320,9 +329,7 @@ export function parseVennDSL(input: string): VennAST {
     }
 
     // Euler relation: ID subset ID   |  ID in ID  |  ID disjoint ID  |  ID overlap ID
-    const eulerMatch = /^([A-Za-z][\w-]*)\s+(subset|in|disjoint|overlap)\s+([A-Za-z][\w-]*)\s*$/i.exec(
-      raw
-    );
+    const eulerMatch = EULER_REL_RE.exec(raw);
     if (eulerMatch && eulerMatch[1] && eulerMatch[2] && eulerMatch[3]) {
       const from = eulerMatch[1];
       const relRaw = eulerMatch[2].toLowerCase();

--- a/tests/core/dsl-preprocess.test.ts
+++ b/tests/core/dsl-preprocess.test.ts
@@ -1,9 +1,49 @@
 import { describe, it, expect } from "vitest";
 import {
+  stripArtifactWrappers,
   parseFrontmatter,
   stripLineComment,
   isBlankOrComment,
 } from "../../src/core/dsl-preprocess";
+
+describe("stripArtifactWrappers", () => {
+  it("unwraps nested Markdown and artifact framing", () => {
+    expect(
+      stripArtifactWrappers(
+        "\n```mermaid\n<artifact title='X' type='diagram'>\nflowchart TD\n  A --> B\n</artifact>\n```"
+      )
+    ).toBe("flowchart TD\n  A --> B");
+  });
+
+  it("removes Anthropic control tags while preserving enclosed DSL", () => {
+    expect(
+      stripArtifactWrappers(
+        'flowchart TD\n<invoke name="render">\n<parameter name="dsl">\n  A --> B\n</parameter>\n</invoke>'
+      )
+    ).toBe("flowchart TD\n\n\n  A --> B\n\n");
+  });
+
+  it("removes standalone scalar parameter lines completely", () => {
+    expect(
+      stripArtifactWrappers(
+        'timeline\n<parameter name="open" string="true">false</parameter>\n2026: "Launch"'
+      )
+    ).toBe('timeline\n2026: "Launch"');
+  });
+
+  it("removes DeepSeek fullwidth-pipe tokens", () => {
+    expect(
+      stripArtifactWrappers(
+        "flowchart TD\n  A --> B\n</｜｜DSML｜｜parameter>\n  B --> C"
+      )
+    ).toBe("flowchart TD\n  A --> B\n\n  B --> C");
+  });
+
+  it("returns clean DSL byte-for-byte and preserves legitimate angle brackets", () => {
+    const clean = "circuit\n  <ep> --color-- <ep>";
+    expect(stripArtifactWrappers(clean)).toBe(clean);
+  });
+});
 
 describe("parseFrontmatter", () => {
   it("returns empty data when no --- block is present", () => {

--- a/tests/core/identifier-conformance.test.ts
+++ b/tests/core/identifier-conformance.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { getExamples } from "../../src/ai";
+import { parseResult } from "../../src/core/api";
+import type { DiagramType } from "../../src/core/types";
+
+const OFFICIAL_EXAMPLE_IDS: Partial<Record<DiagramType, string>> = {
+  blockdiagram: "err",
+  bpmn: "G1",
+  breadboard: "r1",
+  ecomap: "therapist",
+  entity: "acme_fund",
+  epc: "E1",
+  erd: "Enrollment",
+  eventtree: "REL",
+  faulttree: "PA",
+  fbd: "MotorOut",
+  flowchart: "rollback",
+  idef0: "A1",
+  logic: "Y_nand",
+  orgchart: "lead_growth",
+  pert: "A",
+  pid: "FIC-101",
+  sfc: "S0",
+  sociogram: "associate1",
+  state: "Yellow",
+  umlclass: "AbstractShape",
+  usecase: "Customer",
+  venn: "mobile",
+};
+
+const UNICODE_IDENTIFIERS = ["الجد1", "原因1", "סבא1"] as const;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceIdentifier(dsl: string, identifier: string, replacement: string): string {
+  return dsl.replace(
+    new RegExp(
+      `(?<![\\p{L}\\p{N}\\p{M}_-])${escapeRegex(identifier)}(?![\\p{L}\\p{N}\\p{M}_-])`,
+      "gu"
+    ),
+    replacement
+  );
+}
+
+describe("Unicode identifier parser conformance", () => {
+  for (const [type, identifier] of Object.entries(OFFICIAL_EXAMPLE_IDS) as Array<
+    [DiagramType, string]
+  >) {
+    test.each(UNICODE_IDENTIFIERS)(
+      `${type} official example accepts %s in place of ${identifier}`,
+      (replacement) => {
+        const example = getExamples(type, { limit: 1 }).examples[0];
+        expect(example, `${type} must keep an official example`).toBeDefined();
+        const mutated = replaceIdentifier(example!.dsl, identifier, replacement);
+        expect(mutated, `${identifier} must occur as an identifier in ${type}`).not.toBe(
+          example!.dsl
+        );
+        const result = parseResult(mutated, { type });
+        expect(
+          result.ok,
+          result.ok ? undefined : JSON.stringify(result.diagnostics)
+        ).toBe(true);
+      }
+    );
+  }
+
+  test.each(UNICODE_IDENTIFIERS)(
+    "fishbone structured category accepts %s",
+    (identifier) => {
+      const result = parseResult(
+        `fishbone "Cause"\neffect "Delay"\ncategory ${identifier} "People"\n${identifier}: "Understaffed"`,
+        { type: "fishbone" }
+      );
+      expect(result.ok).toBe(true);
+    }
+  );
+
+  test.each(UNICODE_IDENTIFIERS)("pedigree individual accepts %s", (identifier) => {
+    const result = parseResult(
+      `pedigree\n${identifier} [male]\nparent2 [female]\n${identifier} -- parent2`,
+      { type: "pedigree" }
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  test("every parser wired to the shared identifier grammar has a conformance fixture", () => {
+    const diagramsDir = fileURLToPath(
+      new URL("../../src/diagrams/", import.meta.url)
+    );
+    const wired = readdirSync(diagramsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((type) => {
+        try {
+          return readFileSync(`${diagramsDir}/${type}/parser.ts`, "utf8").includes(
+            "core/identifier"
+          );
+        } catch {
+          return false;
+        }
+      })
+      .sort();
+    const covered = [
+      ...Object.keys(OFFICIAL_EXAMPLE_IDS),
+      "fishbone",
+      "pedigree",
+    ].sort();
+    expect(wired).toEqual(covered);
+  });
+});

--- a/tests/core/identifier.test.ts
+++ b/tests/core/identifier.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import {
+  isIdentifier,
+  isQualifiedIdentifier,
+  readIdentifier,
+} from "../../src/core/identifier";
+
+describe("shared Unicode identifier grammar", () => {
+  test.each([
+    "الجد1",
+    "原因1",
+    "סבא1",
+    "Diáconos",
+    "Avô1",
+    "node_2",
+    "phase-one",
+    "Cafe\u0301",
+  ])("accepts %s", (identifier) => {
+    expect(isIdentifier(identifier)).toBe(true);
+    expect(readIdentifier(`${identifier} --> next`)).toEqual({
+      value: identifier,
+      end: identifier.length,
+    });
+  });
+
+  test.each(["9bad", "-node", "has space", "has.dot", "bad!"])(
+    "rejects ambiguous identifier %s",
+    (identifier) => {
+      expect(isIdentifier(identifier)).toBe(false);
+    }
+  );
+
+  test("supports dot-qualified Unicode identifiers where the DSL allows qualification", () => {
+    expect(isQualifiedIdentifier("domínio.原因")).toBe(true);
+    expect(isQualifiedIdentifier("domínio..原因")).toBe(false);
+  });
+});

--- a/tests/core/input-recovery.test.ts
+++ b/tests/core/input-recovery.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "vitest";
-import { renderResult } from "../../src/core/api";
+import {
+  parse,
+  parseResult,
+  render,
+  renderResult,
+} from "../../src/core/api";
+import { renderDsl, validateDsl } from "../../src/ai";
 
 const ok = (dsl: string, type?: import("../../src/core/api").SchematexConfig["type"]) =>
   renderResult(dsl, type ? { type } : undefined);
@@ -30,6 +36,41 @@ describe("markdown code-fence stripping (cross-engine)", () => {
   test("a fence with a language tag (```schematex) is stripped", () => {
     const r = ok("```schematex\norgchart\n  CEO\n  CEO -> CTO\n```");
     expect(r.ok).toBe(true);
+  });
+});
+
+describe("LLM artifact-wrapper stripping (all public entry points)", () => {
+  const dirtyDsl = [
+    "",
+    "```mermaid",
+    "<artifact title='Dependency map' type='diagram'>",
+    "flowchart TD",
+    "  Alpha --> Beta",
+    "</parameter>",
+    "<｜｜DSML｜｜parameter>",
+    "</artifact>",
+    "```",
+  ].join("\n");
+
+  test("strict parse and render inherit the shared cleanup", () => {
+    expect(() => parse(dirtyDsl, { type: "flowchart" })).not.toThrow();
+    expect(render(dirtyDsl, { type: "flowchart" })).toContain("<svg");
+  });
+
+  test("result APIs inherit the shared cleanup", () => {
+    expect(parseResult(dirtyDsl, { type: "flowchart" }).ok).toBe(true);
+    expect(renderResult(dirtyDsl, { type: "flowchart" }).ok).toBe(true);
+  });
+
+  test("AI validate and render entry points inherit the shared cleanup", () => {
+    expect(validateDsl("flowchart", dirtyDsl).ok).toBe(true);
+    expect(renderDsl("flowchart", dirtyDsl).ok).toBe(true);
+  });
+
+  test("a scalar tool parameter line is removed rather than leaving its value", () => {
+    const dsl =
+      'timeline\n<parameter name="open" string="true">false</parameter>\n2026: "Launch"';
+    expect(renderResult(dsl, { type: "timeline" }).ok).toBe(true);
   });
 });
 

--- a/tests/fixtures/regression/parser-tolerance-2026-07.json
+++ b/tests/fixtures/regression/parser-tolerance-2026-07.json
@@ -1,0 +1,74 @@
+[
+  {
+    "error": "expected node identifier, got \"الجد1 --> \"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\nالجد1 --> الأب1"
+  },
+  {
+    "error": "got \"原因1\"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\n原因1 --> 结果1"
+  },
+  {
+    "error": "got \"סבא1 --> ה\"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\nסבא1 --> הורה1"
+  },
+  {
+    "error": "got \"áconos[Diá\"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\nDiáconos[Diáconos] --> Acción1"
+  },
+  {
+    "error": "got \"ô1 --> Pai\"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\nAvô1 --> Pai1"
+  },
+  {
+    "error": "expected edge operator, got \"for F1\"",
+    "engine": "flowchart",
+    "outcome": "actionable-error",
+    "dsl": "flowchart TB\nF1[Father]\nnote for F1\n\"Parents are P1 and P2\""
+  },
+  {
+    "error": "expected edge operator, got \")\"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\nA(Calculate f(x)) --> B[Review for F1]"
+  },
+  {
+    "error": "Part 'esp32' has no pin named 'D2'",
+    "engine": "breadboard",
+    "outcome": "render",
+    "dsl": "breadboard\nparts\n  esp32: mcu esp32 @beside-left\nwires\n  esp32:D2 --blue-- @1a"
+  },
+  {
+    "error": "Part 'nano' has no pin named 'A1' (known pins: ...)",
+    "engine": "breadboard",
+    "outcome": "render",
+    "dsl": "breadboard\nparts\n  nano: mcu nano @beside-left\nwires\n  nano:A1 --blue-- @1a"
+  },
+  {
+    "error": "Part 'btn' has no pin named 'pin1'",
+    "engine": "breadboard",
+    "outcome": "render",
+    "dsl": "breadboard\nparts\n  btn: button @5e\nwires\n  btn:pin1 --green-- @1a"
+  },
+  {
+    "error": "Grid/module part 'servo' must use @coord placement",
+    "engine": "breadboard",
+    "outcome": "render",
+    "dsl": "breadboard\nparts\n  servo: actuator servo @beside-left\nwires\n  servo:signal --yellow-- @1a"
+  },
+  {
+    "error": "Line N: Unrecognized line in section: Tarea C :",
+    "engine": "timeline",
+    "outcome": "warning",
+    "dsl": "timeline \"Plan\"\nsection Trabajo\n  Tarea C :"
+  }
+]

--- a/tests/fixtures/regression/parser-tolerance-2026-07.json
+++ b/tests/fixtures/regression/parser-tolerance-2026-07.json
@@ -1,5 +1,47 @@
 [
   {
+    "error": "[line N:1] expected node identifier, got \"```mermaid\"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "```mermaid\nflowchart TD\nA --> B\n```"
+  },
+  {
+    "error": "[line N:1] expected node identifier, got \"<artifact \"",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "<artifact title='Dependency map' type='diagram'>\nflowchart TD\nA --> B\n</artifact>"
+  },
+  {
+    "error": "</parameter>",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\nA --> B\n</parameter>"
+  },
+  {
+    "error": "</invoke>",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\n<invoke name='render'>\nA --> B\n</invoke>"
+  },
+  {
+    "error": "<parameter …>",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\n<parameter name='dsl'>\nA --> B\n</parameter>"
+  },
+  {
+    "error": "antml:*",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\n<antml:parameter name='dsl'>\nA --> B\n</antml:parameter>"
+  },
+  {
+    "error": "<｜｜DSML｜｜parameter>",
+    "engine": "flowchart",
+    "outcome": "render",
+    "dsl": "flowchart TD\nA --> B\n<｜｜DSML｜｜parameter>"
+  },
+  {
     "error": "expected node identifier, got \"الجد1 --> \"",
     "engine": "flowchart",
     "outcome": "render",

--- a/tests/regression/parser-tolerance-2026-07.test.ts
+++ b/tests/regression/parser-tolerance-2026-07.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+import { renderResult } from "../../src/core/api";
+import { parseBreadboard } from "../../src/diagrams/breadboard/parser";
+import { layoutBreadboard } from "../../src/diagrams/breadboard/layout";
+
+interface RegressionFixture {
+  error: string;
+  engine: "flowchart" | "breadboard" | "timeline";
+  outcome: "render" | "warning" | "actionable-error";
+  dsl: string;
+}
+
+const fixtures = JSON.parse(
+  readFileSync(
+    new URL("../fixtures/regression/parser-tolerance-2026-07.json", import.meta.url),
+    "utf8"
+  )
+) as RegressionFixture[];
+
+describe("production parser tolerance regressions (2026-07)", () => {
+  test("keeps every reported production error verbatim as a fixture", () => {
+    expect(fixtures.map((fixture) => fixture.error)).toEqual([
+      'expected node identifier, got "الجد1 --> "',
+      'got "原因1"',
+      'got "סבא1 --> ה"',
+      'got "áconos[Diá"',
+      'got "ô1 --> Pai"',
+      'expected edge operator, got "for F1"',
+      'expected edge operator, got ")"',
+      "Part 'esp32' has no pin named 'D2'",
+      "Part 'nano' has no pin named 'A1' (known pins: ...)",
+      "Part 'btn' has no pin named 'pin1'",
+      "Grid/module part 'servo' must use @coord placement",
+      "Line N: Unrecognized line in section: Tarea C :",
+    ]);
+  });
+
+  for (const fixture of fixtures.filter((candidate) => candidate.outcome === "render")) {
+    test(`renders: ${fixture.error}`, () => {
+      const result = renderResult(fixture.dsl, { type: fixture.engine });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.svg).toContain("<svg");
+    });
+  }
+
+  test("diagnoses unsupported `note for F1` syntax with a repair", () => {
+    const fixture = fixtures.find((candidate) => candidate.outcome === "actionable-error")!;
+    const result = renderResult(fixture.dsl, { type: "flowchart" });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.message).toContain(
+      "flowchart does not support 'note for <node>' statements"
+    );
+    expect(result.diagnostics[0]?.hint).toContain('F1["Father');
+  });
+
+  test("keeps an empty timeline value as an undated event and warning", () => {
+    const fixture = fixtures.find((candidate) => candidate.outcome === "warning")!;
+    const result = renderResult(fixture.dsl, { type: "timeline" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.status).toBe("partial");
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        severity: "warning",
+        code: "timeline/undated-entry",
+        line: 3,
+      })
+    );
+  });
+
+  test("unknown breadboard pins include a nearest-name repair", () => {
+    const ast = parseBreadboard(`breadboard
+parts
+  nano: mcu nano @beside-left
+wires
+  nano:A9 --blue-- @1a`);
+    expect(() => layoutBreadboard(ast)).toThrow(/Did you mean 'A[0-7]'\?/);
+  });
+});

--- a/tests/regression/parser-tolerance-2026-07.test.ts
+++ b/tests/regression/parser-tolerance-2026-07.test.ts
@@ -21,6 +21,13 @@ const fixtures = JSON.parse(
 describe("production parser tolerance regressions (2026-07)", () => {
   test("keeps every reported production error verbatim as a fixture", () => {
     expect(fixtures.map((fixture) => fixture.error)).toEqual([
+      '[line N:1] expected node identifier, got "```mermaid"',
+      '[line N:1] expected node identifier, got "<artifact "',
+      "</parameter>",
+      "</invoke>",
+      "<parameter …>",
+      "antml:*",
+      "<｜｜DSML｜｜parameter>",
       'expected node identifier, got "الجد1 --> "',
       'got "原因1"',
       'got "סבא1 --> ה"',


### PR DESCRIPTION
## Summary

This is one reliability fix for LLM-generated DSL. It removes globally invalid model wrappers before detection, centralizes user identifiers on Unicode, and recovers inputs the renderer can represent correctly while keeping genuinely invalid syntax fatal.

- strip Markdown fences, leaked `<artifact>` wrappers, Anthropic tool-call tags, and DeepSeek fullwidth-pipe control tokens in the shared preprocess pass used by every parser and public API
- centralize user-facing identifiers on one Unicode grammar after auditing all 50 diagram parsers
- allow paired parentheses inside unquoted flowchart labels and give ambiguous/unsupported label syntax an actionable quote/rewrite hint
- add official-style breadboard pin aliases, restore the full Nano/Pico pin catalogs, suggest the nearest real pin, and deterministically place side-positioned modules
- keep empty timeline values as undated events with a non-fatal `timeline/undated-entry` diagnostic
- preserve every reported production error verbatim as an executable regression fixture
- add a mechanical conformance gate that mutates official examples across all 24 parsers wired to the shared identifier grammar into Arabic, Chinese, and Hebrew ids

The intentionally stable parser rules called out in the report — circuit, SLD, genogram, and ladder — are unchanged. They inherit only the safe shared wrapper cleanup.

## Root cause and safety boundary

Schematex 1.0.3 already strips Markdown code fences globally; ChatDiagram's fence errors show that production is still running an older engine. The missing upstream behavior was `<artifact>` and model tool-call cleanup. Wrapper removal now happens before frontmatter, detection, parsing, validation, and rendering.

- cleanup only treats `<artifact>` as a wrapper when it is the first significant token
- Anthropic removal only recognizes known `function_calls` / `invoke` / `parameter` framing
- DeepSeek removal requires U+FF5C fullwidth pipes
- clean DSL is returned byte-for-byte unchanged
- source offsets are preserved by blanking wrapper ranges in the core API
- legitimate angle-bracket DSL such as circuit `<ep>` endpoints remains unchanged

Identifier start remains a Unicode letter or `_`; Unicode digits/marks and hyphens are accepted after the first character. This preserves operator disambiguation and existing invalid-ID contracts.

`note for F1` is not a valid flowchart construct and cannot be rendered faithfully. It remains an error, but now explains how to rewrite it. It is not counted as a recovered render.

The bundled `getExamples('timeline')` corpus was checked: all three official examples contain real dates and labels; none contains an empty `Task C :` shape. No example change is needed. The parser recovery still handles the translated empty-value shape safely.

## Production validation

Window: 2026-06-27 00:00 PT through 2026-07-27, excluding `victor@mymap.ai`.

A weighted backtest against real `diagram_errors.error_message` rows predicts **5,327 fewer fatal render failures** when ChatDiagram moves from its current engine to 1.0.4, above the 4,500 acceptance target:

- Markdown fence: 2,850 (already fixed in Schematex 1.0.3; confirms CD is stale)
- `<artifact>` wrapper: 289
- Anthropic control tokens: 16
- DeepSeek fullwidth-pipe tokens: 6
- Unicode identifier families: 1,047
- paired-parenthesis label families: 239
- empty timeline values: 880

Breadboard pin/placement rows are not included in that reduction because truly nonexistent pins correctly remain errors with `Did you mean ...?`. Unsupported `note for` rows are also excluded because only their diagnostics improve.

Production stores error messages and metadata but not the failed DSL body, so this is a real-message weighted backtest rather than a literal replay. Checked-in fixtures preserve every reported string and exercise equivalent minimal DSL through the shared APIs.

## Verification

- `npx vitest run --maxWorkers=4 --minWorkers=1` — 181 files, 2,415 tests passed
- wrapper/identifier targeted suite — 145 tests passed
- `npm run typecheck -- --pretty false` — passed
- `npm run lint` — passed (0 errors; existing warnings remain)
- `npm run build` — passed (ESM, CJS, and DTS)
- `git diff --check` — passed

Release metadata and changelog are tracked separately in #74, which should merge after this PR.
