### PR TITLE
feat: serve Schematex Research

### DIFF
--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -3,6 +3,9 @@ import type { MetadataRoute } from 'next';
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [{ userAgent: '*', allow: '/' }],
-    sitemap: 'https://schematex.js.org/sitemap.xml',
+    sitemap: [
+      'https://schematex.js.org/sitemap.xml',
+      'https://schematex.js.org/research/sitemap.xml',
+    ],
   };
 }

--- a/website/components/SiteHeader.tsx
+++ b/website/components/SiteHeader.tsx
@@ -38,6 +38,7 @@ export function SiteHeader({
   const navLinks = [
     { label: nav.docs, href: '/docs' },
     { label: nav.gallery, href: '/gallery' },
+    { label: 'Research', href: '/research' },
     { label: nav.icons, href: '/icons' },
     { label: nav.playground, href: '/playground' },
     { label: nav.changelog, href: '/changelog' },

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -17,6 +17,7 @@ const withPlausibleProxyWrapper = withPlausibleProxy({
 });
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const RESEARCH_ORIGIN = 'https://pseo.ideamarketfit.com/sites/schematex/research';
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -32,6 +33,10 @@ const config = {
   },
   async rewrites() {
     const routes = [
+      // Research notes are authored and rendered by pseo-cockpit but stay on
+      // the Schematex origin so citations and search equity belong here.
+      { source: '/research', destination: RESEARCH_ORIGIN },
+      { source: '/research/:path*', destination: `${RESEARCH_ORIGIN}/:path*` },
       // Clean Markdown mirrors for coding agents and plain-text clients.
       { source: '/docs.md', destination: '/llms.mdx/docs' },
       { source: '/docs/:path*.md', destination: '/llms.mdx/docs/:path*' },


### PR DESCRIPTION
## What
- proxy `/research` and article routes to the canonical pSEO content origin
- expose the research sitemap in robots metadata
- add Research to the Schematex website navigation

## Why
Schematex gets first-party professional research pages without duplicating the editorial pipeline.

## Verification
- `npm run build`
- `npm --prefix website run build`