### PR TITLE
release: schematex 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.4] — 2026-07-27
 
-### Fixed — LLM-generated DSL no longer fails on valid names, labels, pins, or empty timeline dates
+### Fixed — LLM-generated DSL no longer fails on wrappers, valid names, labels, pins, or empty dates
 
-Several diagram parsers maintained their own ASCII-only identifier checks and strict label boundaries. Valid multilingual DSL and familiar hardware notation could therefore fail before layout, even when the diagram had an unambiguous representation.
+Model output framing reached diagram parsers as if it were authored DSL, while several parsers maintained ASCII-only identifier checks and strict label boundaries. Valid multilingual diagrams and familiar hardware notation could therefore fail before layout, even when the intended result was unambiguous.
 
+- **LLM wrappers are removed once, before every parser.** The shared preprocess pass strips Markdown fences, leaked `<artifact>` wrappers, Anthropic `function_calls` / `invoke` / `parameter` tags, and DeepSeek fullwidth-pipe control tokens. Clean DSL is byte-for-byte unchanged, source offsets remain stable, and legitimate angle-bracket syntax such as circuit `<ep>` endpoints survives.
 - **One Unicode identifier contract.** Parsers that validate user-facing ids now share one grammar: a Unicode letter or underscore followed by Unicode letters, digits, combining marks, underscores, or hyphens. Arabic, Chinese, Hebrew, and accented Latin ids render without per-engine exceptions.
 - **More tolerant flowchart labels.** Unquoted labels accept balanced parentheses, including nested function-style text. Ambiguous label syntax now recommends quoting the label; unsupported Mermaid-style `note for` statements remain errors but include a concrete rewrite.
 - **Breadboard names match real pinouts.** Expanded Arduino Nano and Raspberry Pi Pico pin catalogs, plus aliases for common MCU and module notation such as `D2`, `A1`, and `pin1`. Side-placed grid modules such as servos receive a deterministic default coordinate, while genuinely unknown pins report the closest valid name.
 - **Empty timeline values fail soft.** An entry such as `Tarea C :` renders as an undated event and emits a warning instead of rejecting the entire timeline.
-- **Production regressions are executable fixtures.** Every reported error string is preserved verbatim in tests. Circuit, SLD, genogram, and ladder parsing behavior is unchanged.
+- **Production regressions are executable fixtures.** Every reported error string is preserved verbatim, and a mechanical gate rewrites official examples with Arabic, Chinese, and Hebrew ids before reparsing them. Circuit, SLD, genogram, and ladder parser rules are unchanged. A 30-day production-message backtest projects 5,327 fewer fatal renders when consumers upgrade.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.4] — 2026-07-27
+
+### Fixed — LLM-generated DSL no longer fails on valid names, labels, pins, or empty timeline dates
+
+Several diagram parsers maintained their own ASCII-only identifier checks and strict label boundaries. Valid multilingual DSL and familiar hardware notation could therefore fail before layout, even when the diagram had an unambiguous representation.
+
+- **One Unicode identifier contract.** Parsers that validate user-facing ids now share one grammar: a Unicode letter or underscore followed by Unicode letters, digits, combining marks, underscores, or hyphens. Arabic, Chinese, Hebrew, and accented Latin ids render without per-engine exceptions.
+- **More tolerant flowchart labels.** Unquoted labels accept balanced parentheses, including nested function-style text. Ambiguous label syntax now recommends quoting the label; unsupported Mermaid-style `note for` statements remain errors but include a concrete rewrite.
+- **Breadboard names match real pinouts.** Expanded Arduino Nano and Raspberry Pi Pico pin catalogs, plus aliases for common MCU and module notation such as `D2`, `A1`, and `pin1`. Side-placed grid modules such as servos receive a deterministic default coordinate, while genuinely unknown pins report the closest valid name.
+- **Empty timeline values fail soft.** An entry such as `Tarea C :` renders as an undated event and emits a warning instead of rejecting the entire timeline.
+- **Production regressions are executable fixtures.** Every reported error string is preserved verbatim in tests. Circuit, SLD, genogram, and ladder parsing behavior is unchanged.
+
+---
+
 ## [1.0.3] — 2026-07-27
 
 ### Fixed — `prisma` rejected any wholesale-indented block, and said the wrong thing about why

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "schematex",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schematex",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Every diagram a doctor, engineer, or lawyer would actually use. 51 industry-standard diagrams from a text DSL, with open-source React editing, AI tools, and MCP. Pure SVG, zero runtime dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Prepare the patch release for `schematex@1.0.4`.

- bump the root package and lockfile from `1.0.3` to `1.0.4`
- add the 1.0.4 Keep a Changelog entry
- document global LLM-wrapper cleanup, Unicode identifiers, tolerant flowchart labels, breadboard pin aliases/default placement, timeline fail-soft behavior, and executable production regressions

## Dependency

Blocked by #73. Merge the parser reliability fix first, then merge this release PR. This branch starts from current `main`, so its diff stays limited to release metadata.

`@schematex/mcp` remains at `1.0.0`; the parser and preprocess changes are in the root `schematex` package.

## Production evidence

The 30-day error-message backtest, excluding `victor@mymap.ai`, projects 5,327 fewer fatal renders when ChatDiagram upgrades to 1.0.4:

- wrapper/control-token families: 3,161
- Unicode identifier, paired-parenthesis, and empty-timeline families: 2,166

The production table does not store failed DSL bodies, so this is a weighted message backtest rather than a literal replay. Exact report strings and equivalent minimal DSL are checked into #73.

## Verification

- PR #73: 181 test files / 2,415 tests passed
- targeted wrapper/identifier suite: 145 tests passed
- typecheck, lint (0 errors), ESM/CJS/DTS build, GitHub CI, and Vercel checks passed before the follow-up commit; fresh PR checks run on every push
- version manifest assertion: `package.json`, lockfile root, and lockfile package all report `1.0.4`
- `npm pack --dry-run --json`: `schematex@1.0.4`, 280 files
- `git diff --check`: passed
- release diff: only `CHANGELOG.md`, `package.json`, and `package-lock.json`
