### PR TITLE
Add contextual links to Schematex-powered diagram makers

### DIFF
--- a/website/components/home/HomeContent.tsx
+++ b/website/components/home/HomeContent.tsx
@@ -587,8 +587,12 @@ export function HomeContent({
               <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
                 {[
                   { name: 'ChatDiagram', href: 'https://chatdiagram.com', logo: '/logos/chatdiagram.svg' },
-                  { name: 'FreeDiagram', href: 'https://freediagram.app', logo: '/logos/freediagram.svg' },
-                  { name: 'FloorPlan Maker', href: 'https://www.floorplanmaker.app', logo: '/logos/floorplanmaker.svg' },
+                  { name: 'FreeDiagram', href: 'https://www.freediagram.app/', logo: '/logos/freediagram.svg' },
+                  { name: 'FloorPlan Maker', href: 'https://www.floorplanmaker.app/', logo: '/logos/floorplanmaker.svg' },
+                  { name: 'CircuitMaker.ai', href: 'https://circuitmaker.ai/', logo: '/logos/circuitmaker.svg' },
+                  { name: 'GenogramMaker.ai', href: 'https://genogrammaker.ai/', logo: '/logos/genogrammaker.svg' },
+                  { name: 'PedigreeMaker.ai', href: 'https://pedigreemaker.ai/', logo: '/logos/pedigreemaker.svg' },
+                  { name: 'FloorPlanCreator.org', href: 'https://floorplancreator.org/', logo: '/logos/floorplancreator.svg' },
                 ].map((p) => (
                   <a
                     key={p.name}

--- a/website/content/docs/bpmn.mdx
+++ b/website/content/docs/bpmn.mdx
@@ -10,6 +10,8 @@ Schematex implements OMG **BPMN 2.0.2 / ISO/IEC 19510:2013** for the elements th
 
 > **Note** — Schematex is a rendering library, not a process-execution engine. There is no token simulation, no XML round-trip, and no DI (Diagram Interchange) layer. v0.1 covers the visual subset most teams use; boundary events, expanded subprocesses, and the rare trigger types (cancel / compensation / escalation / signal / link) are deferred to v0.2+.
 
+If the process currently exists as a narrative of roles, tasks, and handoffs, [FreeDiagram's BPMN maker](https://www.freediagram.app/bpmn-maker) can turn it into an initial visual model.
+
 <Playground initial={`bpmn
 direction: LR
 title: "Loan Application Approval"

--- a/website/content/docs/breadboard.mdx
+++ b/website/content/docs/breadboard.mdx
@@ -10,6 +10,8 @@ Schematex implements **Fritzing-style** stylized breadboard rendering. Component
 
 > **Note** — this engine is *not* a circuit schematic and does not enforce electrical rules. Use it for tutorials, lab handouts, READMEs, and learning material. For nodal analysis or formal schematics, use the `circuit` engine instead.
 
+For maker instructions that begin with a board, parts, and the intended connections, [CircuitMaker.ai's breadboard diagram maker](https://circuitmaker.ai/breadboard-diagram-maker) can lay out the first wiring view.
+
 <Playground initial={`breadboard
 board: half
 title: "Blink LED — Arduino Uno hello-world"

--- a/website/content/docs/circuit.mdx
+++ b/website/content/docs/circuit.mdx
@@ -8,6 +8,8 @@ A **circuit schematic** is the standard graphical representation of an electroni
 
 The DSL has two modes. **Netlist mode (recommended)** is SPICE-style: you list components and the nodes they connect to, and the engine lays everything out automatically — each line is self-contained, with no spatial state to track. **Positional mode** is for hand-drawing: components chain in a direction like Schemdraw. Both produce the same SVG. **For generated diagrams (e.g. by an LLM), always use netlist mode** — it has by far the smaller error surface.
 
+When the input is a plain-language circuit description rather than a netlist, [CircuitMaker.ai's schematic maker](https://circuitmaker.ai/schematic-maker) can generate the first schematic with this engine.
+
 <Playground initial={`circuit "CE Amp (netlist)" netlist
 V1 vcc 0 9V
 Rc vcc c 2.2k

--- a/website/content/docs/decisiontree.mdx
+++ b/website/content/docs/decisiontree.mdx
@@ -8,6 +8,8 @@ A **decision tree** is a branching diagram that represents a sequence of choices
 
 Schematex decision trees cover: (1) **taxonomy mode** — the yes/no question flows used in medical triage ([Turing 1937](https://en.wikipedia.org/wiki/Decision_tree) lineage; now standard in clinical decision support), (2) **decision analysis mode** — the expected-value rollback method developed in management science ([Raiffa & Schlaifer, 1961](https://en.wikipedia.org/wiki/Decision_tree#Decision_analysis)), and (3) **ML mode** — the CART split/leaf format used to visualize scikit-learn and similar trained classifiers ([Breiman et al., 1984](https://en.wikipedia.org/wiki/Decision_tree_learning)).
 
+For a decision process that is easier to describe as questions and outcomes, [FreeDiagram's decision tree maker](https://www.freediagram.app/decision-tree-maker) can produce the initial branching structure.
+
 <Playground initial={`
   decisiontree "Customer Support Triage"
   direction: top-down

--- a/website/content/docs/ecomap.mdx
+++ b/website/content/docs/ecomap.mdx
@@ -8,6 +8,8 @@ An **ecomap** is a single page that shows a person or family at the center and t
 
 Schematex follows the **[Hartman (1978) ecomap model](https://journals.sagepub.com/doi/10.1177/104438947805900803)** — the original *Social Casework* paper that introduced the notation — extended with conventions from contemporary clinical social work practice. For background see [Wikipedia: Ecomap](https://en.wikipedia.org/wiki/Ecomap). This page documents what the parser accepts today.
 
+When the source is a case summary naming the client, systems, and relationship quality, [GenogramMaker.ai's ecomap maker](https://genogrammaker.ai/ecomap-maker) can turn it into a first-pass ecomap.
+
 <Playground initial={`ecomap "Nguyen Family Resettlement"
   center: family [label: "Nguyen Family"]
   resettlement [label: "IRC Office", category: government]

--- a/website/content/docs/erd.mdx
+++ b/website/content/docs/erd.mdx
@@ -10,6 +10,8 @@ Schematex implements **crow's-foot notation** — the de-facto modern style used
 
 > **Note** — This is **not** the same as the `entity` engine. `entity` (entity structure) is for **corporate / legal ownership** hierarchies (subsidiaries, percentage rollup, trusts). `erd` is for **database schemas** (tables, columns, foreign keys). Different domain, different layout, different audience.
 
+When a schema is still being described in terms of tables and relationships rather than DBML, [FreeDiagram's ER diagram maker](https://www.freediagram.app/er-diagram-maker) can create a useful first draft.
+
 <Playground initial={`erd
 title: "University Schema"
 

--- a/website/content/docs/fishbone.mdx
+++ b/website/content/docs/fishbone.mdx
@@ -8,6 +8,8 @@ A **fishbone diagram** (also called an Ishikawa or cause-and-effect diagram) map
 
 Schematex follows **Ishikawa (1968)** cause-and-effect conventions with the standard 6M manufacturing categories (Man, Machine, Material, Method, Measurement, Mother Nature/Environment) and their service variants (People, Process, Place, Policy, Procedures, Patron). Two authoring styles — structured and compact — can be mixed in one document. External references: [Ishikawa, K. — Guide to Quality Control (1968)](https://en.wikipedia.org/wiki/Ishikawa_diagram) · [ASQ Cause-and-Effect Diagram](https://asq.org/quality-resources/cause-analysis-tools/fishbone) · [ISO 9001:2015 §10.2 — Corrective Action](https://www.iso.org/standard/62085.html).
 
+If a team has already captured the problem and suspected causes in meeting notes, [FreeDiagram's fishbone diagram maker](https://www.freediagram.app/fishbone-diagram-maker) can organize them into a first-pass Ishikawa diagram.
+
 <Playground initial={`fishbone "Solder Joint Defect Rate — Root Cause Analysis"
 effect "3.2% solder joint failure rate"
 category man "Man"

--- a/website/content/docs/floorplan.mdx
+++ b/website/content/docs/floorplan.mdx
@@ -8,6 +8,8 @@ A **floor plan** is the standard 2D architectural view of a space: rooms with re
 
 Unlike image generators, the output is *measurable and editable* — every room is a labeled element with its computed area, and adding a fourth row of desks is a one-line edit.
 
+For a new layout that begins as room requirements and dimensions, [FloorPlan Maker](https://www.floorplanmaker.app/free-floor-plan-maker) can generate a measurable first draft with this engine.
+
 <Playground initial={`floorplan "Studio Apartment" unit m
 room main   "Living / Sleeping" at 0,0 size 5.2x4.0
 room bath   "Bath"   right-of main size 2.0x2.2
@@ -68,6 +70,8 @@ extend living at 5,2 size 2x2          # L-shape: notch at top-right
 ```
 
 An extension that doesn't touch the room, or overlaps it, is rejected with a quantified error. `north` (optionally `north 30` for rotated plans) adds the compass at the top right.
+
+For an addition or conversion where the existing home defines the starting geometry, [FloorPlanCreator.org](https://floorplancreator.org/) provides a workflow centered on that remodeling context.
 
 ---
 

--- a/website/content/docs/flowchart.mdx
+++ b/website/content/docs/flowchart.mdx
@@ -8,6 +8,8 @@ A **flowchart** maps the steps of a process — decisions, operations, inputs, o
 
 Schematex follows the **[ISO 5807:1985](https://www.iso.org/standard/11955.html)** symbol conventions for flowchart shapes and uses a **[Mermaid-compatible](https://mermaid.js.org/syntax/flowchart.html)** DSL so existing Mermaid flowcharts transfer directly. This page documents what the parser accepts today.
 
+For a one-off workflow that begins as a written process, [FreeDiagram's flowchart maker](https://www.freediagram.app/flowchart-maker) provides a plain-language route into the same rendering engine.
+
 <Playground initial={`flowchart LR
   start([New order received])
   start --> validate{Inventory available?}

--- a/website/content/docs/genogram.mdx
+++ b/website/content/docs/genogram.mdx
@@ -8,6 +8,8 @@ A **genogram** is a family diagram that goes beyond the names-and-dates of a tra
 
 Schematex follows the **[McGoldrick, Gerson & Petry (2020) standard](https://www.guilford.com/books/Genograms/McGoldrick-Gerson-Petry/9781462542055)** used in clinical training, plus the widely adopted **[GenoPro](https://genopro.com/genogram/) 32-type emotional-relationship taxonomy**. For theory and history see [Wikipedia: Genogram](https://en.wikipedia.org/wiki/Genogram). This page documents what the parser accepts today.
 
+Clinicians who begin with a plain-English family description can use [GenogramMaker.ai](https://genogrammaker.ai/) to create an initial genogram with this notation, then return here for precise syntax.
+
 <Playground initial={`genogram "The Potter Family"
   fleamont [male, 1909, 1979, deceased]
   euphemia [female, 1920, 1979, deceased]

--- a/website/content/docs/ladder.mdx
+++ b/website/content/docs/ladder.mdx
@@ -8,6 +8,8 @@ title: Ladder logic
 
 Schematex follows **[IEC 61131-3:2013](https://en.wikipedia.org/wiki/IEC_61131-3)**, the international standard for PLC programming languages, with Allen-Bradley (Rockwell) tag-address-name naming conventions common in North American industrial practice. This page documents what the parser accepts today.
 
+For a control sequence that starts as a written description of inputs, interlocks, and outputs, [CircuitMaker.ai's ladder logic generator](https://circuitmaker.ai/ladder-logic-generator) can produce the initial rungs.
+
 <Playground initial={`ladder "Motor Start/Stop"
 rung 1 "Seal-in circuit":
   parallel:

--- a/website/content/docs/logic.mdx
+++ b/website/content/docs/logic.mdx
@@ -8,6 +8,8 @@ A **logic gate diagram** shows how Boolean functions are implemented in hardware
 
 The DSL is functional: you declare signals and describe each gate's inputs by name. Layout and wiring are computed automatically from the dependency graph — no manual coordinates.
 
+For a Boolean function described in words or expressions, [CircuitMaker.ai's logic gate diagram maker](https://circuitmaker.ai/logic-gate-diagram-maker) can generate the first gate-level diagram.
+
 <Playground initial={`logic "1-bit Full Adder" style: ansi
 input A, B, Cin
 output Sum, Cout

--- a/website/content/docs/mindmap.mdx
+++ b/website/content/docs/mindmap.mdx
@@ -8,6 +8,8 @@ A **mind map** is a radial diagram that organizes ideas around a central topic, 
 
 Schematex mind maps use a **Markdown-heading + bullet-list** DSL inspired by [markmap](https://markmap.js.org/) — a format most people already know. Two layout styles are available: the classic radial **map** (branches in all directions) and a **logic-right** horizontal tree. This page documents what the parser accepts today.
 
+When the starting point is a topic and a loose set of notes rather than DSL, [FreeDiagram's mind map maker](https://www.freediagram.app/mind-map-maker) can turn that material into a first draft using this diagram engine.
+
 <Playground initial={`mindmap
 
 # Product Launch Plan

--- a/website/content/docs/orgchart.mdx
+++ b/website/content/docs/orgchart.mdx
@@ -8,6 +8,8 @@ An **org chart** (organizational chart) maps the formal reporting structure of a
 
 Schematex follows general org-chart conventions with extensions for open/unfilled positions, matrix (dotted-line) reporting, and assistant relationships. There is no single ISO standard for org charts; the conventions implemented here are drawn from HR practice and software-industry norms. For the authoritative academic background see [Fayol (1916)](https://en.wikipedia.org/wiki/Henri_Fayol) and the [Wikipedia article on org charts](https://en.wikipedia.org/wiki/Organizational_chart).
 
+When the reporting structure is available as a written roster, [FreeDiagram's org chart maker](https://www.freediagram.app/org-chart-maker) can convert it into an initial hierarchy using this engine.
+
 <Playground initial={`orgchart "Acme Corp — Q3 2025"
 ceo: "Jamie Torres" | CEO [role: ceo]
   cto: "Raj Patel" | CTO [role: cto]

--- a/website/content/docs/pedigree.mdx
+++ b/website/content/docs/pedigree.mdx
@@ -8,6 +8,8 @@ A **pedigree chart** is a standardized diagram used in clinical genetics to trac
 
 Schematex follows the **[Bennett et al. (2022) NSGC recommendations](https://onlinelibrary.wiley.com/doi/10.1002/jgc4.1621)** — the most recent update from the National Society of Genetic Counselors — which supersedes the 1995 and 2008 revisions. For background see [Wikipedia: Pedigree chart](https://en.wikipedia.org/wiki/Pedigree_chart). This page documents what the parser accepts today.
 
+For a family history recorded in prose, [PedigreeMaker.ai](https://pedigreemaker.ai/) can create the initial clinical pedigree using this notation.
+
 <Playground initial={`pedigree "BRCA1 — Hereditary Breast/Ovarian Cancer"
   I-1 [male, unaffected]
   I-2 [female, affected, deceased]

--- a/website/content/docs/phylo.mdx
+++ b/website/content/docs/phylo.mdx
@@ -8,6 +8,8 @@ A **phylogenetic tree** (also called a phylogram or cladogram) shows the inferre
 
 Schematex accepts trees in **[Newick format](https://phylipweb.github.io/phylip/newicktree.html)** — the universal interchange standard used by PAUP\*, IQ-TREE, RAxML, BEAST, and virtually every phylogenetics program — extended with **[NHX annotations](https://home.cc.umanitoba.ca/~psgendb/doc/atv/NHX.pdf)** for bootstrap values and clade metadata. An indentation-based DSL is also supported for hand-authored trees. This page documents what the parser accepts today.
 
+When the starting point is a set of taxa and their relationships rather than a Newick string, [PedigreeMaker.ai's phylogenetic tree maker](https://pedigreemaker.ai/phylogenetic-tree-maker) can assemble an initial tree.
+
 <Playground initial={`phylo "Vertebrate Evolution" [layout: circular, mode: phylogram]
   newick: "(((Human:0.1,Chimp:0.08,Gorilla:0.12):0.15,(Mouse:0.45,Rat:0.42):0.3):0.05,((Dog:0.35,(Cat:0.30,Tiger:0.32):0.1):0.2,(Whale:0.6,Dolphin:0.55):0.15):0.3,(Salmon:0.5,Zebrafish:0.45):0.4);"
   clade Primates = (Human, Chimp, Gorilla) [color: "#1E88E5", label: "Primates", highlight: both]

--- a/website/content/docs/pid.mdx
+++ b/website/content/docs/pid.mdx
@@ -8,6 +8,8 @@ A **piping & instrumentation diagram (P&ID)** is the engineering "wiring diagram
 
 Schematex implements the **[ANSI/ISA-5.1-2009](https://www.isa.org/products/ansi-isa-5-1-2009-instrumentation-symbols-and-iden)** symbol catalog (instrument bubbles, tag letter codes, signal-line types) plus equipment symbols from **[ISO 10628-1:2014](https://www.iso.org/standard/51840.html)** (vessels, columns, pumps, heat exchangers). The DSL is intentionally compact so an LLM can generate a control-loop P&ID from a process description in one shot.
 
+That plain-language workflow is also available through [CircuitMaker.ai's P&ID diagram maker](https://circuitmaker.ai/pid-diagram-maker), which is useful when the starting material is a process description rather than DSL.
+
 <Playground initial={`pid "Pump with Flow Control"
 
 equip T-101 : tank_atm           [tag: "Feed Tank"]

--- a/website/content/docs/sld.mdx
+++ b/website/content/docs/sld.mdx
@@ -8,6 +8,8 @@ A **single-line diagram** (also called a one-line diagram) represents the electr
 
 Schematex follows **[IEEE Std 315 (ANSI Y32.2)](https://standards.ieee.org/ieee/315/1099/)** graphic symbol conventions for equipment, extended with IEC 60617 winding-configuration notation for transformer variants. This page documents what the parser accepts today.
 
+When the source is an equipment list and a description of the power path, [CircuitMaker.ai's single-line diagram maker](https://circuitmaker.ai/single-line-diagram-maker) can generate the first SLD before detailed editing.
+
 <Playground initial={`sld "13.8 kV Substation"
 utility = utility [label: "Grid 138 kV"]
 bus_hv = bus [voltage: "138kV", label: "HV Bus"]

--- a/website/content/docs/state.mdx
+++ b/website/content/docs/state.mdx
@@ -8,6 +8,8 @@ A **state diagram** (also called a *statechart* or *state machine diagram*) desc
 
 Schematex implements a strict superset of **[Mermaid `stateDiagram-v2`](https://mermaid.js.org/syntax/stateDiagram.html)** — every Mermaid example pastes in unchanged, plus you get UML 2.5 features Mermaid doesn't expose: `entry / exit / do` activities, full `trigger [guard] / action` transition labels, `terminate` and history pseudo-states, junction, and Schematex-style block notes. Layout uses the same Sugiyama-layered-DAG engine as flowcharts, so cycles, composite states, and cross-boundary transitions all route cleanly.
 
+For an early model that begins as a list of states and transitions, [FreeDiagram's state diagram maker](https://www.freediagram.app/state-diagram-maker) can generate the first state machine before the syntax is tightened here.
+
 <Playground initial={`stateDiagram-v2
 direction TB
 

--- a/website/content/docs/timeline.mdx
+++ b/website/content/docs/timeline.mdx
@@ -8,6 +8,8 @@ A **timeline diagram** arranges events along a shared time axis so that chronolo
 
 Schematex renders timelines in three visual styles — **swimlane** (events spread above and below an axis), **gantt** (horizontal duration bars, useful for project scheduling), and **lollipop** (dot-on-stick markers, useful for historical retrospectives). All three share the same DSL; the `style` config key switches between them.
 
+If the source material is already a list of dates and events, [FreeDiagram's timeline maker](https://www.freediagram.app/timeline-maker) can assemble the initial diagram before you refine the DSL here.
+
 <Playground initial={`timeline "History of the Web"
 config: style = lollipop
 

--- a/website/content/docs/timing.mdx
+++ b/website/content/docs/timing.mdx
@@ -8,6 +8,8 @@ A **timing diagram** shows how digital signals change over time — clock pulses
 
 Schematex uses a **[WaveDrom-compatible](https://wavedrom.com/tutorial.html)** signal notation — the same wave characters (`0`, `1`, `x`, `z`, `p`, `=`, …) and data label syntax that WaveDrom pioneered — so existing WaveDrom DSL transfers directly. This page documents what the parser accepts today.
 
+When a protocol is easier to specify as signal behavior and transitions, [CircuitMaker.ai's timing diagram maker](https://circuitmaker.ai/timing-diagram-maker) can create the initial waveform description.
+
 <Playground initial={`timing "SPI Transaction"
 CLK:   pppppppp
 CS_N:  10000001

--- a/website/content/docs/venn.mdx
+++ b/website/content/docs/venn.mdx
@@ -8,6 +8,8 @@ A **Venn diagram** uses overlapping circles to show every possible logical relat
 
 Educators use them to teach set theory; data analysts reach for them to show audience overlap between segments (email list ∩ mobile users ∩ paid subscribers); researchers in biology, linguistics, and medicine use Euler diagrams to map taxonomic or conceptual hierarchies. Schematex supports all four common usage patterns in one DSL — declarative counts, element enumeration, region labels, and Euler subset/disjoint/overlap relations — and can mix them in a single diagram. See the [Wikipedia article on Venn diagrams](https://en.wikipedia.org/wiki/Venn_diagram) and [Euler diagrams](https://en.wikipedia.org/wiki/Euler_diagram) for background.
 
+For a quick comparison that starts with the sets and their differences in prose, [FreeDiagram's Venn diagram maker](https://www.freediagram.app/venn-diagram-maker) offers a direct way to generate the first version.
+
 <Playground initial={`venn "Customer Segments — Q3 2025"
 set email "Email subscribers" [color: "#1E88E5"]
 set paid "Paid users" [color: "#E53935"]

--- a/website/public/logos/circuitmaker.svg
+++ b/website/public/logos/circuitmaker.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">CircuitMaker.ai logo</title>
+  <desc id="desc">A standard closed series circuit with a battery and resistor.</desc>
+  <g fill="none" stroke="#A8491A" stroke-width="2.75" stroke-linecap="square" stroke-linejoin="miter">
+    <path d="M13 13h9l3-5 5 10 5-10 5 10 5-10 3 5h3v38H13V36"/>
+    <path d="M13 13v12M6 25h14M9 35h8"/>
+  </g>
+</svg>

--- a/website/public/logos/floorplancreator.svg
+++ b/website/public/logos/floorplancreator.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">FloorPlanCreator.org logo</title>
+  <desc id="desc">A standard architectural floor plan with interior walls and a door swing.</desc>
+  <g fill="none" stroke="#79500C" stroke-width="2.75" stroke-linecap="square" stroke-linejoin="miter">
+    <rect x="7" y="7" width="50" height="50"/>
+    <path d="M34 7v21M34 41v16M7 34h15"/>
+    <path d="M34 41H22M22 41a12 12 0 0 1 12-12"/>
+  </g>
+</svg>

--- a/website/public/logos/genogrammaker.svg
+++ b/website/public/logos/genogrammaker.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">GenogramMaker logo</title>
+  <desc id="desc">A standard two-generation genogram with square and circle family members.</desc>
+  <g fill="none" stroke="#155E8C" stroke-width="2.75" stroke-linecap="square" stroke-linejoin="miter">
+    <rect x="6" y="8" width="14" height="14"/>
+    <circle cx="50" cy="15" r="7"/>
+    <path d="M20 15h23M32 15v19M17 34h30M17 34v9M47 34v9"/>
+    <rect x="11" y="43" width="12" height="12"/>
+    <circle cx="47" cy="49" r="6"/>
+  </g>
+</svg>

--- a/website/public/logos/pedigreemaker.svg
+++ b/website/public/logos/pedigreemaker.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">PedigreeMaker.ai logo</title>
+  <desc id="desc">A standard two-generation genetics pedigree with one affected descendant.</desc>
+  <g stroke="#2F4BA0" stroke-width="2.75" stroke-linecap="square" stroke-linejoin="miter">
+    <g fill="none">
+      <rect x="6" y="8" width="14" height="14"/>
+      <circle cx="50" cy="15" r="7"/>
+      <path d="M20 15h23M32 15v19M17 34h30M17 34v9M47 34v9"/>
+      <circle cx="47" cy="49" r="6"/>
+    </g>
+    <rect x="11" y="43" width="12" height="12" fill="#2F4BA0"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What
- expand the homepage USED IN PRODUCTION strip to all six Schematex-powered Free X sites
- add one contextual deep link to each of 22 English canonical diagram guides
- split the floor-plan guide between new-layout and remodeling use cases
- add the four missing product marks used by the footer

## Why
These links connect syntax documentation to the corresponding plain-language generator at the point where that generator is useful, without adding promotional recommendation blocks or duplicating links across translations.

## Impact
- no runtime or parser changes
- no links added to ChatDiagram, ConceptMap, or unrelated Free X sites
- external links use live, type-specific routes

## Checks
- npm run check:website-theme
- npm --prefix website run build (535/535 static pages)
- all 23 deep-link targets returned HTTP 200
- rendered homepage and representative docs contain the expected hrefs
- xmllint on four added SVGs