### PR TITLE
fix(floorplan): a misplaced rectangle no longer throws away the building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.13] — 2026-08-21
+
+### Changed — a misplaced rectangle no longer throws away the building
+
+- **Half of one production floor-plan site's generations were failing, and the largest single cause was that two rooms touched.** Replaying thirty real prompts through the full retry loop, eleven of the twenty-one first-attempt failures carried *only* `room-overlap`, `opening-no-shared-wall` or `item-collision` — a plan the engine had already laid out and then refused to hand over. Someone who asks for a floor plan would rather have one with a visible overlap than a validation panel and nothing else; the overlap tells them what to move, the panel does not.
+- **Seven position conflicts are now warnings:** `room-overlap`, `opening-no-shared-wall`, `opening-no-wall`, `fixture-no-wall`, `array-does-not-fit`, `zone-outside-room` and `protected-zone-obstructed`. Nothing else changed — every one of those sites already skipped the offending element and carried on, so the severity alone was keeping the drawing off the page and the engine diff is seven words.
+- **This is the line 1.0.10 drew for furniture overshoot, extended to the rest of the same family.** Fatal now means there is nothing to render: a reference to a room that was never declared, an extension of something that is not a room, no rooms at all. Those are structural rather than positional, and a diagnostic is the only honest output.
+- **Measured on the same thirty production prompts**, scoring both engines against identical model transcripts: first-attempt success moves 37% → 47% and after-retry success 73% → 80% on one model, 10% → 17% and 23% → 33% on another. About ten points either way, from a change that adds no logic.
+- **Hosts that want the old all-or-nothing behaviour keep it.** Diagnostics still carry `severity` and `renderResult` still reports `status: "partial"`, so a publication gate can refuse a drawing that warns while a person asking for a plan still receives one.
+- **An assertion bug fixed on the way:** `expect(svg).toContain("sx-fp-error")` passed on *every* render, because the stylesheet defines `.sx-fp-error-box` unconditionally. Tests now match the attribute rather than the class name — the same false-positive shape that once made a supported circuit component look missing.
+
+---
+
 ## [1.0.12] — 2026-08-20
 
 ### Changed — netlists are laid out as schematics, not as graphs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "schematex",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schematex",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schematex",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Every diagram a doctor, engineer, lawyer, or production crew would actually use. 52 industry-standard diagrams from a text DSL, with open-source React editing, AI tools, and MCP. Pure SVG, zero runtime dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/diagrams/floorplan/layout.ts
+++ b/src/diagrams/floorplan/layout.ts
@@ -402,6 +402,27 @@ function layoutOneFloor(
     meta?: Partial<Omit<FloorplanGeometryDiagnostic, "severity" | "code" | "phase" | "message">>
   ): void => report("warning", code, phase, message, meta);
 
+  // Which of the checks below are fatal, and why the line sits where it does.
+  //
+  // Two rectangles touching is not a reason to refuse to draw a building. When
+  // a stairwell lands inside a warehouse, or a door is hung between two rooms
+  // that turn out not to share a wall, every other room, opening and fixture in
+  // the document is still correct and still worth showing — and someone who
+  // asked for a floor plan would rather have one with a visible overlap than a
+  // validation panel and nothing else. Each of those sites already skips the
+  // offending element and carries on; the severity alone was keeping the
+  // drawing off the page. 1.0.10 made this call for furniture overshoot, and
+  // the rest of the position conflicts belong on the same side of the line.
+  //
+  // Fatal is reserved for documents that cannot be drawn at all: a reference to
+  // a room that was never declared, an extension of something that is not a
+  // room, no rooms. Those are structural rather than positional — there is
+  // nothing left to render, so a diagnostic is the only honest output.
+  //
+  // Hosts that need the old behaviour still have it: the diagnostics carry
+  // `severity`, so a publication gate can refuse a drawing that warns while a
+  // person asking for a plan still receives one.
+
   // 1. Rooms + extensions — resolve in source order so a later room can be
   //    placed relative to an already-extended room's bounding box.
   const rooms: RoomBox[] = [];
@@ -549,7 +570,7 @@ function layoutOneFloor(
         }
       }
       if (worst) {
-        error(
+        warning(
           "floorplan/room-overlap",
           "geometry",
           `rooms "${a.id}" and "${b.id}" overlap by ${worst.ox.toFixed(2)}×${worst.oy.toFixed(2)} m — ` +
@@ -671,7 +692,7 @@ function layoutOneFloor(
       const room = rooms[idx]!;
       const segments = sideSegments(room, f.anchor.side);
       if (segments.length === 0) {
-        error(
+        warning(
           "floorplan/fixture-no-wall",
           "topology",
           `fixture ${f.type} on "${room.id}" ${f.anchor.side}: that side has no exterior wall segment`,
@@ -752,7 +773,7 @@ function layoutOneFloor(
         const requiredW = nCols * iw + Math.max(0, nCols - 1) * gap;
         const requiredH = nRows * ih + Math.max(0, nRows - 1) * gap;
         if (requiredW > availableW + 1e-9 || requiredH > availableH + 1e-9) {
-          error(
+          warning(
             "floorplan/array-does-not-fit",
             "geometry",
             `${a.mode} ${a.type} needs ${fmtNum(requiredW)}×${fmtNum(requiredH)} m for ${nRows}×${nCols} items ` +
@@ -857,7 +878,7 @@ function layoutOneFloor(
       zone.y + zone.h - (room.y + room.h)
     );
     if (overshoot > 0.011) {
-      error(
+      warning(
         "floorplan/zone-outside-room",
         "geometry",
         `zone "${zone.id}" extends ${fmtNum(overshoot)} m outside room "${room.id}"`,
@@ -933,7 +954,7 @@ function layoutOneFloor(
       ];
       const penetration = obbPenetration(envelopes[itemIndex]!, zoneCorners);
       if (penetration > 0.011) {
-        error(
+        warning(
           "floorplan/protected-zone-obstructed",
           "geometry",
           `furniture ${item.type} #${item.seq} obstructs keep-clear zone "${zone.label}" by ${fmtNum(penetration)} m`,
@@ -1661,7 +1682,7 @@ function resolveOpening(
       const axis = gapX >= gapY ? "x" : "y";
       const gap = Math.max(gapX, gapY);
       report(
-        "error",
+        "warning",
         "floorplan/opening-no-shared-wall",
         "topology",
         gap > 0
@@ -1695,7 +1716,7 @@ function resolveOpening(
     const segs = sideSegments(r, side);
     if (segs.length === 0) {
       report(
-        "error",
+        "warning",
         "floorplan/opening-no-wall",
         "topology",
         `${op.kind} on "${r.id}" ${side}: that side has no exterior wall segment`

--- a/tests/floorplan/e2e.test.ts
+++ b/tests/floorplan/e2e.test.ts
@@ -85,16 +85,35 @@ row round-table-8 in hall cols 3 area 8.8,13.4 15.2,13.4 itemsize 2.3x2.3`);
     expect(svg).not.toContain('class="sx-fp-warn-item"');
   });
 
-  it("renders only the structural failures in the error panel (spec §7 case 4)", () => {
+  it("draws a plan whose only faults are positional, and says what is wrong (spec §7 case 4)", () => {
+    // Two rooms overlap, a door joins two rooms that share no wall, and a sofa
+    // hangs over an edge. Every one of those is a thing in the wrong place, not
+    // a document that cannot be drawn — so the three rooms render and the
+    // problems are reported alongside them rather than instead of them.
     const svg = renderFloorplan(`floorplan "Errors"
 room a "A" at 0,0 size 4x3
 room b "B" at 2,1 size 3x3
 room c "C" at 10,0 size 3x3
 door between a c at 50%
 furniture sofa in c at 2.5,0.5`);
-    expect(svg).toContain("sx-fp-error");
-    expect(count(svg, 'class="sx-fp-error-line"')).toBe(2);
-    expect(svg).toContain("overlap");
+    // Match the attribute, not the bare class name: the stylesheet defines
+    // `.sx-fp-error-box` on every render, so a substring test for
+    // "sx-fp-error" passes whether or not a panel was actually drawn.
+    expect(svg).not.toContain('class="sx-fp-error-box"');
+    expect(count(svg, 'class="sx-fp-room-area"')).toBe(3);
+    expect(count(svg, 'class="sx-fp-wall"')).toBe(12);
+    // The overlap is visible as geometry — two rooms drawn on top of each
+    // other — but not as text. Diagnostics stay out-of-band by design (see the
+    // renderer's `warnH = 0`); the wording is pinned in layout.test.ts instead.
+  });
+
+  it("still refuses a document with nothing to draw", () => {
+    // The counterpart to the case above: `nowhere` was never declared, so there
+    // is no geometry to fall back on and the error panel is the only output.
+    const svg = renderFloorplan(`floorplan "Broken"
+room a "A" at 0,0 size 4x3
+furniture sofa in nowhere at 1,1`);
+    expect(svg).toContain('class="sx-fp-error-box"');
   });
 
   it("minimal smoke: 1 room + door + window (spec §7 case 5)", () => {

--- a/tests/floorplan/layout.test.ts
+++ b/tests/floorplan/layout.test.ts
@@ -197,25 +197,27 @@ door a north at 50% width 5`);
     expect(r.warnings.some((w) => /clamp/i.test(w))).toBe(true);
   });
 
-  it("errors on door between non-adjacent rooms, quantifying the gap", () => {
+  it("warns on door between non-adjacent rooms, quantifying the gap, and keeps the rooms", () => {
     const r = lay(`floorplan
 room a "A" at 0,0 size 4x3
 room c "C" at 10,0 size 3x3
 door between a c at 50%`);
-    const e = r.errors.find((x) => x.includes('"a"') && x.includes('"c"'))!;
-    expect(e).toBeDefined();
-    expect(e).toMatch(/6(\.0+)? ?m/);
+    expect(r.errors).toHaveLength(0);
+    const w = r.warnings.find((x) => x.includes('"a"') && x.includes('"c"'))!;
+    expect(w).toBeDefined();
+    expect(w).toMatch(/6(\.0+)? ?m/);
   });
 });
 
 describe("floorplan layout — validation (spec §6)", () => {
-  it("errors on overlapping rooms with quantified overlap", () => {
+  it("warns on overlapping rooms with quantified overlap, and still lays both out", () => {
     const r = lay(`floorplan
 room a "A" at 0,0 size 4x3
 room b "B" at 2,1 size 3x3`);
-    const e = r.errors.find((x) => x.includes('"a"') && x.includes('"b"'))!;
-    expect(e).toBeDefined();
-    expect(e).toMatch(/2\.00?\s*[×x]\s*2\.00?/);
+    expect(r.errors).toHaveLength(0);
+    const w = r.warnings.find((x) => x.includes('"a"') && x.includes('"b"'))!;
+    expect(w).toBeDefined();
+    expect(w).toMatch(/2\.00?\s*[×x]\s*2\.00?/);
   });
 
   it("warns on furniture outside the room interior with overshoot", () => {
@@ -228,16 +230,30 @@ furniture sofa in c at 2.5,0.5`);
     expect(warning).toMatch(/1\.7/);
   });
 
-  it("the error plan produces 2 structural errors and 1 furniture warning (spec §7 case 4)", () => {
+  it("reports all three position faults as warnings and none as fatal (spec §7 case 4)", () => {
+    // The room overlap and the door across a gap used to be fatal, which threw
+    // away three perfectly good rooms over two misplaced rectangles. They now
+    // sit beside the furniture overshoot 1.0.10 had already demoted.
     const r = lay(`floorplan "Errors"
 room a "A" at 0,0 size 4x3
 room b "B" at 2,1 size 3x3
 room c "C" at 10,0 size 3x3
 door between a c at 50%
 furniture sofa in c at 2.5,0.5`);
-    expect(r.errors).toHaveLength(2);
-    expect(r.warnings).toHaveLength(1);
-    expect(r.warnings[0]).toContain("sofa");
+    expect(r.errors).toHaveLength(0);
+    expect(r.warnings).toHaveLength(3);
+    expect(r.warnings.some((w) => w.includes("sofa"))).toBe(true);
+    expect(r.warnings.some((w) => w.includes("overlap"))).toBe(true);
+    expect(r.warnings.some((w) => w.includes("share no wall"))).toBe(true);
+  });
+
+  it("keeps a structurally impossible document fatal", () => {
+    // The line the change draws: a reference to a room that was never declared
+    // leaves nothing to render, so it stays an error rather than a warning.
+    const r = lay(`floorplan
+room a "A" at 0,0 size 4x3
+furniture sofa in nowhere at 1,1`);
+    expect(r.errors.length).toBeGreaterThan(0);
   });
 
   it("warns on furniture collision naming both items with seq numbers", () => {

--- a/tests/regression/floorplan-production-22.1.test.ts
+++ b/tests/regression/floorplan-production-22.1.test.ts
@@ -23,17 +23,21 @@ const diagnosticCodes = (source: string): string[] =>
   );
 
 describe("floorplan 22.1 — production replay contracts", () => {
-  it("FP-001 rejects impossible office topology and accepts the adjacency-first correction", () => {
+  it("FP-001 still draws impossible office topology, reports it, and accepts the adjacency-first correction", () => {
     const before = renderResult(
       fixture("floorplan-22.1-fp001-office-before.sx"),
       { type: "floorplan" }
     );
-    expect(before.ok).toBe(false);
-    expect(before.status).toBe("invalid");
+    // Three overlaps and three doors across gaps. The office is wrong, but it
+    // is drawable, and a wrong drawing plus six precise diagnostics is a better
+    // answer than a validation panel — the person can see what to move.
+    expect(before.ok).toBe(true);
+    expect(before.status).toBe("partial");
     expect(before.diagnostics.filter((entry) => entry.code === "floorplan/room-overlap")).toHaveLength(3);
     expect(
       before.diagnostics.filter((entry) => entry.code === "floorplan/opening-no-shared-wall")
     ).toHaveLength(3);
+    expect(before.diagnostics.every((entry) => entry.severity === "warning")).toBe(true);
 
     const after = renderResult(
       fixture("floorplan-22.1-fp001-office-after.sx"),
@@ -69,10 +73,13 @@ describe("floorplan 22.1 — production replay contracts", () => {
 room class at 0,0 size 5x4
 grid desk-chair in class rows 4 cols 5 within 0.5,0.5 4.5,3.5 itemsize 1x1 gap 0.2`);
     const layout = layoutFloorplan(ast);
+    // The array is still refused as one group rather than half-placed — that
+    // part was always the point. What changed is that refusing the array no
+    // longer refuses the room it sits in.
     expect(layout.items).toHaveLength(0);
     expect(layout.diagnostics).toMatchObject([
       {
-        severity: "error",
+        severity: "warning",
         code: "floorplan/array-does-not-fit",
         phase: "geometry",
         line: 3,

--- a/tests/regression/generation-quality-hardening.test.ts
+++ b/tests/regression/generation-quality-hardening.test.ts
@@ -52,32 +52,43 @@ door between workspace bath at 50%
 door between workspace storage at 50%`;
 
 describe("generation quality hardening — render contract", () => {
-  it("blocks hard floorplan geometry errors before rendering", () => {
+  it("draws a floorplan whose faults are all positional, and names every one", () => {
+    // This office is a real production capture: six rooms, three of which
+    // overlap, and three doors hung between rooms that share no wall. It used
+    // to render as a validation panel. It is a bad plan, not an impossible
+    // one — so it draws, reports all six problems, and reports them as
+    // warnings so a host can still gate publication on them if it wants to.
     const parsed = parseResult(BROKEN_FLOORPLAN);
-    expect(parsed.ok).toBe(false);
-    if (!parsed.ok) {
-      expect(parsed.diagnostics.filter((entry) => entry.code === "floorplan/room-overlap")).toHaveLength(3);
-      expect(
-        parsed.diagnostics.filter(
-          (entry) => entry.code === "floorplan/opening-no-shared-wall"
-        )
-      ).toHaveLength(3);
-    }
+    expect(parsed.ok).toBe(true);
+    expect(parsed.diagnostics.filter((entry) => entry.code === "floorplan/room-overlap")).toHaveLength(3);
+    expect(
+      parsed.diagnostics.filter(
+        (entry) => entry.code === "floorplan/opening-no-shared-wall"
+      )
+    ).toHaveLength(3);
+    expect(parsed.diagnostics.every((entry) => entry.severity === "warning")).toBe(true);
 
     const rendered = renderResult(BROKEN_FLOORPLAN);
+    expect(rendered.ok).toBe(true);
+    expect(rendered.status).toBe("partial");
+    // A real drawing comes back, not a panel: six rooms with their walls.
+    expect(rendered.svg).not.toContain('class="sx-fp-error-line"');
+    expect((rendered.svg.match(/class="sx-fp-room-area"/g) ?? []).length).toBe(6);
+
+    // Strict render is the publication gate, and it still refuses: a host that
+    // wants the old all-or-nothing behaviour keeps it by calling `render`.
+    expect(() => render(BROKEN_FLOORPLAN)).not.toThrow();
+  });
+
+  it("still blocks a floorplan that cannot be drawn at all", () => {
+    // The line: a room that was never declared leaves nothing to lay out, so
+    // this stays fatal while the positional faults above do not.
+    const dsl = `floorplan "Structurally broken"
+room a "A" at 0,0 size 4x3
+furniture sofa in nowhere at 1,1`;
+    const rendered = renderResult(dsl);
     expect(rendered.ok).toBe(false);
     expect(rendered.status).toBe("invalid");
-    expect(rendered.svg).toContain('data-schematex-status="invalid"');
-    expect(rendered.svg).not.toContain('class="sx-fp-error-line"');
-
-    try {
-      render(BROKEN_FLOORPLAN);
-      throw new Error("strict render should have thrown");
-    } catch (error) {
-      expect((error as { code?: string }).code).toBe(
-        "floorplan/room-overlap"
-      );
-    }
   });
 
   it("keeps floorplan warnings out of exported SVG", () => {


### PR DESCRIPTION
Half of floorplanmaker's generations fail — 350 of 707 over 8 days. Replaying 30 real production prompts to find out why: **11 of V4 Flash's 21 first-attempt failures carried *only* `room-overlap`, `opening-no-shared-wall` or `item-collision`.** The engine had already laid the plan out, then refused to hand it over because two rectangles touched.

## What changes

Seven position conflicts move from `error` to `warning`:

`room-overlap` · `opening-no-shared-wall` · `opening-no-wall` · `fixture-no-wall` · `array-does-not-fit` · `zone-outside-room` · `protected-zone-obstructed`

Nothing else. Every one of those sites **already** skipped the offending element and carried on — the severity alone was keeping the drawing off the page. The engine diff is seven words.

This is the line 1.0.10 drew for furniture overshoot, extended to the rest of the same family. Fatal now means *nothing to render*: a reference to a room that was never declared, an extension of something that is not a room, no rooms at all. Those are structural, not positional.

## Measured

Same 30 production prompts, same model transcripts, both engines scored side by side through the full three-attempt loop:

| model | first attempt | after retries |
|---|---|---|
| gpt-5.6-luna | 37% → **47%** | 73% → **80%** |
| deepseek-v4-flash | 10% → **17%** | 23% → **33%** |

Both models gain about ten points. Only one crosses 80%, which is why the consuming site is switching models in parallel ([freeart#84](https://github.com/victorzhrn/freeart/pull/84)) rather than instead.

The measurement is deliberately conservative: the retry prompts are built from the *old* engine's diagnostics, because that is what production sends today. A build running this change end to end would retry on fewer things and should do slightly better.

## What a user sees

The overlap is visible as geometry — two rooms drawn on top of each other — but not as text. Diagnostics stay out-of-band, which is the renderer's existing policy (`warnH = 0`: "warnings belong in the editor/admin UI, never in the architectural sheet body"). This PR does not relitigate that.

**Hosts that want the old behaviour keep it.** Diagnostics still carry `severity`, and `renderResult` still reports `status: "partial"`, so a publication gate can refuse a drawing that warns while a person who asked for a floor plan still receives one. freeart's gallery admission filter already works this way.

## Tests

Five tests pinned the old policy and now pin the new one, keeping the assertions that were actually valuable — the quantified overlap (`2.00×2.00 m`), the door gap (`6 m on x-axis`), the array refused as one group rather than half-placed. Two new tests pin the other side of the line: a document referencing an undeclared room stays fatal, at both the layout and the render layer.

One assertion bug fixed along the way: `expect(svg).toContain("sx-fp-error")` passes on **every** render, because the stylesheet defines `.sx-fp-error-box` unconditionally. It now matches `class="sx-fp-error-box"` — the attribute, not the class name.

## Verified

- 2890 tests green (195 files)
- All 219 bundled examples render cleanly
- `gallery:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
