### PR TITLE
fix(circuit): bind every net on multi-pin ICs in netlist mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — circuit netlist ICs no longer discard their connections
+
+- **Multi-pin ICs declared in netlist mode now bind every net the user wrote.** `IC1 0 2 3 8 0 2 7 8 type=ic` previously rendered an eight-pin box with no wires at all: `generic_ic` carried an empty `netlistPins` array, the empty-array-is-truthy guard in `getNetlistPinOrder` returned zero expected pins, and every net the user declared was dropped without a word. Pins are now auto-numbered `1..N` from the declared net count along the DIP convention, the box grows to show exactly N legs, and each leg is wired. Reported in [#79](https://github.com/SchemaTex/SchemaTex/issues/79).
+- **The same silent drop affected far more than the reported case.** `X`/`U` SPICE prefixes and `type=555` were equally broken. `type=555` now binds the real 555 pinout in SPICE order — `1 GND, 2 TRIG, 3 OUT, 4 RESET, 5 CTRL, 6 THRESH, 7 DISCH, 8 VCC` — onto the existing timer symbol's anchors.
+- **`terminal_block` had the same defect and is fixed alongside it.** Its pin anchors were documented as per-instance but never implemented, so `pins="L,N,PE"` bound the nets and then drew no wires. Pin legs and wire anchors are now generated from one shared, label-independent geometry helper, so the two can no longer drift apart.
+- **A component that cannot honour its declared nets now says so.** Explicit `pins=` lists that receive more nets than they name raise `CIRCUIT_PIN_OVERSPECIFIED` instead of silently truncating.
+
 ---
 
 ## [1.0.7] — 2026-07-28

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1181,6 +1181,13 @@ export interface CircuitAST {
    */
   recovered?: {
     underspecified?: { id: string; type: string; expected: number; got: number }[];
+    overspecified?: {
+      id: string;
+      type: string;
+      expected: number;
+      got: number;
+      extraNets: string[];
+    }[];
   };
 }
 

--- a/src/diagrams/circuit/autolayout.ts
+++ b/src/diagrams/circuit/autolayout.ts
@@ -35,7 +35,7 @@ import type {
   CircuitAST,
   CircuitComponent,
 } from "../../core/types";
-import { getSymbol, type PinAnchor } from "./symbols";
+import { effectiveSymbolDef, getSymbol, type PinAnchor } from "./symbols";
 import type {
   LaidOutComponent,
   CircuitLayoutResult,
@@ -143,7 +143,7 @@ function placeComponent(
       : fallbackDir ?? defaultDirection(comp);
   comp.direction = direction;
   const rot = rotationOf(direction);
-  const sym = getSymbol(comp.componentType);
+  const sym = effectiveSymbolDef(comp.componentType, comp.attrs) ?? getSymbol(comp.componentType);
   const worldAnchors: Record<string, PinAnchor> = {};
   if (sym) {
     for (const [name, pt] of Object.entries(sym.anchors)) {
@@ -165,7 +165,7 @@ function placeComponent(
 }
 
 function placeMirroredComponent(comp: CircuitComponent, x: number, y: number): LaidOutComponent {
-  const sym = getSymbol(comp.componentType);
+  const sym = effectiveSymbolDef(comp.componentType, comp.attrs) ?? getSymbol(comp.componentType);
   const length = sym?.length ?? 30;
   const worldAnchors: Record<string, PinAnchor> = {};
   comp.direction = "left";
@@ -942,7 +942,9 @@ function layoutTwoWayLightingLoop(
 
   const rightCommonX = leftLaid.x + leftLaid.length + AC_TRAVELER_SPAN + leftLaid.length;
   const sameTravelerOrder = leftPins.nc === rightPins.nc && leftPins.no === rightPins.no;
-  const rightLength = getSymbol(rightSwitch.componentType)?.length ?? 30;
+  const rightLength =
+    (effectiveSymbolDef(rightSwitch.componentType, rightSwitch.attrs) ??
+      getSymbol(rightSwitch.componentType))?.length ?? 30;
   const rightLaid = sameTravelerOrder
     ? placeMirroredComponent(rightSwitch, rightCommonX - rightLength, AC_LIVE_Y)
     : placeComponent(rightSwitch, rightCommonX, AC_LIVE_Y, "left");

--- a/src/diagrams/circuit/lint.ts
+++ b/src/diagrams/circuit/lint.ts
@@ -24,6 +24,8 @@ import { getSymbol } from "./symbols";
  * Rules:
  *   - CIRCUIT_PIN_UNDERSPECIFIED — multi-terminal part given fewer nets than
  *     pins (missing pins left floating). [both modes via recovered]
+ *   - CIRCUIT_PIN_OVERSPECIFIED  — component given more nets than its explicit
+ *     pin declaration can represent. [netlist via recovered]
  *   - CIRCUIT_DUPLICATE_ID        — same component id declared twice. [both]
  *   - CIRCUIT_NO_GROUND           — has a source but no ground reference. [netlist]
  *   - CIRCUIT_FLOATING_NET        — a node only one pin connects to. [netlist]
@@ -143,6 +145,17 @@ export function lintCircuit(text: string): SchematexDiagnostic[] {
       code: "CIRCUIT_PIN_UNDERSPECIFIED",
       message: `component ${u.id} (${u.type}) needs ${u.expected} nets but got ${u.got}; the missing terminal(s) were left floating`,
       hint: `Give ${u.id} all ${u.expected} net connections (e.g. a transformer is \`${u.id} p1 p2 s1 s2 type=transformer\`). Unconnected pins are drawn but not wired.`,
+      fatal: false,
+    });
+  }
+
+  // ── Over-specified explicit pin lists (recovered during parse) ────────────
+  for (const o of ast.recovered?.overspecified ?? []) {
+    out.push({
+      severity: "warning",
+      code: "CIRCUIT_PIN_OVERSPECIFIED",
+      message: `component ${o.id} (${o.type}) declares ${o.expected} pins but received ${o.got} nets; the extra net(s) ${o.extraNets.map((net) => `"${net}"`).join(", ")} could not be bound`,
+      hint: `Add names for all ${o.got} pins to ${o.id}'s \`pins=\`/\`pins_left=\`/\`pins_right=\` attributes, or remove the extra net connections.`,
       fatal: false,
     });
   }

--- a/src/diagrams/circuit/netlist.ts
+++ b/src/diagrams/circuit/netlist.ts
@@ -31,7 +31,13 @@ import type {
   CircuitComponentType,
   CircuitNet,
 } from "../../core/types";
-import { getNetlistPinOrder, getSymbol } from "./symbols";
+import {
+  getGenericIcPinSides,
+  getNetlistPinOrder,
+  getSymbol,
+  getTerminalBlockPinLabels,
+  normalizePinName,
+} from "./symbols";
 
 export class NetlistParseError extends Error {
   constructor(message: string, public readonly line?: number) {
@@ -80,6 +86,7 @@ const TYPE_ALIASES: Record<string, CircuitComponentType> = {
   gnd: "ground",
   ic: "generic_ic",
   reg: "voltage_regulator",
+  "555": "555_timer",
   timer555: "555_timer",
   transistor: "npn",
   bjt_npn: "npn",
@@ -178,6 +185,13 @@ export function parseNetlist(
   const pinMap: Record<string, Record<string, string>> = {};
   let autoGnd = 0;
   const underspecified: { id: string; type: string; expected: number; got: number }[] = [];
+  const overspecified: {
+    id: string;
+    type: string;
+    expected: number;
+    got: number;
+    extraNets: string[];
+  }[] = [];
 
   const ensureNet = (name: string): CircuitNet => {
     let n = netByName.get(name);
@@ -245,6 +259,7 @@ export function parseNetlist(
     const defaults = PREFIX_MAP[prefix];
     let cType: CircuitComponentType;
     let pinOrder: string[];
+    let genericIcHasExplicitPins = false;
 
     if (kv.type) {
       const t = kv.type.toLowerCase();
@@ -273,6 +288,43 @@ export function parseNetlist(
       );
     }
 
+    // Generic ICs have per-instance pin counts and anchors. Persist the DIP
+    // side labels into attrs so the symbol renderer and effectiveSymbolDef()
+    // build pin legs and wire anchors from the exact same inputs.
+    if (cType === "generic_ic") {
+      let orderedLabels: string[];
+      if (kv.pins !== undefined) {
+        orderedLabels = kv.pins.split(",").map((label) => label.trim()).filter(Boolean);
+        genericIcHasExplicitPins = true;
+        const leftCount = Math.ceil(orderedLabels.length / 2);
+        kv.pins_left = orderedLabels.slice(0, leftCount).join(",");
+        kv.pins_right = orderedLabels.slice(leftCount).reverse().join(",");
+      } else if (kv.pins_left !== undefined || kv.pins_right !== undefined) {
+        const sides = getGenericIcPinSides(kv);
+        kv.pins_left = sides.left.join(",");
+        kv.pins_right = sides.right.join(",");
+        orderedLabels = [...sides.left, ...[...sides.right].reverse()];
+        genericIcHasExplicitPins = true;
+      } else {
+        orderedLabels = Array.from({ length: netRefs.length }, (_, index) => `${index + 1}`);
+        const leftCount = Math.ceil(orderedLabels.length / 2);
+        kv.pins_left = orderedLabels.slice(0, leftCount).join(",");
+        kv.pins_right = orderedLabels.slice(leftCount).reverse().join(",");
+      }
+      pinOrder = orderedLabels.map((label, index) =>
+        normalizePinName(label, `pin_${index + 1}`)
+      );
+    }
+
+    // Terminal blocks are also per-instance symbols. Resolve their pin order
+    // before tail/value handling so T-prefix, type=terminal_block, pins=, and
+    // terminals= all bind against the same labels used by the rendered legs.
+    if (cType === "terminal_block") {
+      pinOrder = getTerminalBlockPinLabels(kv).map((label, index) =>
+        normalizePinName(label, `t${index + 1}`)
+      );
+    }
+
     // Net refs consumption depends on type: last net ref may actually be the
     // "value" / "model" if it doesn't look like a net name.
     // Heuristic: if we have more refs than expected pins+0, last one is value.
@@ -280,7 +332,22 @@ export function parseNetlist(
     const expectedPins = pinOrder.length;
     let valueFromTail: string | undefined;
 
-    if (netRefs.length > expectedPins && expectedPins > 0) {
+    if (
+      cType === "generic_ic" &&
+      genericIcHasExplicitPins &&
+      netRefs.length > expectedPins
+    ) {
+      const got = netRefs.length;
+      const extraNets = netRefs.slice(expectedPins);
+      netRefs.length = expectedPins;
+      overspecified.push({
+        id,
+        type: cType,
+        expected: expectedPins,
+        got,
+        extraNets,
+      });
+    } else if (netRefs.length > expectedPins && expectedPins > 0) {
       // tail contains model/value
       const tail = netRefs.slice(expectedPins);
       netRefs.length = expectedPins;
@@ -312,18 +379,6 @@ export function parseNetlist(
     // implicit. The parser supports `GND1 gnd_net` as a 1-pin component.
     if (cType === "ground" || cType === "gnd_signal" || cType === "gnd_chassis" || cType === "gnd_digital") {
       pinOrder = ["start"];
-    }
-
-    // Terminal block / junction box: pins from pins="..." attr (or t1/t2/…).
-    // Always reset pinOrder — prefix-derived defaults (e.g. J→jfet_n) are wrong here.
-    if (cType === "terminal_block") {
-      const pinsAttr = kv.pins ?? kv.terminals;
-      const labels = pinsAttr
-        ? pinsAttr.split(",").map((s) => s.trim()).filter(Boolean)
-        : Array.from({ length: Math.max(netRefs.length, 1) }, (_, i) => `t${i + 1}`);
-      pinOrder = labels.map((label, idx) =>
-        label.toLowerCase().replace(/[^a-z0-9]+/g, "_") || `t${idx + 1}`
-      );
     }
 
     if (netRefs.length < pinOrder.length) {
@@ -417,6 +472,10 @@ export function parseNetlist(
     pinMap,
     mode: "netlist",
   };
-  if (underspecified.length) ast.recovered = { underspecified };
+  if (underspecified.length || overspecified.length) {
+    ast.recovered = {};
+    if (underspecified.length) ast.recovered.underspecified = underspecified;
+    if (overspecified.length) ast.recovered.overspecified = overspecified;
+  }
   return ast;
 }

--- a/src/diagrams/circuit/renderer.ts
+++ b/src/diagrams/circuit/renderer.ts
@@ -1,7 +1,7 @@
 import type { CircuitAST, RenderConfig, SceneItem } from "../../core/types";
 import { layoutCircuit, type LaidOutComponent, type CircuitLayoutResult } from "./layout";
 import { layoutCircuitNetlist, rerouteCircuitNetlist, type RoutedWire } from "./autolayout";
-import { getSymbol } from "./symbols";
+import { effectiveSymbolDef, getSymbol } from "./symbols";
 import {
   svgRoot,
   defs,
@@ -149,7 +149,7 @@ function renderItem(
     ));
   }
 
-  const sym = getSymbol(comp.componentType);
+  const sym = effectiveSymbolDef(comp.componentType, comp.attrs) ?? getSymbol(comp.componentType);
   if (!sym) {
     return wrap(`<rect x="${tx - 10}" y="${ty - 10}" width="20" height="20" fill="none" class="schematex-circuit-err" stroke-dasharray="3,2"/><text x="${tx}" y="${ty + 3}" text-anchor="middle" font-size="9" class="schematex-circuit-err">?${escapeXml(comp.componentType)}</text>`);
   }

--- a/src/diagrams/circuit/symbols.ts
+++ b/src/diagrams/circuit/symbols.ts
@@ -843,8 +843,68 @@ const antenna: SymbolDef = {
 
 // ─── ICs / Generic blocks ────────────────────────────────────
 
+const IC_BODY_W = 80;
+const IC_PIN_PITCH = 16;
+const GENERIC_IC_LEFT = ["1", "2", "3", "4"];
+const GENERIC_IC_RIGHT = ["8", "7", "6", "5"];
+
+interface IcPinSides {
+  left: string[];
+  right: string[];
+}
+
+function pinLabels(value: string | undefined, fallback: string[]): string[] {
+  return value === undefined
+    ? [...fallback]
+    : value.split(",").map((label) => label.trim()).filter(Boolean);
+}
+
+function resolveIcPinSides(
+  defaultLeft: string[],
+  defaultRight: string[],
+  attrs?: Record<string, string>
+): IcPinSides {
+  return {
+    left: pinLabels(attrs?.pins_left, defaultLeft),
+    right: pinLabels(attrs?.pins_right, defaultRight),
+  };
+}
+
+export function normalizePinName(label: string, fallback: string): string {
+  return label.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "") || fallback;
+}
+
+export function getGenericIcPinSides(attrs?: Record<string, string>): IcPinSides {
+  return resolveIcPinSides(GENERIC_IC_LEFT, GENERIC_IC_RIGHT, attrs);
+}
+
+function icPinAnchors(
+  sides: IcPinSides,
+  leftNames?: string[],
+  rightNames?: string[]
+): Record<string, PinAnchor> {
+  const rowCount = Math.max(sides.left.length, sides.right.length, 2);
+  const bodyH = IC_PIN_PITCH * (rowCount + 1);
+  const topY = -bodyH / 2;
+  const anchors: Record<string, PinAnchor> = {
+    start: { x: 0, y: 0 },
+    end: { x: IC_BODY_W, y: 0 },
+  };
+
+  for (let i = 0; i < sides.left.length; i++) {
+    const name = leftNames?.[i] ?? normalizePinName(sides.left[i], `pin_${i + 1}`);
+    anchors[name] = { x: -8, y: topY + IC_PIN_PITCH * (i + 1) };
+  }
+  for (let i = 0; i < sides.right.length; i++) {
+    const spicePosition = sides.left.length + sides.right.length - i;
+    const name = rightNames?.[i] ?? normalizePinName(sides.right[i], `pin_${spicePosition}`);
+    anchors[name] = { x: IC_BODY_W + 8, y: topY + IC_PIN_PITCH * (i + 1) };
+  }
+  return anchors;
+}
+
 /**
- * Generic IC — 8-pin dual-inline rectangular block.
+ * Dual-inline rectangular IC block with per-instance pin labels.
  * `attrs.pins_left` / `attrs.pins_right`: comma-separated pin labels.
  * Total pins determine body height. Left pins are input side (start anchor
  * attaches to pin 1 = top-left).
@@ -854,36 +914,33 @@ function icSymbol(
   defaultRight: string[],
   bodyLabel?: string
 ): SymbolDef {
-  const BODY_W = 80;
   return {
-    length: BODY_W,
+    length: IC_BODY_W,
     netlistPins: [],
     anchors: {
       start: { x: 0, y: 0 },
-      end: { x: BODY_W, y: 0 },
+      end: { x: IC_BODY_W, y: 0 },
     },
     svg: (_label?: string, _value?: string, attrs?: Record<string, string>) => {
-      const left = (attrs?.pins_left ? attrs.pins_left.split(",").map((s) => s.trim()) : defaultLeft);
-      const right = (attrs?.pins_right ? attrs.pins_right.split(",").map((s) => s.trim()) : defaultRight);
+      const { left, right } = resolveIcPinSides(defaultLeft, defaultRight, attrs);
       const n = Math.max(left.length, right.length, 2);
-      const pitch = 16;
-      const bodyH = pitch * (n + 1);
+      const bodyH = IC_PIN_PITCH * (n + 1);
       const topY = -bodyH / 2;
       const parts: string[] = [];
-      parts.push(`<rect x="0" y="${topY}" width="${BODY_W}" height="${bodyH}" fill="white" ${BODY}/>`);
+      parts.push(`<rect x="0" y="${topY}" width="${IC_BODY_W}" height="${bodyH}" fill="white" ${BODY}/>`);
       const labelText = attrs?.ic_label ?? bodyLabel ?? "";
       if (labelText) {
-        parts.push(`<text x="${BODY_W / 2}" y="3" text-anchor="middle" class="schematex-circuit-meter">${labelText}</text>`);
+        parts.push(`<text x="${IC_BODY_W / 2}" y="3" text-anchor="middle" class="schematex-circuit-meter">${labelText}</text>`);
       }
       for (let i = 0; i < left.length; i++) {
-        const y = topY + pitch * (i + 1);
+        const y = topY + IC_PIN_PITCH * (i + 1);
         parts.push(`<line x1="-8" y1="${y}" x2="0" y2="${y}" ${WIRE}/>`);
         parts.push(`<text x="4" y="${y + 3}" class="schematex-circuit-pol">${left[i]}</text>`);
       }
       for (let i = 0; i < right.length; i++) {
-        const y = topY + pitch * (i + 1);
-        parts.push(`<line x1="${BODY_W}" y1="${y}" x2="${BODY_W + 8}" y2="${y}" ${WIRE}/>`);
-        parts.push(`<text x="${BODY_W - 4}" y="${y + 3}" text-anchor="end" class="schematex-circuit-pol">${right[i]}</text>`);
+        const y = topY + IC_PIN_PITCH * (i + 1);
+        parts.push(`<line x1="${IC_BODY_W}" y1="${y}" x2="${IC_BODY_W + 8}" y2="${y}" ${WIRE}/>`);
+        parts.push(`<text x="${IC_BODY_W - 4}" y="${y + 3}" text-anchor="end" class="schematex-circuit-pol">${right[i]}</text>`);
       }
       return parts.join("");
     },
@@ -891,8 +948,8 @@ function icSymbol(
 }
 
 const generic_ic: SymbolDef = icSymbol(
-  ["1", "2", "3", "4"],
-  ["8", "7", "6", "5"],
+  GENERIC_IC_LEFT,
+  GENERIC_IC_RIGHT,
   "IC"
 );
 
@@ -901,24 +958,13 @@ const timer_555: SymbolDef = (() => {
   const left = ["GND", "TRG", "OUT", "RST"];
   const right = ["VCC", "DIS", "THR", "CTL"];
   const sym = icSymbol(left, right, "555");
-  // Add custom pin anchors so DSL can reference U1.trg, U1.out, etc.
-  const BODY_W = 80;
-  const pitch = 16;
-  const n = 4;
-  const bodyH = pitch * (n + 1);
-  const topY = -bodyH / 2;
-  const anchors: Record<string, PinAnchor> = {
-    start: { x: 0, y: 0 },
-    end: { x: BODY_W, y: 0 },
-  };
   const leftNames = ["gnd", "trg", "out", "rst"];
   const rightNames = ["vcc", "dis", "thr", "ctl"];
-  for (let i = 0; i < n; i++) {
-    const y = topY + pitch * (i + 1);
-    anchors[leftNames[i]] = { x: -8, y };
-    anchors[rightNames[i]] = { x: BODY_W + 8, y };
-  }
-  return { ...sym, anchors };
+  return {
+    ...sym,
+    anchors: icPinAnchors({ left, right }, leftNames, rightNames),
+    netlistPins: ["gnd", "trg", "out", "rst", "ctl", "thr", "dis", "vcc"],
+  };
 })();
 
 const voltage_regulator: SymbolDef = {
@@ -959,35 +1005,89 @@ const potentiometer: SymbolDef = {
     ].join(""),
 };
 
+const TERMINAL_BLOCK_BODY_W = 80;
+const TERMINAL_BLOCK_PIN_PITCH = 18;
+const TERMINAL_BLOCK_LABEL_BAND = 8;
+const DEFAULT_TERMINAL_BLOCK_PINS = ["1", "2", "3", "4"];
+
+interface TerminalBlockPinGeometry {
+  label: string;
+  anchorName: string;
+  x: number;
+  y: number;
+}
+
+interface TerminalBlockGeometry {
+  bodyWidth: number;
+  bodyHeight: number;
+  topY: number;
+  pins: TerminalBlockPinGeometry[];
+}
+
+export function getTerminalBlockPinLabels(attrs?: Record<string, string>): string[] {
+  const labels = pinLabels(attrs?.pins ?? attrs?.terminals, DEFAULT_TERMINAL_BLOCK_PINS);
+  return labels.length > 0 ? labels : ["T1"];
+}
+
+function terminalBlockGeometry(attrs?: Record<string, string>): TerminalBlockGeometry {
+  const labels = getTerminalBlockPinLabels(attrs);
+  const bodyHeight = TERMINAL_BLOCK_PIN_PITCH * (labels.length + 1);
+  const topY = -bodyHeight / 2;
+  return {
+    bodyWidth: TERMINAL_BLOCK_BODY_W,
+    bodyHeight,
+    topY,
+    pins: labels.map((label, index) => ({
+      label,
+      anchorName: normalizePinName(label, `t${index + 1}`),
+      x: -8,
+      // Reserve the label band for every instance so labels never move pins.
+      y:
+        topY +
+        TERMINAL_BLOCK_PIN_PITCH * (index + 1) +
+        TERMINAL_BLOCK_LABEL_BAND,
+    })),
+  };
+}
+
+function terminalBlockAnchors(
+  geometry: TerminalBlockGeometry
+): Record<string, PinAnchor> {
+  const anchors: Record<string, PinAnchor> = {
+    start: { x: 0, y: 0 },
+    end: { x: geometry.bodyWidth, y: 0 },
+  };
+  for (const pin of geometry.pins) {
+    anchors[pin.anchorName] = { x: pin.x, y: pin.y };
+  }
+  return anchors;
+}
+
 // Terminal block / junction box. Pin anchors are dynamic per-instance from
-// `pins="..."`; the static `start`/`end` anchors here are placeholders.
+// `pins="..."` or `terminals="..."`; static start/end remain cursor anchors.
 const terminal_block: SymbolDef = {
-  length: 80,
+  length: TERMINAL_BLOCK_BODY_W,
   netlistPins: [],
-  anchors: { start: { x: 0, y: 0 }, end: { x: 80, y: 0 } },
+  anchors: {
+    start: { x: 0, y: 0 },
+    end: { x: TERMINAL_BLOCK_BODY_W, y: 0 },
+  },
   svg: (label?: string, _value?: string, attrs?: Record<string, string>) => {
-    const pinsAttr = attrs?.pins ?? attrs?.terminals ?? "1,2,3,4";
-    const pins = pinsAttr.split(",").map((s) => s.trim()).filter(Boolean);
-    const n = Math.max(pins.length, 1);
-    const BODY_W = 80;
-    const pitch = 18;
-    const bodyH = pitch * (n + 1);
-    const topY = -bodyH / 2;
+    const geometry = terminalBlockGeometry(attrs);
     const parts: string[] = [];
     parts.push(
-      `<rect x="0" y="${topY}" width="${BODY_W}" height="${bodyH}" rx="3" fill="white" stroke-width="2" ${BODY}/>`
+      `<rect x="0" y="${geometry.topY}" width="${geometry.bodyWidth}" height="${geometry.bodyHeight}" rx="3" fill="white" stroke-width="2" ${BODY}/>`
     );
     if (label) {
       parts.push(
-        `<text x="${BODY_W / 2}" y="${topY + 14}" text-anchor="middle" class="schematex-circuit-meter">${label}</text>`
+        `<text x="${geometry.bodyWidth / 2}" y="${geometry.topY + 14}" text-anchor="middle" class="schematex-circuit-meter">${label}</text>`
       );
     }
-    for (let i = 0; i < n; i++) {
-      const y = topY + pitch * (i + 1) + (label ? 8 : 0);
-      parts.push(`<line x1="-8" y1="${y}" x2="0" y2="${y}" ${WIRE}/>`);
-      parts.push(`<circle cx="6" cy="${y}" r="2" ${FILL}/>`);
+    for (const pin of geometry.pins) {
+      parts.push(`<line x1="${pin.x}" y1="${pin.y}" x2="0" y2="${pin.y}" ${WIRE}/>`);
+      parts.push(`<circle cx="6" cy="${pin.y}" r="2" ${FILL}/>`);
       parts.push(
-        `<text x="12" y="${y + 3}" class="schematex-circuit-pol">${pins[i] ?? `T${i + 1}`}</text>`
+        `<text x="12" y="${pin.y + 3}" class="schematex-circuit-pol">${pin.label}</text>`
       );
     }
     return parts.join("");
@@ -1002,6 +1102,13 @@ function numAttr(attrs: Record<string, string> | undefined, key: string, fallbac
 export function effectiveSymbolDef(type: string, attrs?: Record<string, string>): SymbolDef | undefined {
   const sym = getSymbol(type);
   if (!sym) return undefined;
+  if (type === "generic_ic") {
+    return { ...sym, anchors: icPinAnchors(getGenericIcPinSides(attrs)) };
+  }
+  if (type === "terminal_block") {
+    const geometry = terminalBlockGeometry(attrs);
+    return { ...sym, anchors: terminalBlockAnchors(geometry) };
+  }
   if (type !== "enclosure" && type !== "din_rail" && type !== "wire_duct") return sym;
 
   if (type === "enclosure") {
@@ -1867,7 +1974,7 @@ export function listCircuitSymbolTypes(): CircuitComponentType[] {
 export function getNetlistPinOrder(t: string): string[] | undefined {
   const sym = getSymbol(t);
   if (!sym) return undefined;
-  if (sym.netlistPins) return [...sym.netlistPins];
+  if (sym.netlistPins?.length) return [...sym.netlistPins];
   if (sym.anchors.start && sym.anchors.end) return ["start", "end"];
   return Object.keys(sym.anchors);
 }

--- a/tests/circuit/ic-netlist.test.ts
+++ b/tests/circuit/ic-netlist.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "vitest";
+import { layoutCircuitNetlist } from "../../src/diagrams/circuit/autolayout";
+import { lintCircuit } from "../../src/diagrams/circuit/lint";
+import { parseCircuit } from "../../src/diagrams/circuit/parser";
+import { renderCircuit } from "../../src/diagrams/circuit/renderer";
+import {
+  effectiveSymbolDef,
+  getNetlistPinOrder,
+} from "../../src/diagrams/circuit/symbols";
+
+const ISSUE_79 = `circuit "555" netlist
+VCC 8 0 DC 5.0
+R1 8 7 1k
+R2 7 2 4.7k
+C1 2 0 10uf
+IC1 0 2 3 8 0 2 7 8 type=ic`;
+
+function routeTouchesPin(
+  layout: ReturnType<typeof layoutCircuitNetlist>,
+  componentId: string,
+  pinName: string
+): boolean {
+  const item = layout.items.find((candidate) => candidate.component.id === componentId);
+  const anchor = item?.anchors[pinName];
+  if (!anchor) return false;
+  return layout.routes.some((route) =>
+    route.points.some(
+      (point) => Math.abs(point.x - anchor.x) < 0.1 && Math.abs(point.y - anchor.y) < 0.1
+    )
+  );
+}
+
+function terminalLegEndpoints(svg: string): Array<{ y1: number; y2: number }> {
+  return [...svg.matchAll(/<line x1="-8" y1="([^"]+)" x2="0" y2="([^"]+)"/g)].map(
+    (match) => ({ y1: Number(match[1]), y2: Number(match[2]) })
+  );
+}
+
+describe("circuit netlist — multi-pin IC binding", () => {
+  test("issue #79 binds every generic IC net and emits routes from the connected pins", () => {
+    const ast = parseCircuit(ISSUE_79);
+
+    expect(ast.pinMap?.IC1).toEqual({
+      "1": "GND",
+      "2": "2",
+      "3": "3",
+      "4": "8",
+      "5": "GND",
+      "6": "2",
+      "7": "7",
+      "8": "8",
+    });
+
+    const ic = ast.components.find((component) => component.id === "IC1");
+    expect(ic?.attrs).toMatchObject({
+      pins_left: "1,2,3,4",
+      pins_right: "8,7,6,5",
+    });
+
+    const layout = layoutCircuitNetlist(ast);
+    const laidIc = layout.items.find((item) => item.component.id === "IC1");
+    expect(Object.keys(laidIc?.anchors ?? {})).toEqual(
+      expect.arrayContaining(["1", "2", "3", "4", "5", "6", "7", "8"])
+    );
+    // Pin 3 is the only intentionally dangling net in the issue repro. Every
+    // IC pin that shares a net with another component must terminate a route.
+    for (const pin of ["1", "2", "4", "5", "6", "7", "8"]) {
+      expect(routeTouchesPin(layout, "IC1", pin), `IC1.${pin} should be wired`).toBe(true);
+    }
+
+    const svg = renderCircuit(ast);
+    expect(svg).toMatch(/<polyline[^>]*class="schematex-circuit-wire"/);
+  });
+
+  test("type=555 binds SPICE positions 1..8 to the real 555 anchor names", () => {
+    const ast = parseCircuit(`circuit "timer" netlist
+R1 trig GND 1k
+R2 out GND 1k
+R3 reset GND 1k
+R4 ctrl GND 1k
+R5 thresh GND 1k
+R6 disch GND 1k
+V1 vcc GND 5V
+U1 GND trig out reset ctrl thresh disch vcc type=555`);
+
+    expect(ast.components.find((component) => component.id === "U1")?.componentType).toBe(
+      "555_timer"
+    );
+    expect(ast.pinMap?.U1).toEqual({
+      gnd: "GND",
+      trg: "trig",
+      out: "out",
+      rst: "reset",
+      ctl: "ctrl",
+      thr: "thresh",
+      dis: "disch",
+      vcc: "vcc",
+    });
+
+    const layout = layoutCircuitNetlist(ast);
+    for (const pin of ["gnd", "trg", "out", "rst", "ctl", "thr", "dis", "vcc"]) {
+      expect(routeTouchesPin(layout, "U1", pin), `U1.${pin} should be wired`).toBe(true);
+    }
+  });
+
+  test.each(["X1", "U1"])("%s prefix auto-numbers all declared nets", (id) => {
+    const ast = parseCircuit(`circuit "prefix" netlist\n${id} n1 n2 n3 n4`);
+    expect(ast.pinMap?.[id]).toEqual({
+      "1": "n1",
+      "2": "n2",
+      "3": "n3",
+      "4": "n4",
+    });
+  });
+
+  test("odd pin counts use the DIP left-down/right-up convention", () => {
+    const ast = parseCircuit(`circuit "odd" netlist
+U1 n1 n2 n3 n4 n5 n6 n7 n8 n9`);
+    const ic = ast.components.find((component) => component.id === "U1");
+    expect(ic?.attrs).toMatchObject({ pins_left: "1,2,3,4,5", pins_right: "9,8,7,6" });
+    expect(ast.pinMap?.U1).toEqual({
+      "1": "n1",
+      "2": "n2",
+      "3": "n3",
+      "4": "n4",
+      "5": "n5",
+      "6": "n6",
+      "7": "n7",
+      "8": "n8",
+      "9": "n9",
+    });
+
+    const layout = layoutCircuitNetlist(ast);
+    const anchors = layout.items.find((item) => item.component.id === "U1")?.anchors;
+    expect(anchors?.["1"].x).toBeLessThan(anchors?.["6"].x ?? 0);
+    expect(anchors?.["9"].y).toBeLessThan(anchors?.["6"].y ?? 0);
+
+    const symbolSvg = effectiveSymbolDef("generic_ic", ic?.attrs)?.svg(
+      ic?.label,
+      ic?.value,
+      ic?.attrs
+    );
+    expect(symbolSvg?.match(/<line [^>]*class="schematex-circuit-wire"/g)).toHaveLength(9);
+    expect(symbolSvg).toContain('height="96"');
+  });
+
+  test("explicit pins= names take precedence and drive both bindings and anchors", () => {
+    const ast = parseCircuit(`circuit "named" netlist
+U1 net_a net_b net_c pins="A,B,C"`);
+    expect(ast.pinMap?.U1).toEqual({ a: "net_a", b: "net_b", c: "net_c" });
+
+    const ic = ast.components.find((component) => component.id === "U1");
+    expect(ic?.attrs).toMatchObject({ pins_left: "A,B", pins_right: "C" });
+    const anchors = layoutCircuitNetlist(ast).items.find(
+      (item) => item.component.id === "U1"
+    )?.anchors;
+    expect(anchors).toMatchObject({
+      a: expect.any(Object),
+      b: expect.any(Object),
+      c: expect.any(Object),
+    });
+  });
+
+  test("explicit pins_left/pins_right preserve their displayed DIP order", () => {
+    const ast = parseCircuit(`circuit "sides" netlist
+U1 net_a net_b net_c net_d pins_left="A,B" pins_right="D,C"`);
+    expect(ast.pinMap?.U1).toEqual({
+      a: "net_a",
+      b: "net_b",
+      c: "net_c",
+      d: "net_d",
+    });
+  });
+
+  test("terminal blocks bind every net to a real laid-out anchor", () => {
+    const terminal = parseCircuit(`circuit "terminal" netlist
+VCC 1 0 DC 5.0
+T1 1 2 0 pins="L,N,PE"`);
+    expect(terminal.pinMap?.T1).toEqual({ l: "1", n: "2", pe: "GND" });
+
+    const layout = layoutCircuitNetlist(terminal);
+    const anchors = layout.items.find((item) => item.component.id === "T1")?.anchors;
+    for (const pin of ["l", "n", "pe"]) {
+      expect(anchors?.[pin], `T1.${pin} should resolve to an anchor`).toBeDefined();
+    }
+    for (const pin of ["l", "pe"]) {
+      expect(routeTouchesPin(layout, "T1", pin), `T1.${pin} should be wired`).toBe(true);
+    }
+
+    const opamp = parseCircuit(`circuit "opamp" netlist
+U1 noninv inv output type=opamp`);
+    expect(opamp.pinMap?.U1).toEqual({ plus: "noninv", minus: "inv", out: "output" });
+  });
+
+  test.each([
+    { caseName: "with a label", label: "T1" },
+    { caseName: "without a label", label: undefined },
+  ])("terminal anchors match painted leg endpoints $caseName", ({ label }) => {
+    const attrs = { pins: "L,N,PE" };
+    const symbol = effectiveSymbolDef("terminal_block", attrs);
+    expect(symbol).toBeDefined();
+    if (!symbol) throw new Error("terminal_block symbol is missing");
+
+    const svg = symbol.svg(label, undefined, attrs);
+    const legs = terminalLegEndpoints(svg);
+    const anchorYs = ["l", "n", "pe"].map((pin) => symbol.anchors[pin]?.y);
+    expect(anchorYs).toEqual(legs.map((leg) => leg.y1));
+    expect(anchorYs).toEqual(legs.map((leg) => leg.y2));
+    expect(["l", "n", "pe"].map((pin) => symbol.anchors[pin]?.x)).toEqual([-8, -8, -8]);
+  });
+
+  test("terminals= remains an alias for terminal block pin labels", () => {
+    const ast = parseCircuit(`circuit "terminal alias" netlist
+T1 line neutral earth terminals="L,N,PE"`);
+    expect(ast.pinMap?.T1).toEqual({ l: "line", n: "neutral", pe: "GND" });
+
+    const component = ast.components.find((candidate) => candidate.id === "T1");
+    const anchors = layoutCircuitNetlist(ast).items.find(
+      (item) => item.component.id === "T1"
+    )?.anchors;
+    expect(component?.attrs?.terminals).toBe("L,N,PE");
+    expect(anchors).toMatchObject({
+      l: expect.any(Object),
+      n: expect.any(Object),
+      pe: expect.any(Object),
+    });
+  });
+
+  test("empty netlistPins arrays no longer suppress the symbol fallback order", () => {
+    expect(getNetlistPinOrder("generic_ic")).toEqual(["start", "end"]);
+  });
+
+  test("extra nets beyond explicit IC pins surface a diagnostic instead of disappearing silently", () => {
+    const dsl = `circuit "too many" netlist
+U1 n1 n2 n3 n4 pins="A,B,C"`;
+    const ast = parseCircuit(dsl);
+    expect(ast.recovered?.overspecified?.[0]).toMatchObject({
+      id: "U1",
+      expected: 3,
+      got: 4,
+      extraNets: ["n4"],
+    });
+    expect(lintCircuit(dsl).map((diagnostic) => diagnostic.code)).toContain(
+      "CIRCUIT_PIN_OVERSPECIFIED"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #79.

## The bug

```
circuit "555" netlist
VCC 8 0 DC 5.0
R1 8 7 1k
R2 7 2 4.7k
C1 2 0 10uf
IC1 0 2 3 8 0 2 7 8 type=ic
```

The RC network renders correctly; the 8-pin IC floats with **zero wires**. Every net the user declared for that component is discarded without a diagnostic — the exact opposite of the guarantee the network engine advertises ("never silently drops a device/port/link").

## Root cause

`generic_ic` is built with `netlistPins: []`. In `getNetlistPinOrder()` the guard was `if (sym.netlistPins)` — an **empty array is truthy**, so it returned `[]`. That made `expectedPins === 0` in `netlist.ts`, the pin-binding loop never ran, `ensureNet()` was never called, and `pinMap[id]` came out `{}`.

Fixed at the root (`sym.netlistPins?.length`) so this class of failure cannot recur.

## Scope was wider than reported

Measured before fixing — all of these produced `pinMap[id] === {}`:

| Input | Before | After |
|---|---|---|
| `IC1 … type=ic` | 0 pins bound | 8/8 wired |
| `X1 …` (SPICE prefix) | 0 pins bound | 8/8 wired |
| `U1 …` (SPICE prefix) | 0 pins bound | 8/8 wired |
| `U1 … type=555` | 0 pins bound | 8/8 wired |
| `T1 … pins="L,N,PE"` | bound, but **no anchors** → no wires | 3/3 wired |

`type=555` was broken too, so the obvious workaround for this issue did not work either. `terminal_block` bound its nets but had only `start`/`end` anchors, so `anchorForNet()` resolved every pin to `undefined` and drew nothing — a pre-existing bug of the same class (confirmed on `main`), fixed here since the machinery was already being built.

## How it is fixed

A wire needs the pin name to exist in **both** `pinMap` (from `netlist.ts`) and `SymbolDef.anchors` (consumed by `layout.ts` / `autolayout.ts`). Both are now derived from one source:

- `netlist.ts` derives DIP-ordered pin names from the declared net count (`1..N`, left top-to-bottom then right bottom-to-top) and persists the side labels into `attrs`.
- `effectiveSymbolDef()` builds per-instance anchors from those same `attrs`, so the painted pin legs and the wire endpoints share a geometry helper and cannot drift.
- `type=555` binds the real pinout in SPICE order: `1 GND, 2 TRIG, 3 OUT, 4 RESET, 5 CTRL, 6 THRESH, 7 DISCH, 8 VCC`.
- `terminal_block`'s label band is now reserved unconditionally so pin-leg positions no longer depend on whether a label is present — otherwise anchors (which never see the label) would sit 8 units off the painted legs.
- Explicit `pins=` lists given more nets than they name now raise `CIRCUIT_PIN_OVERSPECIFIED` instead of truncating silently.

## Verification

Beyond the unit tests, each case was checked end-to-end: every bound pin name resolves to a defined anchor **and** a routed wire vertex actually lands on that anchor's coordinates. The one apparent miss (`terminal_block` pin `n` at 2/3) turned out to be a genuinely floating net — `CIRCUIT_FLOATING_NET` correctly warns about it, and it wires 3/3 once the net has a second endpoint.

Gate: `typecheck` pass · **2475 tests pass** (184 files) · `lint` 0 errors · `build` ESM/CJS/DTS pass.

Zero new dependencies. No compatibility branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)