### PR TITLE
fix(website): serve English docs links without the /en prefix

### DIFF
--- a/website/app/api/pseo/manifest/route.ts
+++ b/website/app/api/pseo/manifest/route.ts
@@ -1,6 +1,6 @@
 import { source } from '@/lib/source';
 import { LIVE_LOCALES } from '@/lib/i18n/locales';
-import { buildDocLocaleMap, docBarePath, docFileKey } from '@/lib/docs-locales';
+import { buildDocLocaleMap, docFileKey } from '@/lib/docs-locales';
 import { allExamples } from '@/lib/examples-source';
 
 export const runtime = 'nodejs';
@@ -19,16 +19,9 @@ export function GET(request: Request) {
   // from localeMap (actual translation files, not fumadocs fallbacks).
   const enPages = source.getPages('en');
   const docSlugs = enPages.flatMap((page) => {
-    // IMPORTANT: do NOT use page.url here. fumadocs i18n prefixes EVERY locale
-    // (including the default) so page.url is '/en/docs/api', not '/docs/api'.
-    // The cockpit treats the manifest slug as the locale-agnostic baseSlug and
-    // prepends each non-default locale itself (→ '/fr/docs/api'); feeding it the
-    // already-prefixed '/en/docs/api' both breaks the grouping (group header
-    // shows '/en/...') and produces double-prefixed URLs like '/fr/en/docs/api'.
-    // English is served bare at '/docs/...' (app/docs/[[...slug]]). So emit the
-    // bare canonical path, same for every locale; the cockpit prefixes non-default
-    // locales itself.
-    const slug = docBarePath(page.slugs);
+    // English page URLs are locale-agnostic base slugs. The cockpit prepends
+    // non-default locales itself (for example, '/fr/docs/api').
+    const slug = page.url;
     const locales = localeMap[docFileKey(page.slugs)] ?? ['en'];
 
     return locales.map((locale) => ({

--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -44,9 +44,7 @@ export async function generateMetadata(props: { params: Promise<{ slug?: string[
       }
     : undefined;
 
-  // NOT page.url — fumadocs i18n prefixes the default locale too, so page.url
-  // is '/en/docs/api', which 404s. English docs are served bare at '/docs/...'.
-  const canonicalPath = params.slug?.length ? `/docs/${params.slug.join('/')}` : '/docs';
+  const canonicalPath = page.url;
 
   return {
     title: page.data.title,

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from 'next';
 import { source } from '@/lib/source';
 import { allExamples } from '@/lib/examples-source';
 import { LIVE_LOCALES, buildLanguageAlternates, localizedUrl } from '@/lib/i18n/locales';
-import { buildDocLocaleMap, docBarePath, docFileKey } from '@/lib/docs-locales';
+import { buildDocLocaleMap, docFileKey } from '@/lib/docs-locales';
 
 const SITE = 'https://schematex.js.org';
 const NOW = new Date();
@@ -27,13 +27,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${SITE}/changelog`, priority: 0.6, lastModified: NOW, changeFrequency: 'weekly' },
     { url: `${SITE}/icons`, priority: 0.6, lastModified: NOW, changeFrequency: 'monthly' },
   ];
-  // One sitemap entry per (doc page × translated locale). NOT page.url — fumadocs
-  // i18n prefixes the default locale, so page.url is '/en/docs/api' (a 404). The
-  // English doc is served bare at '/docs/api'; translated locales at '/<loc>/docs/api'.
-  // Each entry carries the hreflang alternate set across its live translations.
+  // One sitemap entry per (doc page × translated locale). English page.url is
+  // the bare path; localizedUrl adds a prefix only for non-default locales.
   const localeMap = buildDocLocaleMap();
   const docPages: MetadataRoute.Sitemap = source.getPages('en').flatMap((page) => {
-    const barePath = docBarePath(page.slugs);
+    const barePath = page.url;
     const locales = localeMap[docFileKey(page.slugs)] ?? ['en'];
     const languages = Object.fromEntries(
       locales.map((locale) => [locale, localizedUrl(SITE, locale, barePath)]),

--- a/website/lib/docs-locales.ts
+++ b/website/lib/docs-locales.ts
@@ -38,9 +38,8 @@ export function buildDocLocaleMap(): Record<string, string[]> {
 }
 
 /** The bare (locale-agnostic) canonical path for a docs page given its fumadocs
- *  `page.slugs`. English is served here; non-default locales get a `/<locale>`
- *  prefix applied by the caller. NEVER derive this from `page.url` — fumadocs
- *  i18n prefixes the default locale too, yielding '/en/docs/api' which 404s. */
+ *  `page.slugs`. English is served here; callers add a `/<locale>` prefix for
+ *  non-default locales when needed. */
 export function docBarePath(slugs: string[]): string {
   return slugs.length ? `/docs/${slugs.join('/')}` : '/docs';
 }

--- a/website/lib/source.ts
+++ b/website/lib/source.ts
@@ -12,6 +12,7 @@ export const docsI18n = defineI18n({
   defaultLanguage: 'en',
   languages: [...DOC_LOCALES],
   fallbackLanguage: 'en',
+  hideLocale: 'default-locale',
 });
 
 export const source = loader({


### PR DESCRIPTION
Fixes #67.

## The bug

Every reference page in the docs sidebar linked to `/en/docs/<page>` and rendered a generic 404. Reproduced live before fixing: `https://schematex.js.org/en/docs/genogram` 404s, `https://schematex.js.org/docs/genogram` works. In-page links were already correct, so only the sidebar (and anything else derived from the page tree) was affected.

## Root cause

`defineI18n()` in `website/lib/source.ts` was called without `hideLocale`. fumadocs defaults to `'never'`, which prefixes **every** locale including the default one — but the App Router serves English bare at `/docs/*` and has no `/en/*` route. So the generated `pageTree` pointed at URLs that do not exist.

The trap was already known: `lib/docs-locales.ts` carried a comment warning never to derive paths from `page.url` for exactly this reason. The sitemap worked around it; the sidebar had no such escape hatch.

## The fix

`hideLocale: 'default-locale'` — one line, fixes `page.url` at the source.

Three call sites had each grown their own manual `/en/` compensation (sitemap, pSEO manifest, canonical metadata). With the root cause fixed those workarounds would double-apply, so they now trust `page.url` and the duplicated logic is deleted rather than layered. No redirect shim: `/en/docs/*` was never a real route and does not become one.

## Verification

Checked against the production build output, not just the source:

- **No `/en/docs/` link is emitted anywhere** in the build.
- English resolves to `/docs/genogram`.
- All eight non-default locales keep their prefix — `/de/`, `/es/`, `/fr/`, `/ja/`, `/ko/`, `/pt-BR/`, `/zh-Hans/`, `/zh-Hant/` — confirming the change hides only the default locale.

`next build` passes (535 pages), `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)